### PR TITLE
SupportProfile importing scheme

### DIFF
--- a/src/Lib.cs
+++ b/src/Lib.cs
@@ -56,6 +56,27 @@ namespace KERBALISM
 			a = tmp;
 		}
 
+		// find a directory in the GameData directory
+		public static bool GameDirectoryExist(string findpath)
+		{
+			try
+			{
+				string gamedir = Path.Combine(Path.GetFullPath(KSPUtil.ApplicationRootPath), "GameData/" + findpath);
+				findpath = Path.GetFileName(gamedir);
+				gamedir = Path.GetDirectoryName(gamedir);
+				string[] paths = System.IO.Directory.GetDirectories(gamedir, findpath, SearchOption.AllDirectories);
+				if (paths.Length > 0)
+					return true;
+				else
+					return false;
+			}
+			catch (Exception e)
+			{
+				Log("error while looking for directory '" + findpath + "' in 'GameData' directory. (" + e.Message + ")");
+				return false;
+			}
+		}
+
 
 		// --- MATH -----------------------------------------------------------------
 
@@ -1600,4 +1621,3 @@ namespace KERBALISM
 
 
 } // KERBALISM
-

--- a/src/Profile/Profile.cs
+++ b/src/Profile/Profile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 
@@ -8,6 +8,105 @@ namespace KERBALISM
 
 	public static class Profile
 	{
+
+		// node parsing
+		private static void nodeparse(ConfigNode profile_node)
+		{
+			// parse all rules
+			foreach (ConfigNode rule_node in profile_node.GetNodes("Rule"))
+			{
+				try
+				{
+					// parse rule
+					Rule rule = new Rule(rule_node);
+
+					// ignore duplicates
+					if (rules.Find(k => k.name == rule.name) == null)
+					{
+						// add the rule
+						rules.Add(rule);
+					}
+				}
+				catch (Exception e)
+				{
+					Lib.Log(Lib.BuildString("warning: failed to load rule (reason: ", e.Message, ")"));
+				}
+			}
+
+			// parse all supplies
+			foreach (ConfigNode supply_node in profile_node.GetNodes("Supply"))
+			{
+				try
+				{
+					// parse supply
+					Supply supply = new Supply(supply_node);
+
+					// ignore duplicates
+					if (supplies.Find(k => k.resource == supply.resource) == null)
+					{
+						// add the supply
+						supplies.Add(supply);
+					}
+				}
+				catch (Exception e)
+				{
+					Lib.Log(Lib.BuildString("warning: failed to load supply (reason: ", e.Message, ")"));
+				}
+			}
+
+			// parse all processes
+			foreach (ConfigNode process_node in profile_node.GetNodes("Process"))
+			{
+				try
+				{
+					// parse process
+					Process process = new Process(process_node);
+
+					// ignore duplicates
+					if (processes.Find(k => k.name == process.name) == null)
+					{
+						// add the process
+						processes.Add(process);
+					}
+				}
+				catch (Exception e)
+				{
+					Lib.Log(Lib.BuildString("warning: failed to load process (reason: ", e.Message, ")"));
+				}
+			}
+		}
+
+		// Support config file parsing
+		private static void parseSupport()
+		{
+			// for each profile
+			foreach (ConfigNode profile_node in Lib.ParseConfigs("Profile"))
+			{
+				// get the name
+				string name = Lib.ConfigValue(profile_node, "name", string.Empty);
+
+				// if this is a Kerbalism Support profile
+				if (name == "KerbalismSupport")
+				{
+					// get the mod name and directory
+					string modname = Lib.ConfigValue(profile_node, "modname", string.Empty);
+					string moddir = Lib.ConfigValue(profile_node, "moddir", string.Empty);
+
+					// if the mods directory exists
+					if (Lib.GameDirectoryExist(moddir))
+					{
+						// log profile and mod name
+						Lib.Log(Lib.BuildString("importing Kerbalism Support profile for mod: ", modname));
+
+						// parse nodes
+						nodeparse(profile_node);
+
+						// done a Support profile now on to the next
+					}
+				}
+			}
+		}
+
 		public static void parse()
 		{
 			// initialize data
@@ -30,68 +129,11 @@ namespace KERBALISM
 						// log profile name
 						Lib.Log(Lib.BuildString("using profile: ", Settings.Profile));
 
-						// parse all rules
-						foreach (ConfigNode rule_node in profile_node.GetNodes("Rule"))
-						{
-							try
-							{
-								// parse rule
-								Rule rule = new Rule(rule_node);
+						// parse nodes
+						nodeparse(profile_node);
 
-								// ignore duplicates
-								if (rules.Find(k => k.name == rule.name) == null)
-								{
-									// add the rule
-									rules.Add(rule);
-								}
-							}
-							catch (Exception e)
-							{
-								Lib.Log(Lib.BuildString("warning: failed to load rule (reason: ", e.Message, ")"));
-							}
-						}
-
-						// parse all supplies
-						foreach (ConfigNode supply_node in profile_node.GetNodes("Supply"))
-						{
-							try
-							{
-								// parse supply
-								Supply supply = new Supply(supply_node);
-
-								// ignore duplicates
-								if (supplies.Find(k => k.resource == supply.resource) == null)
-								{
-									// add the supply
-									supplies.Add(supply);
-								}
-							}
-							catch (Exception e)
-							{
-								Lib.Log(Lib.BuildString("warning: failed to load supply (reason: ", e.Message, ")"));
-							}
-						}
-
-						// parse all processes
-						foreach (ConfigNode process_node in profile_node.GetNodes("Process"))
-						{
-							try
-							{
-								// parse process
-								Process process = new Process(process_node);
-
-								// ignore duplicates
-								if (processes.Find(k => k.name == process.name) == null)
-								{
-									// add the process
-									processes.Add(process);
-								}
-							}
-							catch (Exception e)
-							{
-								Lib.Log(Lib.BuildString("warning: failed to load process (reason: ", e.Message, ")"));
-							}
-						}
+						// Add support configs
+						parseSupport();
 
 						// log info
 						Lib.Log("supplies:");
@@ -175,4 +217,3 @@ namespace KERBALISM
 
 
 } // KERBALISM
-


### PR DESCRIPTION
enable Profiles that are stored in any config file to be imported into
the loaded profile, this also allows modders to include their own
Supplies, Rules or Processes and not have to edit the default profile.

The code also checks a field supplied in the imported profile to
determine if the profile should be imported or not. This mechanism works
by searching the GameData directory for a matching directory that is
named in the moddir field of the profile.
Simply create a Profile node named KerbalismSupport and include the
necessary script to define the Supplies, Rules and Processes you need,
as you would with the default profile.
The KerbalismSupport profile node must have a modname field which is
used for logging and a moddir field which is used to decide if a mods
support profile should be loaded.
```
Profile
{
name = KerbalismSupport    // name must be KerbalismSupport
modname = FooBar Zoo       // Just a name for display purposes
moddir = FooBar/Zoo           // Could use Zoo if you wish

Supply
{
etc...
```

(cherry picked from commit 1aa431b47b05fa3d0cbf244904ad45aea675a8d7)
closes #2 