### PR TITLE
Re-fix greenhouses crop amounts

### DIFF
--- a/GameData/Kerbalism/Support/SSPX.cfg
+++ b/GameData/Kerbalism/Support/SSPX.cfg
@@ -341,7 +341,7 @@
 // ============================================================================
 // region Greenhouses
 // ============================================================================
-@PART[sspx-greenhouse-25-1|sspx-greenhouse-375-1]:NEEDS[ProfileDefault]:FOR[Kerbalism]
+@PART[sspx-greenhouse-25-1]:NEEDS[ProfileDefault]:FOR[Kerbalism]
 {
   MODULE
   {
@@ -363,10 +363,9 @@
     name = Greenhouse
 
     crop_resource = Food                // name of resource produced by harvests
-    crop_size = #$../mass$              // amount of resource produced by harvests
-	crop_size *= 1000
+    crop_size = 4250.0                  // amount of resource produced by harvests
     crop_rate = 0.00000023148           // growth per-second when all conditions apply
-    ec_rate = #$../mass$                 // EC/s consumed by the lamp at max intensity
+    ec_rate = 4.25                      // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
     pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
@@ -379,25 +378,25 @@
     INPUT_RESOURCE
     {
       name = Ammonia
-      rate = 0.00695                    // 37530 units required for crop
+      rate = 0.011815                   // 63800 units required for crop
     }
 
     INPUT_RESOURCE
     {
       name = Water
-      rate = 0.00023148                 // 1250 units required for crop
+      rate = 0.000393516                // 2125 units required for crop
     }
 
     OUTPUT_RESOURCE
     {
       name = Oxygen
-      rate = 0.00463                    // 25% of oxygen required by 1 crew member
+      rate = 0.007871                   // 42.5% of oxygen required by 1 crew member
     }
 
     OUTPUT_RESOURCE
     {
       name = WasteWater
-      rate = 0.00023033
+      rate = 0.000391561
     }
   }
   
@@ -405,14 +404,89 @@
   {
     name = Waste
     amount = 0
-    maxAmount = 10
+    maxAmount = 17
   }
 
   RESOURCE
   {
     name = Ammonia
-    amount = 1000
-    maxAmount = 1000
+    amount = 1700
+    maxAmount = 1700
+  }
+}
+
+
+@PART[sspx-greenhouse-375-1]:NEEDS[ProfileDefault]:FOR[Kerbalism]
+{
+  MODULE
+  {
+    name = Habitat
+    toggle = false
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _PressureControl
+    title = Pressure control
+    capacity = 0.2143
+    running = true
+  }
+
+  MODULE
+  {
+    name = Greenhouse
+
+    crop_resource = Food                // name of resource produced by harvests
+    crop_size = 6375.0                  // amount of resource produced by harvests
+    crop_rate = 0.00000023148           // growth per-second when all conditions apply
+    ec_rate = 6.375                     // EC/s consumed by the lamp at max intensity
+
+    light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
+    pressure_tolerance = 0.1            // minimum pressure required for growth, in sea level atmospheres
+    radiation_tolerance = 0.000008333   // maximum radiation allowed for growth in rad/s, considered after shielding is applied
+	
+    lamps = Cylinder001                 // object with emissive texture used to represent lamp intensity graphically
+    shutters = door                     // animation to manipulate shutters
+    plants =                            // animation to represent plant growth graphically
+
+    INPUT_RESOURCE
+    {
+      name = Ammonia
+      rate = 0.0177225                  // 95700 units required for crop
+    }
+
+    INPUT_RESOURCE
+    {
+      name = Water
+      rate = 0.000590274                // 3190 units required for crop
+    }
+
+    OUTPUT_RESOURCE
+    {
+      name = Oxygen
+      rate = 0.0118065                  // 64% of oxygen required by 1 crew member
+    }
+
+    OUTPUT_RESOURCE
+    {
+      name = WasteWater
+      rate = 0.0005873415
+    }
+  }
+  
+  RESOURCE
+  {
+    name = Waste
+    amount = 0
+    maxAmount = 25.5
+  }
+
+  RESOURCE
+  {
+    name = Ammonia
+    amount = 2550
+    maxAmount = 2550
   }
 }
 


### PR DESCRIPTION
Fixed not only crop amounts but also resources i/o rates and build-in storages too. (x1.7 for 2.5m and x2.55 for 3.75). 
crop_size = #$../mass$
crop_size *= 1000
doesn't work for me