### PR TITLE
Updated profiler GUI to use the Canvas system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
  * Profile importing is now available to modders who wish to import their own procceses, rules, supplies etc (thanks to PiezPiedPy)
    see Issue #2 on GitHub for more information [Here](https://github.com/MoreRobustThanYou/Kerbalism/issues/2)
+ * Updated Profiler GUI to use the Canvas system. Added Reset averages & Show zero calls buttons,
+   a Framerate limiter, avg calls and frame counter (thanks go to PiezPiedPy)
 
 
 1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.5.2 for KSP 1.4.3
+## v1.6.0 for KSP 1.4.3
  - 2018-05-xx
 
 ### Changes since the last release

--- a/src/Kerbalism.csproj
+++ b/src/Kerbalism.csproj
@@ -65,7 +65,7 @@
     <OutputPath Condition="!Exists('$(KSPDEVDIR)\GameData\Kerbalism\')">obj\Kerbalism\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <CheckForOverflowUnderflow>false</CheckForOverflowUnderflow>
-    <DefineConstants>TRACE;DEBUG;DEVELOPMENT;ENABLE_PROFILER;KERBALISM_PROFILER</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;DEVELOPMENT;ENABLE_PROFILER;DEBUG_PROFILER</DefineConstants>
     <DebugType>full</DebugType>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -24,5 +24,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can use the default the Revision and
 // Build Numbers by using the '*' as shown below:
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")]


### PR DESCRIPTION
Included the Profiler from Trajectories that was originaly from Kerbalism, I gave it a major overhaul in Trajectories with the following changes:

* The Profiler GUI has been updated to use KSP's PopupDialog class which in turn uses a GameObject with a canvas and also has the added benefit of stopping most mouse click through events, even to the context menus.
* A button to reset the average values.
* A button to disable clearing of values when there are zero calls.
* A frame limiter to smooth out display.
* An average calls per physics frame value and physics frame counter.
* Profiler Addon no longer loads in the release build.

You can change the display framerate by changing the `update_fps` value on line 59.
To Show/Hide the profiler use CTRL+P

There is more info in the CONTRIBUTING.md file on how to use the profiler.