### PR TITLE
Fix signal notification checkbox not showing up in vessel config

### DIFF
--- a/src/Kerbalism/UI/VesselConfig.cs
+++ b/src/Kerbalism/UI/VesselConfig.cs
@@ -53,8 +53,7 @@ namespace KERBALISM
 				p.AddContent(Local.VESSELCONFIG_supply, string.Empty, tooltip);//"supply"
 				p.AddRightIcon(vd.cfg_supply ? Textures.toggle_green : Textures.toggle_red, tooltip, () => p.Toggle(ref vd.cfg_supply));
 			}
-			// FIXME: Because RemoteTech does not show up in API.Comm.handlers, as a workaround, always show the signal notification checkbox
-			// if (API.Comm.handlers.Count > 0 || HighLogic.fetch.currentGame.Parameters.Difficulty.EnableCommNet)
+			if (API.Comm.handlers.Count > 0 || RemoteTech.Installed || HighLogic.fetch.currentGame.Parameters.Difficulty.EnableCommNet)
 			{
 				tooltip = Local.VESSELCONFIG_Signallost;//"Receive a message when signal is lost or obtained"
 				p.AddContent(Local.VESSELCONFIG_signal, string.Empty, tooltip);//"signal"

--- a/src/Kerbalism/UI/VesselConfig.cs
+++ b/src/Kerbalism/UI/VesselConfig.cs
@@ -53,7 +53,8 @@ namespace KERBALISM
 				p.AddContent(Local.VESSELCONFIG_supply, string.Empty, tooltip);//"supply"
 				p.AddRightIcon(vd.cfg_supply ? Textures.toggle_green : Textures.toggle_red, tooltip, () => p.Toggle(ref vd.cfg_supply));
 			}
-			if (API.Comm.handlers.Count > 0 || HighLogic.fetch.currentGame.Parameters.Difficulty.EnableCommNet)
+			// FIXME: Because RemoteTech does not show up in API.Comm.handlers, as a workaround, always show the signal notification checkbox
+			// if (API.Comm.handlers.Count > 0 || HighLogic.fetch.currentGame.Parameters.Difficulty.EnableCommNet)
 			{
 				tooltip = Local.VESSELCONFIG_Signallost;//"Receive a message when signal is lost or obtained"
 				p.AddContent(Local.VESSELCONFIG_signal, string.Empty, tooltip);//"signal"


### PR DESCRIPTION
This is a workaround for RemoteTech users to always show the checkbox to toggle signal lost/regained notifications, because it does not show up when using RemoteTech, which, if signal notifications are enabled in the global Kerbalism settings, leads to annoying notifications (and timewarp cancelling) for every craft that cannot be disabled without editing the save file.

I am not sure why RemoteTech does not show up as a comm handler in `API.Comm.handlers` though.

Fixes #823.