### PR TITLE
Add resources to SSPX deep space logistics modules

### DIFF
--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -1325,6 +1325,16 @@
 			transform = SnacksDecal
 		}
 	}
+	@MODULE[ModuleB9PartSwitch]:HAS[!SUBTYPE[Water]]
+	{
+		SUBTYPE
+		{
+			name = Water
+			tankType = Water
+			title = Water
+			transform = WaterDecal
+		}
+	}
 	@MODULE[ModuleB9PartSwitch]:HAS[!SUBTYPE[Supplies]]
 	{
 		SUBTYPE
@@ -1345,6 +1355,26 @@
 			transform = LifeSupportDecal
 		}
 	}
+	@MODULE[ModuleB9PartSwitch]:HAS[!SUBTYPE[WasteWater]]
+	{
+		SUBTYPE
+		{
+			name = WasteWater
+			tankType = WasteWater
+			title = Wet Waste
+			transform = LifeSupportDecal
+		}
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[!SUBTYPE[Sewage]]
+	{
+		SUBTYPE
+		{
+			name = Sewage
+			tankType = Sewage
+			title = Sewage
+			transform = LifeSupportDecal
+		}
+	}
 }
 
 @PART[sspx-logistics*]:HAS[@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch]]]:NEEDS[StationPartsExpansionRedux,B9PartSwitch,CommunityResourcePack,!ProfileNone]:AFTER[zzzKerbalismDefault]
@@ -1357,6 +1387,16 @@
 			tankType = Food
 			title = Food
 			transform = SnacksDecal
+		}
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch],!SUBTYPE[Water]]
+	{
+		SUBTYPE
+		{
+			name = Water
+			tankType = Water
+			title = Water
+			transform = WaterDecal
 		}
 	}
 	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch],!SUBTYPE[Supplies]]
@@ -1376,6 +1416,26 @@
 			name = Waste
 			tankType = Waste
 			title = Waste
+			transform = LifeSupportDecal
+		}
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch],!SUBTYPE[WasteWater]]
+	{
+		SUBTYPE
+		{
+			name = WasteWater
+			tankType = WasteWater
+			title = Wet Waste
+			transform = LifeSupportDecal
+		}
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[cargoSwitch],!SUBTYPE[Sewage]]
+	{
+		SUBTYPE
+		{
+			name = Sewage
+			tankType = Sewage
+			title = Sewage
 			transform = LifeSupportDecal
 		}
 	}


### PR DESCRIPTION
I noticed the Kerbalism resources were missing on the Stockalike Station Parts Redux's Deep Space Logistics Modules.
They are the essentially the exact same as the cargo containers that are already supported, except just larger.

Also added the liquid resources to the cargo containers because they can hold other liquids.