### PR TITLE
proposal: produce food constantly from greenhouses, remove harvests

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -1181,10 +1181,8 @@ PARTUPGRADE:NEEDS[ProfileDefault]
     // Much larger design for producing food for 6 people can be found here (values not used): https://www.degruyter.com/downloadpdf/j/opag.2017.2.issue-1/opag-2017-0011/opag-2017-0011.pdf
     // This Greenhouse is assumed to have 24 m^3 volume dedicated to food production (all greenhouses in mod support files are calculated relative to this one).
     // This Greenhouse is intended to support 0.5 Kerbal just like the Prototype Lunar Greenhouse.
-    // Harvest time is 200 days, but in order to avoid micromanagement this greenhouse supports 0.5 Kerbal for 210 days.
-    // Kerbals need 52.5 food per 200 days, converted to 210 days that is 55.125 food.
-    crop_size = 27.5625                 // amount of resource produced by harvests
-    crop_rate = 0.00000023148           // growth per second when all conditions apply, a fully grown crop equals value of 1.0
+    crop_size = 1                       // harvests now create almost no food. Set this to 27.5625, crop_rate to 0.00000023148, and delete the OUTPUT_RESOURCE Food if you prefer your greenhouses to be harvested manually
+    crop_rate = 0.00000000001           // Harvest every ~10,000 years (because harvestable greenhouses stop continuous food/oxygen production, which we do not want)
     ec_rate = 2.5                       // EC/s consumed by the lamp at max intensity
 
     light_tolerance = 400.0             // minimum lighting flux required for growth, in W/m^2
@@ -1237,6 +1235,12 @@ PARTUPGRADE:NEEDS[ProfileDefault]
     // Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
     // CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
     // If there is not enough resources then the plants will suffer.
+
+    OUTPUT_RESOURCE
+    {
+        name = Food
+        rate = 0.00000638               // after 200 days, this creates 27.56 food, which is 105 days' worth of food for a Kerbal
+    }
 
     OUTPUT_RESOURCE
     {

--- a/GameData/KerbalismConfig/Support/SSPX.cfg
+++ b/GameData/KerbalismConfig/Support/SSPX.cfg
@@ -738,9 +738,8 @@
 		// Twice as effective as kerbalism-greenhouse part. 
 		// See https://forum.kerbalspaceprogram.com/index.php?/topic/172400-131145-kerbalism-v180/&page=32&tab=comments#comment-3446891 for details.
 
-		// This greenhouse has 18 independent sections! It's 18 staged crops in rotation. Almost non-stop production, but each harvest is 18 times smaller.
-		crop_size = 3.0625									// 18 times less harvest than 2x"kerbalism-greenhouse"
-		crop_rate = 0.00000416664					 // but you can harvest 18 times more often due to independent sections!
+		crop_size = 1									// disable the harvest system because we produce food constantly instead
+		crop_rate = 0.00000000001					 // disable the harvest system because we produce food constantly instead
 		ec_rate = 5												 // 2x"kerbalism-greenhouse"
 		light_tolerance = 400.0						 // minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1						// minimum pressure required for growth, in sea level atmospheres
@@ -776,6 +775,12 @@
 		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
 		// CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
 		// If there is not enough resources then the plants will suffer.
+
+        OUTPUT_RESOURCE
+        {
+            name = Food
+            rate = 0.00001276                               // 2x"kerbalism-greenhouse"
+        }
 
 		OUTPUT_RESOURCE
 		{
@@ -834,9 +839,8 @@
 		// Twice as effective as kerbalism-greenhouse part. 
 		// See https://forum.kerbalspaceprogram.com/index.php?/topic/172400-131145-kerbalism-v180/&page=32&tab=comments#comment-3446891 for details.
 
-		// Both growing "rings" of this greenhouse are unfortunately in the same section. No independent growing possible. (Different watering and lighting needs for different grow stages). 
-		crop_size = 55.125									// 2x kerbalism-greenhouse
-		crop_rate = 0.00000023148					 // regular growth speed
+		crop_size = 1									// disable the harvest system because we produce food constantly instead
+		crop_rate = 0.00000000001					 // disable the harvest system because we produce food constantly instead
 		ec_rate = 5												 // 2x"kerbalism-greenhouse"
 		light_tolerance = 400.0						 // minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1						// minimum pressure required for growth, in sea level atmospheres
@@ -870,6 +874,12 @@
 		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
 		// CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
 		// If there is not enough resources then the plants will suffer.
+
+        OUTPUT_RESOURCE
+        {
+            name = Food
+            rate = 0.00001276                               // 2x"kerbalism-greenhouse"
+        }
 
 		OUTPUT_RESOURCE
 		{
@@ -926,9 +936,8 @@
 		// 12 as effective as kerbalism-greenhouse part. 
 		// See https://forum.kerbalspaceprogram.com/index.php?/topic/172400-131145-kerbalism-v180/&page=32&tab=comments#comment-3446891 for details.
 
-		// This greenhouse has 2 sections! 2 staged crops in rotation, each harvest is 2 times smaller.
-		crop_size = 165.375									// 2 times less harvest than 12x"kerbalism-greenhouse"
-		crop_rate = 0.00000046296					 // but you can harvest 2 times more often due to independent sections!
+		crop_size = 1									// disable the harvest system because we produce food constantly instead
+		crop_rate = 0.00000000001					 // disable the harvest system because we produce food constantly instead
 		ec_rate = 30												 // 12x"kerbalism-greenhouse"
 		light_tolerance = 400.0						 // minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1						// minimum pressure required for growth, in sea level atmospheres
@@ -962,6 +971,12 @@
 		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
 		// CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
 		// If there is not enough resources then the plants will suffer.
+
+        OUTPUT_RESOURCE
+        {
+            name = Food
+            rate = 0.000076562                               // 12x"kerbalism-greenhouse"
+        }
 
 		OUTPUT_RESOURCE
 		{
@@ -1019,9 +1034,8 @@
 		// Twice as effective as kerbalism-greenhouse part. 
 		// See https://forum.kerbalspaceprogram.com/index.php?/topic/172400-131145-kerbalism-v180/&page=32&tab=comments#comment-3446891 for details.
 
-		// This is a surface greenhouse. For the time, it acts as the 375m greenhouse, as it cant have different crops, so just 1 big harvest. 
-		crop_size = 55.125									// 2x kerbalism-greenhouse
-		crop_rate = 0.00000023148					 // regular growth speed
+		crop_size = 1									// disable the harvest system because we produce food constantly instead
+		crop_rate = 0.00000000001					 // disable the harvest system because we produce food constantly instead
 		ec_rate = 5												 // 2x"kerbalism-greenhouse"
 		light_tolerance = 400.0						 // minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1						// minimum pressure required for growth, in sea level atmospheres
@@ -1055,6 +1069,12 @@
 		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
 		// CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
 		// If there is not enough resources then the plants will suffer.
+
+        OUTPUT_RESOURCE
+        {
+            name = Food
+            rate = 0.00001276                               // 2x"kerbalism-greenhouse"
+        }
 
 		OUTPUT_RESOURCE
 		{
@@ -1112,9 +1132,8 @@
 		// 1/6 as effective as kerbalism-greenhouse part. 
 		// See https://forum.kerbalspaceprogram.com/index.php?/topic/172400-131145-kerbalism-v180/&page=32&tab=comments#comment-3446891 for details.
 
-		// No independent growing possible. (Different watering and lighting needs for different grow stages). 
-		crop_size = 4.59375						// 1/3x kerbalism-greenhouse
-		crop_rate = 0.00000023148					// regular growth speed
+		crop_size = 1									// disable the harvest system because we produce food constantly instead
+		crop_rate = 0.00000000001					 // disable the harvest system because we produce food constantly instead
 		ec_rate = 0.833							// 1/6x"kerbalism-greenhouse"
 		light_tolerance = 400.0						// minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1						// minimum pressure required for growth, in sea level atmospheres
@@ -1148,6 +1167,12 @@
 		// Note. if there is a deficiency in the amount of WasteAtmosphere needed then the missing amount of WasteAtmosphere will be added to the
 		// CarbonDioxide input and Vies Versa if not enough CarbonDioxide is present and there is extra WasteAtmosphere.
 		// If there is not enough resources then the plants will suffer.
+
+        OUTPUT_RESOURCE
+        {
+            name = Food
+            rate = 0.000001063                               // 1/6x"kerbalism-greenhouse"
+        }
 
 		OUTPUT_RESOURCE
 		{
@@ -1216,8 +1241,8 @@
 		// consumes waste of 2 kerbals + ammonia of 1x kerbalism-greenhouse (for algae), o2 of 0.75 kerbals, some water and ec
 		// somewhat higher food per ammonia ratio than traditional greenhouses, 0.0957 food/nh3 instead of 0.0667 food/nh3
 
-		crop_size = 58.7087						// slightly faster than 1x kerbalism-greenhouse to match changed growth speed, would be 234.8312 if treated as one tank
-		crop_rate = 0.0000004347					// way faster growth speed, would be 0.000000108675 if treated as one tank, one kerbin year growth cycle, 1/4 bc 4 tanks
+		crop_size = 1									// disable the harvest system because we produce food constantly instead
+		crop_rate = 0.00000000001					 // disable the harvest system because we produce food constantly instead
 		ec_rate = 20							// 8x"kerbalism-greenhouse" bc of more expensive pumping, filtration, and temp regulation needs
 		light_tolerance = 400.0						// minimum lighting flux required for growth, in W/m^2
 		pressure_tolerance = 0.1					// minimum pressure required for growth, in sea level atmospheres
@@ -1247,6 +1272,12 @@
 										// does this work? no it doesnt, and i dont know how to make it work. System seems to only work with WasteAtmosphere/CO2
 //			rate = 0.001868699625					// 1.5x"kerbalism-greenhouse"
 //		}
+
+        OUTPUT_RESOURCE
+        {
+            name = Food
+            rate = 0.000025521                               // around 4x"kerbalism-greenhouse"
+        }
 
 		INPUT_RESOURCE
 		{


### PR DESCRIPTION
proposal: let's make greenhouses deliver food constantly.

Why: greenhouses interfere with timewarp, to have the player do a chore that involves no actual decisions.

If you have a mining base or space station with many greenhouses, and you try running 10,000x timewarp, you'll need to interrupt your timewarp every 7-8 minutes to click "harvest" on each one, or your base will have a loss of food/oxygen production.

For gameplay purposes, let's just allow them to grow food constantly.

This PR is a demo implementation for testing and feedback:

 * it retains the food rates of kerbalism and sspx greenhouses
 * it stalls out harvests so they don't disrupt the food production

Ideally if this proposal gets strong support, this PR should include some code changes as it retains these flaws:

 * the "harvest" is still part of the UI; it's vestigial with this change
 * food growth seems to continue when co2 is depleted
 * it doesn't help players who play with other profiles, like Realism Overhaul players -- who could also use a break :D