### PR TITLE
Add API methods to get average rates of vessel resources

### DIFF
--- a/src/Kerbalism/System/API.cs
+++ b/src/Kerbalism/System/API.cs
@@ -455,6 +455,19 @@ namespace KERBALISM
 			return result;
 		}
 
+		public static double ResourceAverageRate(Vessel v, string resource_name)
+		{
+			return ResourceCache.GetResource(v, resource_name).AverageRate;
+		}
+
+		public static List<double> ResourceAverageRates(Vessel v, List<string> resource_names)
+		{
+			List<double> result = new List<double>(resource_names.Count);
+			foreach (var name in resource_names)
+				result.Add(ResourceAverageRate(v, name));
+			return result;
+		}
+
 		public static double ResourceCapacity(Vessel v, string resource_name)
 		{
 			return ResourceCache.GetResource(v, resource_name).Capacity;


### PR DESCRIPTION
I have made these match the existing API methods. I _think_ `AverageRate` is the right field to expose to users. I'm happy to adjust that if that is not the case.