### PR TITLE
Update Default.cfg to fix a localized language ISRU bug

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -1478,11 +1478,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 
 @PART[kerbalism-chemicalplant,MiniISRU,ISRU]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
 {
-  !MODULE[ModuleResourceConverter]:HAS[#ConverterName[Lf+Ox]] {}
-  !MODULE[ModuleResourceConverter]:HAS[#ConverterName[LiquidFuel]] {}
-  !MODULE[ModuleResourceConverter]:HAS[#ConverterName[Oxidizer]] {}
-  !MODULE[ModuleResourceConverter]:HAS[#ConverterName[Monoprop]] {}
-  !MODULE[ModuleResourceConverter]:HAS[#ConverterName[MonoPropellant]] {}
+  !MODULE[ModuleResourceConverter],* {}
   !MODULE[ModuleOverheatDisplay] {}
   !MODULE[ModuleCoreHeat] {}
 


### PR DESCRIPTION
Fixed #959. The bug that caused ISRU to be unable to delete the `ModuleResourceConverter` module due to a localized language.
This issue should have been fixed. In fact, this bug may have affected all players of non-English KSP games?

 