### PR TITLE
Fix: Disabled habitats included in radiation calculations （#965）

### DIFF
--- a/src/Kerbalism/Database/VesselHabitatInfo.cs
+++ b/src/Kerbalism/Database/VesselHabitatInfo.cs
@@ -80,6 +80,8 @@ namespace KERBALISM
 		{
             state = ObjectState.Uninitialized;
 			habitatIndex = -1;
+			habitatWrappers?.Clear();
+			habitatShieldings?.Clear();
         }
 
 		internal void Save(ConfigNode node)
@@ -300,7 +302,14 @@ namespace KERBALISM
 			{
 				// first run, do them all
 				foreach (var habitat in habitatWrappers)
-					RaytraceToSun(habitat.LoadedPart);
+				{
+					// only calculate radiation for enabled habitats
+					if (habitat.State == State.enabled || habitat.State == State.evaKerbal)
+						RaytraceToSun(habitat.LoadedPart);
+					else
+						// remove disabled habitat from shielding calculations
+						habitatShieldings.Remove(habitat.LoadedPart.flightID);
+				}
 				habitatIndex = 0;
 			}
 			else
@@ -310,7 +319,14 @@ namespace KERBALISM
 				if (habitatWrappers[habitatIndex].LoadedPart == null)
 					habitatWrappers.RemoveAt(habitatIndex);
 				else
-					RaytraceToSun(habitatWrappers[habitatIndex].LoadedPart);
+				{
+					// only calculate radiation for enabled habitats
+					if (habitatWrappers[habitatIndex].State == State.enabled || habitatWrappers[habitatIndex].State == State.evaKerbal)
+						RaytraceToSun(habitatWrappers[habitatIndex].LoadedPart);
+					else
+						// remove disabled habitat from shielding calculations
+						habitatShieldings.Remove(habitatWrappers[habitatIndex].LoadedPart.flightID);
+				}
 
 				if (habitatWrappers.Count == 0)
 					habitatIndex = -1;


### PR DESCRIPTION
Fixes  #965 

### Problem
1. Disabled habitats are still included in radiation shielding calculations during CME events, making it impossible to reduce radiation by disabling habitats
2. Habitat wrappers and shielding data are not cleared when vessel structure changes (dock/undock), causing cumulative radiation issues - stations become progressively worse at shielding after multiple docking operations

### Root Cause
- `HabitatsRadiationUpdate()` calls `RaytraceToSun()` on all habitats without checking their `State`
- `Reset()` method doesn't clear `habitatWrappers` list and `habitatShieldings` dictionary when vessel modification events occur

### Solution
- Added state checks (`State.enabled` or `State.evaKerbal`) before calculating radiation in `HabitatsRadiationUpdate()`
- Remove disabled habitats from `habitatShieldings` dictionary to prevent them from being included in `AverageHabitatRadiation()` calculations
- Clear both `habitatWrappers` and `habitatShieldings` collections in `Reset()` method

### Testing
- Compiled and tested in KSP 1.12.x
- Verified disabled habitats no longer contribute to radiation calculations
- Confirmed habitat lists are properly cleared and rebuilt after dock/undock operations

### Impact
This fix makes space station design more reasonable and allows players to manage radiation exposure during CME events by disabling non-essential habitats as intended.