### PR TITLE
add datarate information to CONTROL PATH window

### DIFF
--- a/src/Kerbalism/Comms/CommHandlerCommNetBase.cs
+++ b/src/Kerbalism/Comms/CommHandlerCommNetBase.cs
@@ -25,8 +25,11 @@ namespace KERBALISM
 			{
 				connection.strength = 0.0;
 				connection.rate = 0.0;
+				connection.hop_datarate = 0.0;
 				connection.target_name = string.Empty;
-				connection.control_path.Clear();
+				connection.next_hop = Guid.Empty;
+				connection.hop_distance = 0.0;
+				connection.hop_max_distance = 0.0;
 
 				if (!vIsNull && v.connection.InPlasma)
 				{
@@ -47,52 +50,40 @@ namespace KERBALISM
 			connection.Status = firstLink.hopType == HopType.Home ? LinkStatus.direct_link : LinkStatus.indirect_link;
 			connection.strength = firstLink.signalStrength;
 
-			connection.rate = baseRate * Math.Pow(firstLink.signalStrength, Sim.DataRateDampingExponent);
+			connection.hop_datarate = baseRate * Math.Pow(firstLink.signalStrength, Sim.DataRateDampingExponent);
+			connection.rate = connection.hop_datarate;
 
 			connection.target_name = Lib.Ellipsis(Localizer.Format(v.connection.ControlPath.First.end.displayName).Replace("Kerbin", "DSN"), 20);
 
+			var link = v.Connection.ControlPath.First;
+
 			if (connection.Status != LinkStatus.direct_link)
 			{
-				Vessel firstHop = CommNodeToVessel(v.Connection.ControlPath.First.end);
+				Vessel firstHop = CommNodeToVessel(link.end);
 				// Get rate from the firstHop, each Hop will do the same logic, then we will have the min rate for whole path
 				if (firstHop == null || !firstHop.TryGetVesselData(out VesselData vd))
+				{
 					connection.rate = 0.0;
+					connection.hop_datarate = 0.0;
+				}
 				else
 					connection.rate = Math.Min(vd.Connection.rate, connection.rate);
+
+				connection.next_hop = firstHop.id;
 			}
+			else
+				connection.next_hop = Guid.Empty;
 
-			connection.control_path.Clear();
-			foreach (CommLink link in v.connection.ControlPath)
-			{
-				double antennaPower = link.end.isHome ? link.start.antennaTransmit.power + link.start.antennaRelay.power : link.start.antennaTransmit.power;
-				double linkDistance = (link.start.position - link.end.position).magnitude;
-				double linkMaxDistance = Math.Sqrt(antennaPower * link.end.antennaRelay.power);
-				double signalStrength = 1 - (linkDistance / linkMaxDistance);
-				signalStrength = (3 - (2 * signalStrength)) * Math.Pow(signalStrength, 2);
-				signalStrength = Math.Pow(signalStrength, Sim.DataRateDampingExponent);
-
-				string[] controlPoint = new string[3];
-
-				// name
-				controlPoint[0] = Localizer.Format(link.end.displayName);
-				if (link.end.isHome)
-					controlPoint[0] = controlPoint[0].Replace("Kerbin", "DSN");
-				controlPoint[0] = Lib.Ellipsis(controlPoint[0], 35);
-
-				// signal strength
-				controlPoint[1] = Lib.HumanReadablePerc(Math.Ceiling(signalStrength * 10000) / 10000, "F2");
-
-				// extra info
-				controlPoint[2] = Lib.BuildString(
-					"Distance: ", Lib.HumanReadableDistance(linkDistance),
-					" (Max: ", Lib.HumanReadableDistance(linkMaxDistance), ")");
-
-				connection.control_path.Add(controlPoint);
-			}
+			double antennaPower = link.end.isHome ? link.start.antennaTransmit.power + link.start.antennaRelay.power : link.start.antennaTransmit.power;
+			connection.hop_distance = (link.start.position - link.end.position).magnitude;
+			connection.hop_max_distance = Math.Sqrt(antennaPower * link.end.antennaRelay.power);
 
 			// set minimal data rate to what is defined in Settings (1 bit/s by default) 
 			if (connection.rate > 0.0 && connection.rate * Lib.bitsPerMB < Settings.DataRateMinimumBitsPerSecond)
 				connection.rate = Settings.DataRateMinimumBitsPerSecond / Lib.bitsPerMB;
+
+			if (connection.hop_datarate > 0.0 && connection.hop_datarate * Lib.bitsPerMB < Settings.DataRateMinimumBitsPerSecond)
+				connection.hop_datarate = Settings.DataRateMinimumBitsPerSecond / Lib.bitsPerMB;
 		}
 
 		private static Vessel CommNodeToVessel(CommNode node)

--- a/src/Kerbalism/Comms/ConnectionInfo.cs
+++ b/src/Kerbalism/Comms/ConnectionInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace KERBALISM
 {
@@ -98,13 +99,24 @@ namespace KERBALISM
 		public string target_name;
 
 		/// <summary>
-		/// Optional: communication path that will be displayed in the UI.
-		/// Each entry in the List is one "hop" in your path.
-		/// provide up to 3 values for each hop: string[] hop = { name, value, tooltip }
-		/// <para/>- name: the name of the relay/station
-		/// <para/>- value: link quality to that relay
-		/// <para/>- tooltip: anything you want to display, maybe link distance, frequency band used, ...
+		/// The next hop in the control path. (Guid.Empty if none or KSC)
 		/// </summary>
-		public List<string[]> control_path = new List<string[]>();
+		public Guid next_hop = Guid.Empty;
+
+		/// <summary>
+		/// The distance to the next hop in meters.
+		/// </summary>
+		public double hop_distance;
+
+		/// <summary>
+		/// The maximum distance to the next hop in meters.
+		/// </summary>
+		public double hop_max_distance;
+
+		/// <summary>
+		/// The data rate to the next hop, contrary to rate which include the min along the path logic,
+		/// hop_datarate is only the data rate of this specific hop.
+		/// </summary>
+		public double hop_datarate;
 	}
 }


### PR DESCRIPTION
Fixes #969

- Added datarate to CONTROL PATH window
- Colorize the datarate and signal strength based on the signal strength
- move strength to hover (it's already implied by color)
- unified across commnet implementations (semi-refactor)

### Before

<img width="366" height="262" alt="image" src="https://github.com/user-attachments/assets/a6463a54-f591-4542-a4bc-a5b6e09e4b72" />

### After

<img width="380" height="102" alt="image" src="https://github.com/user-attachments/assets/d88abddb-1995-4c97-9d15-bbb8d33ec1a9" />