### PR TITLE
with RT update path's next_hop when switching from vessel → KSC radio link

### DIFF
--- a/src/Kerbalism/Comms/CommHandlerRemoteTech.cs
+++ b/src/Kerbalism/Comms/CommHandlerRemoteTech.cs
@@ -71,15 +71,15 @@ namespace KERBALISM
 			{
 				if (controlPath.Length > 0)
 				{
-					double dist = RemoteTech.GetCommsDistance(vd.VesselId, controlPath[0]);
-					double maxDist = RemoteTech.GetCommsMaxDistance(vd.VesselId, controlPath[0]);
+					var nextHop = controlPath[0];
+
+					double dist = RemoteTech.GetCommsDistance(vd.VesselId, nextHop);
+					double maxDist = RemoteTech.GetCommsMaxDistance(vd.VesselId, nextHop);
 					connection.strength = maxDist > 0.0 ? 1.0 - (dist / Math.Max(maxDist, 1.0)) : 0.0;
 					connection.strength = Math.Pow(connection.strength, Sim.DataRateDampingExponentRT);
 
 					connection.hop_datarate = baseRate * connection.strength;
 					connection.rate = connection.hop_datarate;
-
-					var nextHop = controlPath[0];
 
 					connection.hop_distance = RemoteTech.GetCommsDistance(vd.VesselId, nextHop);
 					connection.hop_max_distance = RemoteTech.GetCommsMaxDistance(vd.VesselId, nextHop);
@@ -98,6 +98,8 @@ namespace KERBALISM
 						// Also tell the ConnManager about it.
 						connection.next_hop = nextHop;
 					}
+					else
+						connection.next_hop = Guid.Empty; // Tell the ConnManager we are directly connected to the KSC.
 				}
 
 			}


### PR DESCRIPTION
Updates #974

In fact 947 is in fact two different bugs:
1. the radio path sometimes isn't updated affecting b/s and CONTROL PATH
2. the radio path sometimes isn't updated affecting CONTROL PATH

This fix the second of the two which I've introduced in f08fa1601de4dd16e679f08be2140d30837df4f3, I am pretty sure the first one was already there since I didn't changed the rate calculation. But the first bug is also much rarer and I don't know what triggers it.