### PR TITLE
Add HabTech2 dependency to part upgrades

### DIFF
--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -1,4 +1,4 @@
-PARTUPGRADE:NEEDS[ProfileDefault]
+PARTUPGRADE:NEEDS[ProfileDefault,HabTech2]
 {
 	name = Upgrade-Slots_advScienceTech
 	partIcon = kerbalism-chemicalplant
@@ -9,7 +9,7 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 	description = Adds an additional configurable slot to a Lab/Hab.
 }
 
-PARTUPGRADE:NEEDS[FeatureComfort]
+PARTUPGRADE:NEEDS[FeatureComfort,HabTech2]
 {
 	name = Upgrade-ColumbusShower
 	partIcon = crewCabin
@@ -20,7 +20,7 @@ PARTUPGRADE:NEEDS[FeatureComfort]
 	description = Add a "Shower" to Columbus laboratory module. It's a napkin in a package.
 }
 
-PARTUPGRADE:NEEDS[FeatureComfort]
+PARTUPGRADE:NEEDS[FeatureComfort,HabTech2]
 {
 	name = Upgrade-KiboLaundry
 	partIcon = crewCabin


### PR DESCRIPTION
I noticed in my game that there were upgrades available to add showers and laundry to Columbus and Kibo lab modules, even though I don't have HabTech2 installed. This specifies the missing dependency.