### PR TITLE
Add SCANsat visual experiment definition

### DIFF
--- a/GameData/KerbalismConfig/Support/SCANsat.cfg
+++ b/GameData/KerbalismConfig/Support/SCANsat.cfg
@@ -81,3 +81,14 @@
 	}
 }
 
+@EXPERIMENT_DEFINITION:HAS[#id[SCANsatVisual]]:NEEDS[SCANSat,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	@baseValue = 15
+	@dataScale = 300
+	@dataScale /= #$baseValue$
+	KERBALISM_EXPERIMENT
+	{
+		Situation = InSpaceHigh
+	}
+}
+


### PR DESCRIPTION
SCANsat support was missing the "SCANsatVisual" experiment definition altogether, which meant that visual scanners would never produce data/science in Kerbalism.