### PR TITLE
Fix NullReferenceException and Kerbalism UI errors for Probodobody OKTO2 part in VAB/SPH (Comfort.cfg update)

### DIFF
--- a/GameData/KerbalismConfig/System/Comfort.cfg
+++ b/GameData/KerbalismConfig/System/Comfort.cfg
@@ -40,18 +40,3 @@
 
   @tags ^= :$: comfort:
 }
-
-
-@PART[probeCoreOcto2,probeCoreOcto2_v2]:NEEDS[FeatureComfort]:FOR[KerbalismDefault]
-{
-  MODULE
-  {
-    name = Comfort
-    bonus = not-alone
-    desc = This probe comes with the G.E.R.T.Y. User Interface Software, designed to play chess and disgress about philosophical matters with the crew. The innovative EMOT-ICON interface trick the user into feeling empathy for the software.
-  }
-
-  @tags ^= :$: comfort:
-}
-
-


### PR DESCRIPTION
Update `Comfort.cfg` to fix issues with NullReferenceException and Kerbalism UI exceptions when using the **Probodobody OKTO2** part in VAB/SPH. See #981 for details.