### PR TITLE
Add VABOrganizer configuration for various parts

### DIFF
--- a/GameData/KerbalismConfig/Support/VABOrganizer.cfg
+++ b/GameData/KerbalismConfig/Support/VABOrganizer.cfg
@@ -1,0 +1,47 @@
+@PART[kerbalism-chemicalplant,kerbalism-lifesupportmodule]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = resources
+  }
+}
+
+@PART[kerbalism-geigercounter]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = science
+  }
+}
+
+@PART[kerbalism-gravityring]:NEEDS[StationPartsExpansionRedux,VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = crewCentrifuges
+  }
+}
+
+@PART[kerbalism-greenhouse]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = greenhouses
+  }
+}
+
+@PART[kerbalism-minipump,kerbalism-radialpump]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = resources
+  }
+}
+
+@PART[kerbalism-antenna]:NEEDS[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = direct
+  }
+}

--- a/GameData/KerbalismConfig/Support/VABOrganizer.cfg
+++ b/GameData/KerbalismConfig/Support/VABOrganizer.cfg
@@ -30,7 +30,7 @@
   }
 }
 
-@PART[kerbalism-minipump,kerbalism-radialpump]:NEEDS[VABOrganizer]
+@PART[kerbalism-minipump,kerbalism-radialpump]:NEEDS[VABOrganizer]:AFTER:[KerbalismDefault]
 {
   %VABORGANIZER
   {


### PR DESCRIPTION
Everything gets categorized using existing subcategories except for the containers and active shield, which don't obviously fit into existing subcategories.