### PR TITLE
Fix radiation archives issue

### DIFF
--- a/GameData/KerbalismConfig/System/Radiation.cfg
+++ b/GameData/KerbalismConfig/System/Radiation.cfg
@@ -178,7 +178,7 @@ RadiationModel
   name = heliopause
 
   has_pause = true
-  pause_radius = 1000.0
+  pause_radius = 1250.0
   pause_quality = 0.05
 }
 

--- a/src/Kerbalism/Radiation/Radiation.cs
+++ b/src/Kerbalism/Radiation/Radiation.cs
@@ -738,8 +738,15 @@ namespace KERBALISM
 					}
                 }
 
-                // avoid loops in the chain
-                body = (body.referenceBody != null && body.referenceBody.referenceBody == body) ? null : body.referenceBody;
+                if (Lib.IsSun(body))
+				{
+					body = null;
+				}
+				else
+				{
+					// avoid loops in the chain
+					body = (body.referenceBody != null && body.referenceBody.referenceBody == body) ? null : body.referenceBody;
+				}
             }
 
             // add extern radiation


### PR DESCRIPTION
Mainly fixing issue #922.
For creators of planetary packs, the `pause_radius` of a star's `RadiationModel` should ideally include planets within a reasonable range to avoid vehicles entering interstellar space due to an excessively small magnitude.