### PR TITLE
Add support file for mod PlanetSideExplorationTechnologies

### DIFF
--- a/GameData/KerbalismConfig/Support/PlanetSideExplorationTechnologies.cfg
+++ b/GameData/KerbalismConfig/Support/PlanetSideExplorationTechnologies.cfg
@@ -1,0 +1,101 @@
+@PART[Benjee10_base_HDU_attic]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    MODULE
+    {
+        name = Habitat
+        inflate = true
+        deployed = false
+        volume = 55
+        surface = 65
+    }
+}
+
+@PART[Benjee10_MMSEV_baseHDU]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    @MODULE[HardDrive]
+    {
+        @dataCapacity = 4096
+        @sampleCapacity = 128
+    }
+}
+
+// Turbines
+@PART[Benjee10_MMSEV_baseTurbineGiant]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    !MODULE[ModuleGenerator] {}
+    MODULE
+    {
+        name = ProcessController
+        resource = _ECGen
+        title = Turbine
+        capacity =50.0
+        running = false
+        toggle = true
+    }
+}
+@PART[Benjee10_MMSEV_baseTurbineHelicalLarge1]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    !MODULE[ModuleGenerator] {}
+    MODULE
+    {
+        name = ProcessController
+        resource = _ECGen
+        title = Turbine
+        capacity = 20.0
+        running = false
+        toggle = true
+    }
+}
+@PART[Benjee10_MMSEV_baseTurbineHelicalLarge2]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    !MODULE[ModuleGenerator] {}
+    MODULE
+    {
+        name = ProcessController
+        resource = _ECGen
+        title = Turbine
+        capacity = 20.0
+        running = false
+        toggle = true
+    }
+}
+@PART[Benjee10_MMSEV_baseTurbineHelicalTiny]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    !MODULE[ModuleGenerator] {}
+    MODULE
+    {
+        name = ProcessController
+        resource = _ECGen
+        title = Turbine
+        capacity = 2.0
+        running = false
+        toggle = true
+    }
+}
+@PART[Benjee10_MMSEV_baseTurbineLowDensity]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    !MODULE[ModuleGenerator] {}
+    MODULE
+    {
+        name = ProcessController
+        resource = _ECGen
+        title = Turbine
+        capacity = 10
+        running = false
+        toggle = true
+    }
+}
+@PART[Benjee10_MMSEV_baseTurbineHighDensity]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]
+{
+    !MODULE[ModuleGenerator] {}
+    MODULE
+    {
+        name = ProcessController
+        resource = _ECGen
+        title = Turbine
+        capacity = 15.0
+        running = false
+        toggle = true
+    }
+}
+@PART[Benjee10_MMSEV_baseTurbineMedDensity]:NEEDS[Kerbalism,PlanetSideExplorationTechnologies]:AFTER[KerbalismDefault]


### PR DESCRIPTION
- Added habitat volume for the inflatable base part Benjee10_base_HDU_attic.
- Increased hard drive storage and sample capacity for the command module Benjee10_MMSEV_baseHDU.
- Add electric generation for all **  wind turbine generator **. The electricity production in the background is a fixed value. This value is the same as the one shown in the original tab of the wind turbine.