### PR TITLE
Add suport for Feline utility rover

### DIFF
--- a/GameData/KerbalismConfig/Support/FelineUtilityRover.cfg
+++ b/GameData/KerbalismConfig/Support/FelineUtilityRover.cfg
@@ -1,0 +1,435 @@
+// Support for Lynx parts, from the Feline Utility Rover mod.
+//
+// Stats for minidrill and miniisru copy-pasted from stock.
+// Stats for habitats copy-pasted from Buffalo rover configs.
+
+
+// ============================================================================
+// Lynx Rear Mini-drill
+// ============================================================================
+@PART[Lynx_DrillRear]:NEEDS[FelineUtilityRover,ProfileDefault]:FOR[KerbalismDefault]
+{
+  !MODULE[ModuleResourceHarvester] {}
+  !MODULE[ModuleOverheatDisplay] {}
+  !MODULE[ModuleCoreHeat] {}
+
+  // Crustal - - -
+  MODULE
+  {
+    name = Harvester
+    title = #KERBALISM_WaterExcavation_title//Water Excavation
+    type = 0
+    resource = Water
+    min_abundance = 0.01
+    // https://www.nasa.gov/sites/default/files/atoms/files/mars_ice_drilling_assessment_v6_for_public_release.pdf shows
+    // water harvesters from Ice at a rate of 50-400 L/day, as a middle ground we choose 65 L/day for the small harvester
+    // which when scaled by factor 5 for the big harvester becomes 325 L/day.
+    rate = 0.003 // 65 L/day / (6 hours/day * 3600 seconds/hour)
+    // This is the maximum abundance on a random planet/moon
+    // And the average on Duna poles, which are the only place where at the time writing higher than baseline water levels are modeled
+    // And lower than what is found on Kerbin and Laythe
+    abundance_rate = 0.1
+    ec_rate = 1.0
+  }
+
+  MODULE
+  {
+    name = Harvester
+    title = #KERBALISM_OreExcavation_title//Ore Excavation
+    type = 0
+    resource = Ore
+    min_abundance = 0.02
+    rate = 0.0025
+    ec_rate = 1.0
+  }
+
+  MODULE
+  {
+    name = Harvester
+    title = #KERBALISM_NitrogenExcavation_title//Nitrogen Excavation
+    type = 0
+    resource = Nitrogen
+    min_abundance = 0.02
+    rate = 0.0025
+    ec_rate = 1.0
+  }
+
+  MODULE
+  {
+    name = Configure
+    title = Drill
+    slots = 1
+
+    SETUP
+    {
+      name = Water Extraction
+      desc = #KERBALISM_WaterExcavation_desc//Extract <b>Water</b> from the surface.
+
+      MODULE
+      {
+        type = Harvester
+        id_field = resource
+        id_value = Water
+      }
+
+      RESOURCE
+      {
+        name = Water
+        amount = 0
+        maxAmount = 50
+      }
+    }
+
+    SETUP
+    {
+      name = Ore Extraction
+      desc = #KERBALISM_OreExcavation_desc//Extract <b>Ore</b> from the surface.
+
+      MODULE
+      {
+        type = Harvester
+        id_field = resource
+        id_value = Ore
+      }
+
+      RESOURCE
+      {
+        name = Ore
+        amount = 0
+        maxAmount = 50
+      }
+    }
+
+    SETUP
+    {
+      name = Nitrogen Extraction
+      desc = #KERBALISM_NitrogenExcavation_desc//Extract <b>Nitrogen</b> from the surface.
+
+      MODULE
+      {
+        type = Harvester
+        id_field = resource
+        id_value = Nitrogen
+      }
+
+      RESOURCE
+      {
+        name = Nitrogen
+        amount = 0
+        maxAmount = 50
+      }
+    }
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = Harvester
+    title = #KERBALISM_Harvester_title//Harvester
+    repair = Engineer
+    mtbf = 72576000
+    extra_cost = 1.0
+    extra_mass = 0.2
+  }
+}
+
+// Same stats as stock minidrill
+@PART[Lynx_DrillRear]:NEEDS[FelineUtilityRover,ProfileDefault]:FOR[KerbalismDefault]
+{
+  @MODULE[Harvester],*
+  {
+    drill = ImpactTransform
+    length = 1.08
+  }
+}
+
+
+// ============================================================================
+// Lynx ISRU
+// ============================================================================
+@PART[Lynx_ISRU]:NEEDS[FelineUtilityRover,ProfileDefault]:FOR[KerbalismDefault]
+{
+  !MODULE[ModuleResourceConverter],* {}
+  !MODULE[ModuleOverheatDisplay] {}
+  !MODULE[ModuleCoreHeat] {}
+  !MODULE[ModuleKerbetrotterConverterSwitch] {}
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _WaterElectrolysis
+    title = #KERBALISM_WaterElectrolysis_title//Water electrolysis
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _Sabatier
+    title = #KERBALISM_SabatierProcess_title//Sabatier process
+    capacity = 1
+    valve_i = 2 // workaround until we have a better way to deal with dump valves
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _Haber
+    title = #KERBALISM_HaberProcess_title//Haber process
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _WasteIncinerator
+    title = Waste incinerator
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _WasteCompressor
+    title = #KERBALISM_WasteCompressor_title//Waste compressor
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _Anthraquinone
+    title = #KERBALISM_AnthraquinoneProcess_title//Anthraquinone process
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _HydrazineProduction
+    title = #KERBALISM_HydrazineProduction_title//Hydrazine production
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _NitroHydrazine
+    title = #KERBALISM_HydrazineProductionN2_title//Hydrazine production N2
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _MRE
+    title = #KERBALISM_MoltenRegolithElectrolysis_title//MRE
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _SOE
+    title = #KERBALISM_SolidOxideElectrolysis_title//SOE
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _SCO
+    title = #KERBALISM_SelectiveCatalyticOxidation_title//SCO
+    capacity = 1
+  }
+
+  MODULE
+  {
+    name = Configure
+    title = Chemical Plant
+    slots = 1
+
+    UPGRADES
+    {
+      UPGRADE
+      {
+        name__ = Upgrade-Slots
+        techRequired__ = electronics
+        slots = 0
+      }
+    }
+
+    SETUP
+    {
+      name = Water Electrolysis
+      desc = #KERBALISM_WaterElectrolysis_desc//Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _WaterElectrolysis
+      }
+    }
+
+    SETUP
+    {
+      name = Sabatier Process
+      desc = #KERBALISM_SabatierProcess_desc//<b>Hydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LiquidFuel</b>.
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _Sabatier
+      }
+    }
+
+    SETUP
+    {
+      name = Haber Process
+      desc = #KERBALISM_HaberProcess_desc//Produce <b>Ammonia</b> by <b>Nitrogen</b> fixation.
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _Haber
+      }
+    }
+
+    SETUP
+    {
+      name = Waste Incinerator
+      desc = #KERBALISM_WasteIncinerator_desc//Produce <b>CarbonDioxide</b> and <b>Water</b> by combustion of <b>Waste</b> with <b>Oxygen</b>. Includes a small exhaust turbine generator. If needed <b>Water</b> will be vented to continue <b>CarbonDioxide</b> extraction.
+      tech = precisionEngineering
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _WasteIncinerator
+      }
+    }
+
+    SETUP
+    {
+      name = Waste Compressor
+      desc = #KERBALISM_WasteCompressor_desc//Compact <b>Waste</b> to the density of <b>shielding material</b>.
+      tech = precisionEngineering
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _WasteCompressor
+      }
+    }
+
+    SETUP
+    {
+      name = Anthraquinone Process
+      desc = #KERBALISM_AnthraquinoneProcess_desc//Synthesize <b>Oxidizer</b> using a redox of <b>Oxygen</b> and <b>Hydrogen</b>.
+      tech = advScienceTech
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _Anthraquinone
+      }
+    }
+
+    SETUP
+    {
+      name = Hydrazine Production
+      desc = #KERBALISM_HydrazineProduction_desc//<b>Oxidizer</b> and <b>Ammonia</b> react to produce <b>MonoPropellant</b>, <b>Oxygen</b> and <b>Water</b>.
+      tech = advScienceTech
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _HydrazineProduction
+      }
+    }
+
+    SETUP
+    {
+      name = Hydrazine Production (N2 Injection)
+      desc = #KERBALISM_HydrazineProductionN2_desc//<b>Oxidizer</b> and <b>Ammonia</b> with <b>Nitrogen</b> injection react to produce <b>MonoPropellant</b> and <b>Oxygen</b>.
+      tech = experimentalScience
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _NitroHydrazine
+      }
+    }
+
+    SETUP
+    {
+      name = Solid Oxide Electrolysis
+      desc = #KERBALISM_SolidOxideElectrolysis_desc//Transform <b>CarbonDioxide</b> into <b>Oxygen</b> and <b>Shielding</b>.
+      tech = experimentalScience
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _SOE
+      }
+    }
+
+    SETUP
+    {
+      name = Molten Regolith Electrolysis
+      desc = #KERBALISM_MoltenRegolithElectrolysis_desc//Extract <b>Oxygen</b>, <b>CarbonDioxide</b> and <b>Shielding</b> out of <b>Ore</b>. If needed <b>CarbonDioxide</b> and/or <b>Shielding</b> will be vented in order to continue the <b>Oxygen</b> extraction.
+      tech = advScienceTech
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _MRE
+      }
+    }
+
+    SETUP
+    {
+      name = Selective Catalytic Oxidation
+      desc = #KERBALISM_SelectiveCatalyticOxidation_desc//<b>Ammonia</b> and <b>Oxygen</b> react with a hydrotalcite-like catalyst to produce <b>Nitrogen</b> and <b>Water</b>.
+      tech = experimentalScience
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _SCO
+      }
+    }
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = #KERBALISM_ChemicalPlant_title//Chemical Plant
+    repair = Engineer
+    mtbf = 72576000
+    extra_cost = 1.0
+    extra_mass = 0.2
+  }
+}
+
+
+@PART[Lynx_ISRU]:NEEDS[FelineUtilityRover,ProfileDefault]:FOR[KerbalismDefault]
+{
+  @MODULE[ProcessController],*
+  {
+    @capacity *= 36.0      // Same mass as stock miniISRU, so same capacity
+  }
+}
+
+

--- a/GameData/KerbalismConfig/Support/FelineUtilityRover.cfg
+++ b/GameData/KerbalismConfig/Support/FelineUtilityRover.cfg
@@ -1,7 +1,6 @@
 // Support for Lynx parts, from the Feline Utility Rover mod.
 //
-// Stats for minidrill and miniisru copy-pasted from stock.
-// Stats for habitats copy-pasted from Buffalo rover configs.
+// Stats copy-pasted from stock minidrill and miniisru.
 
 
 // ============================================================================


### PR DESCRIPTION
This adds support for the drill and ISRU from the "Feline Utility Rovers" mod (https://spacedock.info/mod/1172/Feline%20Utility%20Rovers), by means of copy-pasting the config for the stock mini-drill and stock mini-isru.

I wish I could provide a cleaner configuration instead of copy-pasting a bunch of stuff, but my ModManager skills are next to nil.

The other rover parts from that mod seem to work just fine without any specific tweaks.

