### PR TITLE
Fix spelling "evering" -> "everything"

### DIFF
--- a/GameData/Kerbalism/Localization/de.cfg
+++ b/GameData/Kerbalism/Localization/de.cfg
@@ -586,7 +586,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = Kapazität // "Capacity"
     #KERBALISM_HardDrive_Data = Daten // "Data"
     #KERBALISM_HardDrive_Dataempty = Leer // "empty"
-    #KERBALISM_HardDrive_WARNING_title = WARNUNG: Nicht vollständig kopiert // "WARNING: not evering copied"
+    #KERBALISM_HardDrive_WARNING_title = WARNUNG: Nicht vollständig kopiert // "WARNING: not everything copied"
     #KERBALISM_HardDrive_WARNING = Speicher ist ausgelastet // "Storage is at capacity"
     #KERBALISM_HardDrive_info1 = Dateikapazität // "File capacity"
     #KERBALISM_HardDrive_info2 = Probenkapazität // "Sample capacity"

--- a/GameData/Kerbalism/Localization/en-us.cfg
+++ b/GameData/Kerbalism/Localization/en-us.cfg
@@ -126,8 +126,8 @@ Localization
     #KERBALISM_BodyInfo_RADIATION = RADIATION
     #KERBALISM_BodyInfo_solaractivity = solar activity
     #KERBALISM_BodyInfo_radiationonsurface = radiation on surface:
-    #KERBALISM_BodyInfo_innerbelt = inner belt: 
-    #KERBALISM_BodyInfo_outerbelt = outer belt: 
+    #KERBALISM_BodyInfo_innerbelt = inner belt:
+    #KERBALISM_BodyInfo_outerbelt = outer belt:
     #KERBALISM_BodyInfo_magnetopause = magnetopause:
     #KERBALISM_BodyInfo_show = show
     #KERBALISM_BodyInfo_hide = hide
@@ -516,7 +516,7 @@ Localization
     //
     // Module : Greenhouse
     //
-    #KERBALISM_Greenhouse_msg_1 = On <<1>> 
+    #KERBALISM_Greenhouse_msg_1 = On <<1>>
     #KERBALISM_Greenhouse_msg_2 = harvest produced <<1>>
     #KERBALISM_Greenhouse_msg_3 = emergency harvest produced <<1>>
     #KERBALISM_Greenhouse_resoucesmissing = missing <<1>>
@@ -587,7 +587,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = Capacity
     #KERBALISM_HardDrive_Data = Data
     #KERBALISM_HardDrive_Dataempty = empty
-    #KERBALISM_HardDrive_WARNING_title = WARNING: not evering copied
+    #KERBALISM_HardDrive_WARNING_title = WARNING: not everything copied
     #KERBALISM_HardDrive_WARNING = Storage is at capacity
     #KERBALISM_HardDrive_info1 = File capacity
     #KERBALISM_HardDrive_info2 = Sample capacity
@@ -754,7 +754,7 @@ Localization
     #KERBALISM_Sensor_notbreathable = not breathable
     #KERBALISM_Sensor_insidethermosphere = inside <b>thermosphere</b>
     #KERBALISM_Sensor_insideexosphere = inside <b>exosphere</b>
-    #KERBALISM_Sensor_Graviolidetection = Gravioli detection events per-year: 
+    #KERBALISM_Sensor_Graviolidetection = Gravioli detection events per-year:
     #KERBALISM_Sensor_info1 = The elusive negative gravioli particle\nseems to be much harder to detect than expected.
     #KERBALISM_Sensor_info2 = On the other\nhand there seems to be plenty\nof useless positive graviolis around.
     //
@@ -795,7 +795,7 @@ Localization
     #KERBALISM_SolarPanelFixer_failure = failure
     #KERBALISM_SolarPanelFixer_invalidstate = invalid state
     #KERBALISM_SolarPanelFixer_Trackedstar = Tracked star
-    #KERBALISM_SolarPanelFixer_AutoTrack = [Auto] : 
+    #KERBALISM_SolarPanelFixer_AutoTrack = [Auto] :
     //
     // Class : Callbacks
     //
@@ -1092,58 +1092,58 @@ Localization
     #KERBALISM_FlightLogger_Destruction = <<1>> fuel system leak caused destruction of the engine
     #KERBALISM_FlightLogger_Ignition = <<1>> failure on ignition
     //Experiment required
-    #KERBALISM_ExperimentReq_OrbitMinInclination = Min. inclination 
-    #KERBALISM_ExperimentReq_OrbitMaxInclination = Max. inclination 
-    #KERBALISM_ExperimentReq_OrbitMinEccentricity = Min. eccentricity 
-    #KERBALISM_ExperimentReq_OrbitMaxEccentricity = Max. eccentricity 
-    #KERBALISM_ExperimentReq_OrbitMinArgOfPeriapsis = Min. argument of Pe 
-    #KERBALISM_ExperimentReq_OrbitMaxArgOfPeriapsis = Max. argument of Pe 
-    #KERBALISM_ExperimentReq_TemperatureMin = Min. temperature 
-    #KERBALISM_ExperimentReq_TemperatureMax = Max. temperature 
-    #KERBALISM_ExperimentReq_AltitudeMin = Min. altitude 
-    #KERBALISM_ExperimentReq_AltitudeMax = Max. altitude 
-    #KERBALISM_ExperimentReq_RadiationMin = Min. radiation 
-    #KERBALISM_ExperimentReq_RadiationMax = Max. radiation 
-    #KERBALISM_ExperimentReq_VolumePerCrewMin = Min. vol./crew 
-    #KERBALISM_ExperimentReq_VolumePerCrewMax = Max. vol./crew 
+    #KERBALISM_ExperimentReq_OrbitMinInclination = Min. inclination
+    #KERBALISM_ExperimentReq_OrbitMaxInclination = Max. inclination
+    #KERBALISM_ExperimentReq_OrbitMinEccentricity = Min. eccentricity
+    #KERBALISM_ExperimentReq_OrbitMaxEccentricity = Max. eccentricity
+    #KERBALISM_ExperimentReq_OrbitMinArgOfPeriapsis = Min. argument of Pe
+    #KERBALISM_ExperimentReq_OrbitMaxArgOfPeriapsis = Max. argument of Pe
+    #KERBALISM_ExperimentReq_TemperatureMin = Min. temperature
+    #KERBALISM_ExperimentReq_TemperatureMax = Max. temperature
+    #KERBALISM_ExperimentReq_AltitudeMin = Min. altitude
+    #KERBALISM_ExperimentReq_AltitudeMax = Max. altitude
+    #KERBALISM_ExperimentReq_RadiationMin = Min. radiation
+    #KERBALISM_ExperimentReq_RadiationMax = Max. radiation
+    #KERBALISM_ExperimentReq_VolumePerCrewMin = Min. vol./crew
+    #KERBALISM_ExperimentReq_VolumePerCrewMax = Max. vol./crew
     #KERBALISM_ExperimentReq_SunAngleMin = Min. sun-surface angle
     #KERBALISM_ExperimentReq_SunAngleMax = Max. sun-surface angle
-    #KERBALISM_ExperimentReq_SurfaceSpeedMin = Min. surface speed 
-    #KERBALISM_ExperimentReq_SurfaceSpeedMax = Max. surface speed 
-    #KERBALISM_ExperimentReq_VerticalSpeedMin = Min. vertical speed 
-    #KERBALISM_ExperimentReq_VerticalSpeedMax = Max. vertical speed 
-    #KERBALISM_ExperimentReq_SpeedMin = Min. speed 
-    #KERBALISM_ExperimentReq_SpeedMax = Max. speed 
+    #KERBALISM_ExperimentReq_SurfaceSpeedMin = Min. surface speed
+    #KERBALISM_ExperimentReq_SurfaceSpeedMax = Max. surface speed
+    #KERBALISM_ExperimentReq_VerticalSpeedMin = Min. vertical speed
+    #KERBALISM_ExperimentReq_VerticalSpeedMax = Max. vertical speed
+    #KERBALISM_ExperimentReq_SpeedMin = Min. speed
+    #KERBALISM_ExperimentReq_SpeedMax = Max. speed
     #KERBALISM_ExperimentReq_DynamicPressureMin = Min. dynamic pressure
     #KERBALISM_ExperimentReq_DynamicPressureMax = Max. dynamic pressure
-    #KERBALISM_ExperimentReq_StaticPressureMin = Min. pressure 
-    #KERBALISM_ExperimentReq_StaticPressureMax = Max. pressure 
-    #KERBALISM_ExperimentReq_AtmDensityMin = Min. atm. density 
-    #KERBALISM_ExperimentReq_AtmDensityMax = Max. atm. density 
+    #KERBALISM_ExperimentReq_StaticPressureMin = Min. pressure
+    #KERBALISM_ExperimentReq_StaticPressureMax = Max. pressure
+    #KERBALISM_ExperimentReq_AtmDensityMin = Min. atm. density
+    #KERBALISM_ExperimentReq_AtmDensityMax = Max. atm. density
     #KERBALISM_ExperimentReq_AltAboveGroundMin = Min. ground altitude
     #KERBALISM_ExperimentReq_AltAboveGroundMax = Max. ground altitude
     #KERBALISM_ExperimentReq_MaxAsteroidDistance = Max. asteroid distance
     #KERBALISM_ExperimentReq_CommSpeedMin = Min. transmission rate
     #KERBALISM_ExperimentReq_CommSpeedMax = Max. transmission rate
-    #KERBALISM_ExperimentReq_AtmosphereAltMin = Min. atmosphere altitude 
-    #KERBALISM_ExperimentReq_AtmosphereAltMax = Max. atmosphere altitude 
-    #KERBALISM_ExperimentReq_CrewMin = Min. crew 
-    #KERBALISM_ExperimentReq_CrewMax = Max. crew 
-    #KERBALISM_ExperimentReq_CrewCapacityMin = Min. crew capacity 
-    #KERBALISM_ExperimentReq_CrewCapacityMax = Max. crew capacity 
-    #KERBALISM_ExperimentReq_AstronautComplexLevelMin = Astronaut Complex min level 
-    #KERBALISM_ExperimentReq_AstronautComplexLevelMax = Astronaut Complex max level 
-    #KERBALISM_ExperimentReq_TrackingStationLevelMin = Tracking Station min level 
-    #KERBALISM_ExperimentReq_TrackingStationLevelMax = Tracking Station max level 
-    #KERBALISM_ExperimentReq_MissionControlLevelMin = Mission Control min level 
-    #KERBALISM_ExperimentReq_MissionControlLevelMax = Mission Control max level 
-    #KERBALISM_ExperimentReq_AdministrationLevelMin = Administration min level 
-    #KERBALISM_ExperimentReq_AdministrationLevelMax = Administration max level 
-    #KERBALISM_ExperimentReq_Part = Need part 
-    #KERBALISM_ExperimentReq_Module = Need module 
+    #KERBALISM_ExperimentReq_AtmosphereAltMin = Min. atmosphere altitude
+    #KERBALISM_ExperimentReq_AtmosphereAltMax = Max. atmosphere altitude
+    #KERBALISM_ExperimentReq_CrewMin = Min. crew
+    #KERBALISM_ExperimentReq_CrewMax = Max. crew
+    #KERBALISM_ExperimentReq_CrewCapacityMin = Min. crew capacity
+    #KERBALISM_ExperimentReq_CrewCapacityMax = Max. crew capacity
+    #KERBALISM_ExperimentReq_AstronautComplexLevelMin = Astronaut Complex min level
+    #KERBALISM_ExperimentReq_AstronautComplexLevelMax = Astronaut Complex max level
+    #KERBALISM_ExperimentReq_TrackingStationLevelMin = Tracking Station min level
+    #KERBALISM_ExperimentReq_TrackingStationLevelMax = Tracking Station max level
+    #KERBALISM_ExperimentReq_MissionControlLevelMin = Mission Control min level
+    #KERBALISM_ExperimentReq_MissionControlLevelMax = Mission Control max level
+    #KERBALISM_ExperimentReq_AdministrationLevelMin = Administration min level
+    #KERBALISM_ExperimentReq_AdministrationLevelMax = Administration max level
+    #KERBALISM_ExperimentReq_Part = Need part
+    #KERBALISM_ExperimentReq_Module = Need module
     //Vessel Recovery Window
-    #KERBALISM_VesselRecovery_title = recovery 
-    #KERBALISM_VesselRecovery_info = SCIENCE RECOVERED 
+    #KERBALISM_VesselRecovery_title = recovery
+    #KERBALISM_VesselRecovery_info = SCIENCE RECOVERED
     #KERBALISM_VesselRecovery_CREDITS = CREDITS
     #KERBALISM_VesselRecovery_OKbutton = OK
     //Statu Toggle

--- a/GameData/Kerbalism/Localization/es-es.cfg
+++ b/GameData/Kerbalism/Localization/es-es.cfg
@@ -586,7 +586,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = Capacity // "Capacity"
     #KERBALISM_HardDrive_Data = Data // "Data"
     #KERBALISM_HardDrive_Dataempty = empty // "empty"
-    #KERBALISM_HardDrive_WARNING_title = WARNING: not evering copied // "WARNING: not evering copied"
+    #KERBALISM_HardDrive_WARNING_title = WARNING: not everything copied // "WARNING: not everything copied"
     #KERBALISM_HardDrive_WARNING = Storage is at capacity // "Storage is at capacity"
     #KERBALISM_HardDrive_info1 = File capacity // "File capacity"
     #KERBALISM_HardDrive_info2 = Sample capacity // "Sample capacity"

--- a/GameData/Kerbalism/Localization/fr-fr.cfg
+++ b/GameData/Kerbalism/Localization/fr-fr.cfg
@@ -586,7 +586,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = Capacité // "Capacity"
     #KERBALISM_HardDrive_Data = Données // "Data"
     #KERBALISM_HardDrive_Dataempty = vide // "empty"
-    #KERBALISM_HardDrive_WARNING_title = ATTENTION : tout n'a pas été copié // "WARNING: not evering copied"
+    #KERBALISM_HardDrive_WARNING_title = ATTENTION : tout n'a pas été copié // "WARNING: not everything copied"
     #KERBALISM_HardDrive_WARNING = Disque plein // "Storage is at capacity"
     #KERBALISM_HardDrive_info1 = Fichiers max // "File capacity"
     #KERBALISM_HardDrive_info2 = Échantillons max // "Sample capacity"

--- a/GameData/Kerbalism/Localization/it-it.cfg
+++ b/GameData/Kerbalism/Localization/it-it.cfg
@@ -586,7 +586,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = Capacità // "Capacity"
     #KERBALISM_HardDrive_Data = Dati // "Data"
     #KERBALISM_HardDrive_Dataempty = vuoto // "empty"
-    #KERBALISM_HardDrive_WARNING_title = ATTENZIONE: Non completamente copiato // "WARNING: not evering copied"
+    #KERBALISM_HardDrive_WARNING_title = ATTENZIONE: Non completamente copiato // "WARNING: not everything copied"
     #KERBALISM_HardDrive_WARNING = Lo spazio di archiviazione è esaurito // "Storage is at capacity"
     #KERBALISM_HardDrive_info1 = Capacità file // "File capacity"
     #KERBALISM_HardDrive_info2 = Capacità campioni // "Sample capacity"

--- a/GameData/Kerbalism/Localization/pt-br.cfg
+++ b/GameData/Kerbalism/Localization/pt-br.cfg
@@ -586,7 +586,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = Capacity // "Capacity"
     #KERBALISM_HardDrive_Data = Data // "Data"
     #KERBALISM_HardDrive_Dataempty = empty // "empty"
-    #KERBALISM_HardDrive_WARNING_title = WARNING: not evering copied // "WARNING: not evering copied"
+    #KERBALISM_HardDrive_WARNING_title = WARNING: not everything copied // "WARNING: not everything copied"
     #KERBALISM_HardDrive_WARNING = Storage is at capacity // "Storage is at capacity"
     #KERBALISM_HardDrive_info1 = File capacity // "File capacity"
     #KERBALISM_HardDrive_info2 = Sample capacity // "Sample capacity"

--- a/GameData/Kerbalism/Localization/ru.cfg
+++ b/GameData/Kerbalism/Localization/ru.cfg
@@ -586,7 +586,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = Вместимость // "Capacity"
     #KERBALISM_HardDrive_Data = Данные // "Data"
     #KERBALISM_HardDrive_Dataempty = пусто // "empty"
-    #KERBALISM_HardDrive_WARNING_title = ПРЕДУПРЕЖДЕНИЕ: не все скопировали // "WARNING: not evering copied"
+    #KERBALISM_HardDrive_WARNING_title = ПРЕДУПРЕЖДЕНИЕ: не все скопировали // "WARNING: not everything copied"
     #KERBALISM_HardDrive_WARNING = Хранилище заполнено до отказа // "Storage is at capacity"
     #KERBALISM_HardDrive_info1 = Емкость файла // "File capacity"
     #KERBALISM_HardDrive_info2 = Емкость образца // "Sample capacity"

--- a/GameData/Kerbalism/Localization/zh-cn.cfg
+++ b/GameData/Kerbalism/Localization/zh-cn.cfg
@@ -586,7 +586,7 @@ Localization
     #KERBALISM_HardDrive_Capacity = 容量 // "Capacity"
     #KERBALISM_HardDrive_Data = 数据 // "Data"
     #KERBALISM_HardDrive_Dataempty = 空 // "empty"
-    #KERBALISM_HardDrive_WARNING_title = 警告：未复制所有内容 // "WARNING: not evering copied"
+    #KERBALISM_HardDrive_WARNING_title = 警告：未复制所有内容 // "WARNING: not everything copied"
     #KERBALISM_HardDrive_WARNING = 内容已经存储在容器里 // "Storage is at capacity"
     #KERBALISM_HardDrive_info1 = 文件容量 // "File capacity"
     #KERBALISM_HardDrive_info2 = 样本容量 // "Sample capacity"

--- a/src/Kerbalism/LocalizationCache.cs
+++ b/src/Kerbalism/LocalizationCache.cs
@@ -870,7 +870,7 @@ namespace KERBALISM
 		public static string HardDrive_Capacity = GetLoc("HardDrive_Capacity"); // "Capacity"
 		public static string HardDrive_Data = GetLoc("HardDrive_Data"); // "Data"
 		public static string HardDrive_Dataempty = GetLoc("HardDrive_Dataempty"); // "empty"
-		public static string HardDrive_WARNING_title = GetLoc("HardDrive_WARNING_title"); // "WARNING: not evering copied"
+		public static string HardDrive_WARNING_title = GetLoc("HardDrive_WARNING_title"); // "WARNING: not everything copied"
 		public static string HardDrive_WARNING = GetLoc("HardDrive_WARNING"); // "Storage is at capacity"
 		public static string HardDrive_info1 = GetLoc("HardDrive_info1"); // "File capacity"
 		public static string HardDrive_info2 = GetLoc("HardDrive_info2"); // "Sample capacity"

--- a/src/Kerbalism/Modules/HardDrive.cs
+++ b/src/Kerbalism/Modules/HardDrive.cs
@@ -222,7 +222,7 @@ namespace KERBALISM
 		{
 			if (drive == null)
 				return;
-			
+
 			double mass = 0;
 			foreach (var sample in drive.samples.Values) mass += sample.mass;
 			totalSampleMass = mass;
@@ -292,7 +292,7 @@ namespace KERBALISM
 			{
 				Message.Post
 				(
-					Lib.Color(Lib.BuildString(Local.HardDrive_WARNING_title), Lib.Kolor.Red, true),//"WARNING: not evering copied"
+					Lib.Color(Lib.BuildString(Local.HardDrive_WARNING_title), Lib.Kolor.Red, true),//"WARNING: not everything copied"
 					Lib.BuildString(Local.HardDrive_WARNING)//"Storage is at capacity"
 				);
 			}
@@ -310,7 +310,7 @@ namespace KERBALISM
 			{
 				Message.Post
 				(
-					Lib.Color(Lib.BuildString(Local.HardDrive_WARNING_title), Lib.Kolor.Red, true),//"WARNING: not evering copied"
+					Lib.Color(Lib.BuildString(Local.HardDrive_WARNING_title), Lib.Kolor.Red, true),//"WARNING: not everything copied"
 					Lib.BuildString(Local.HardDrive_WARNING)//"Storage is at capacity"
 				);
 			}
@@ -455,7 +455,7 @@ namespace KERBALISM
 		{
 			double result = 0;
 
-			if(effectiveSampleCapacity > sampleCapacity && sampleCapacity > 0)
+			if (effectiveSampleCapacity > sampleCapacity && sampleCapacity > 0)
 			{
 				var sampleMultiplier = (effectiveSampleCapacity / sampleCapacity) - 1;
 				result += sampleMultiplier * sampleCapacityCost;

--- a/src/Kerbalism/Science/Drive.cs
+++ b/src/Kerbalism/Science/Drive.cs
@@ -521,7 +521,7 @@ namespace KERBALISM
 			else
 				Message.Post
 				(
-					Lib.Color(Lib.BuildString("WARNING: not everything copied"), Lib.Kolor.Red, true),
+					Lib.Color(Lib.BuildString(Local.HardDrive_WARNING_title), Lib.Kolor.Red, true), //"WARNING: not everything copied"
 					Lib.BuildString(Local.Generic_FROM, " <b>", src.vesselName, "</b> ", Local.Generic_TO, " <b>", dst.vesselName, "</b>")
 				);
 		}

--- a/src/Kerbalism/Science/Drive.cs
+++ b/src/Kerbalism/Science/Drive.cs
@@ -521,7 +521,7 @@ namespace KERBALISM
 			else
 				Message.Post
 				(
-					Lib.Color(Lib.BuildString("WARNING: not evering copied"), Lib.Kolor.Red, true),
+					Lib.Color(Lib.BuildString("WARNING: not everything copied"), Lib.Kolor.Red, true),
 					Lib.BuildString(Local.Generic_FROM, " <b>", src.vesselName, "</b> ", Local.Generic_TO, " <b>", dst.vesselName, "</b>")
 				);
 		}
@@ -665,4 +665,3 @@ namespace KERBALISM
 
 
 } // KERBALISM
-


### PR DESCRIPTION
Fix a spelling error in an english warning message.

This message was also included as a string directly in a `Drive.Transfer` warning. I have replaced it with its localized version.