### PR TITLE
Add NFPropulsion support

### DIFF
--- a/GameData/KerbalismConfig/Support/NFPropulsion.cfg
+++ b/GameData/KerbalismConfig/Support/NFPropulsion.cfg
@@ -1,0 +1,62 @@
+//@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[ArgonGas]]]:NEEDS[FeatureReliability]:AFTER[KerbalismDefault]
+//{
+//	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+//		@rated_operation_duration = 0
+//		@turnon_failure_probability = 0.002
+//		@repair = Engineer@2
+//	}
+//}
+
+//@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Lithium]]]:NEEDS[FeatureReliability]:AFTER[KerbalismDefault]
+//{
+//	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+//		@rated_operation_duration = 0
+//		@turnon_failure_probability = 0.002
+//		@repair = Engineer@2
+//	}
+//}
+
+@PART[ionArgon-*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[NearFuturePropulsion,FeatureReliability]:AFTER[KerbalismDefault]
+{
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+		@rated_operation_duration = 0
+		@turnon_failure_probability = 0.002
+		@repair = Engineer@2
+	}
+}
+
+@PART[ionXenon-*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[NearFuturePropulsion,FeatureReliability]:AFTER[KerbalismDefault]
+{
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+		@rated_operation_duration = 0
+		@turnon_failure_probability = 0.002
+		@repair = Engineer@2
+	}
+}
+
+@PART[mpdt-*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[NearFuturePropulsion,FeatureReliability]:AFTER[KerbalismDefault]
+{
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+		@rated_operation_duration = 0
+		@turnon_failure_probability = 0.002
+		@repair = Engineer@2
+	}
+}
+
+@PART[pit-*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[NearFuturePropulsion,FeatureReliability]:AFTER[KerbalismDefault]
+{
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+		@rated_operation_duration = 0
+		@turnon_failure_probability = 0.002
+		@repair = Engineer@2
+	}
+}
+
+@PART[vasimr-*]:HAS[@MODULE[ModuleEngines*]]:NEEDS[NearFuturePropulsion,FeatureReliability]:AFTER[KerbalismDefault]
+{
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+		@rated_operation_duration = 0
+		@turnon_failure_probability = 0.002
+		@repair = Engineer@2
+	}
+}


### PR DESCRIPTION
Largely addresses #850 (the other "endgame" engines references are mostly addressed in #719.) 

Near Future Propulsion engines, which use ArgonGas and Lithium from CRP as propellants alongside stock Xenon, are configured to have the same reliability characteristics as Xenon engines in core Kerbalism: unlimited burn time, hundreds of restarts, stricter repair requirements. 

This modifies parts by name, but there is an alternative implementation (included as code that has been commented-out) which addresses all engines by propellant type instead. This is more generic and would largely address any other NFP-like mods (I think there are probably a few, like Supplementary Electric Engines). However I'm wasn't sure where that would best be placed in terms of folder structure and file name. 