### PR TITLE
CryoEnginesExtensions support

### DIFF
--- a/GameData/KerbalismConfig/Support/CryoEnginesExtensions.cfg
+++ b/GameData/KerbalismConfig/Support/CryoEnginesExtensions.cfg
@@ -1,0 +1,7 @@
+@PART[CEX_LMO_Owl]:HAS[@MODULE[Reliability]]:NEEDS[FeatureReliability]:AFTER[KerbalismDefault]
+{
+  @MODULE[Reliability]:HAS[#type[ModuleEngines*]]
+  {
+    @rated_ignitions = 11 //was autoconfigured to 2
+  }
+}


### PR DESCRIPTION
Adds support for CryoEnginesExtensions mod by manually configuring reliability on a single engine that wasn't handled well by the generic/core auto configuration. 

The Owl is a Poodle-like methalox "orbital-class" engine that was rated for only 2-4 ignitions, which prevented it from fulfilling its role effectively. This changes it to 11 ignitions, slightly less than the Poodle or Corgi. 

![](https://i.imgur.com/dJ7fwVg.jpeg)
