### PR TITLE
NF Launch Vehicles support (fuel cells)

### DIFF
--- a/GameData/KerbalismConfig/Support/NFLaunchVehicle.cfg
+++ b/GameData/KerbalismConfig/Support/NFLaunchVehicle.cfg
@@ -1,0 +1,102 @@
+@PART[nflv-rcs-integrated*]:NEEDS[NearFutureLaunchVehicles,ProfileDefault]:AFTER[NearFutureLaunchVehicles]
+{
+  !MODULE[ModuleResourceConverter] {}
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _FuelCell
+    title = #KERBALISM_H2O2FuelCell_title//H2+O2 fuel cell
+    capacity = 0.5
+    valve_i = 1
+  }
+
+  MODULE
+  {
+    name = ProcessController
+    resource = _MonopropFuelCell
+    title = #KERBALISM_MonopropO2FuelCell_title//Monoprop+O2 fuel cell
+    capacity = 2.5
+  }
+
+  MODULE
+  {
+    name = Configure
+    title = Fuel Cell
+    slots = 1
+
+    SETUP
+    {
+      name = Hydrogen Oxygen Fuel Cell
+      desc = #KERBALISM_H2O2FuelCell_desc//Burns <b>Hydrogen</b> gas and <b>Oxygen</b> gas, producing <b>Water</b> as a by-product.
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _FuelCell
+      }
+    }
+
+    SETUP
+    {
+      name = Monoprop Oxygen Fuel Cell
+      desc = #KERBALISM_MonopropO2FuelCell_desc2//Burns <b>MonoPropellant</b> and <b>Oxygen</b> gas, producing <b>Water</b> and <b>Nitrogen</b> gas as by-products.
+      tech = basicScience
+
+      MODULE
+      {
+        type = ProcessController
+        id_field = resource
+        id_value = _MonopropFuelCell
+      }
+    }
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = #KERBALISM_FuelCell_title//Fuel Cell
+    redundancy = Power Generation
+    repair = Engineer
+    mtbf = 72576000
+    extra_cost = 1.0
+    extra_mass = 0.5
+  }
+
+}
+
+@PART[nflv-rcs-integrated*]:NEEDS[NearFutureLaunchVehicles,CryoTanks,ProfileDefault]:AFTER[zzz_CryoTanks]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _LH2FuelCell
+		title = LH2+O2 fuel cell
+		capacity = 0.5
+	}
+	@MODULE[Configure]
+	{
+		SETUP
+		{
+			name = LH2 Oxygen Fuel Cell
+			desc = Burns <b>Liquid Hydrogen</b> and <b>Oxygen</b> gas, producing <b>Water</b> as a by-product.
+			tech = advFuelSystems
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _LH2FuelCell
+			}
+		}
+	}
+	@MODULE[ModuleB9PartSwitch]:HAS[#moduleID[RCS]]
+	{
+		@SUBTYPE[*],*
+		{
+			!MODULE:HAS[@IDENTIFIER[ModuleResourceConverter]] {}
+		}
+	}
+}


### PR DESCRIPTION
Near Future Launch Vehicles adds several bipropellant RCS blocks with integrated fuel cells and batteries. 

This migrates their fuel cells to work like other fuel cells in Kerbalism. It also extends Kerbalism's support for CryoTanks to these fuel cells (LH2+O2 option). 

These parts are based on the [Advanced Cryogenic Evolved Stage Integrated Vehicle Fluids](https://en.wikipedia.org/wiki/Advanced_Cryogenic_Evolved_Stage) proposal. It's may be feasible to adapt them further to actually work with boiled-off fuel like the real-world concept, which would be cool (CryoTanks documentation mentions it is possible for boiloff to produce byproducts). However this would take more work to incorporate additional features that may or may not function properly in the background, so I'm leaving it as a possible future development. 