### PR TITLE
Use Restock models for chemical plant and ECLSS

### DIFF
--- a/GameData/KerbalismConfig/Parts/ChemicalPlant/kerbalism-chemicalplant.cfg
+++ b/GameData/KerbalismConfig/Parts/ChemicalPlant/kerbalism-chemicalplant.cfg
@@ -18,7 +18,7 @@ PART
 	node_attach  = -0.44, -0.752, 0.0, -1.0, 0.0, 0.0, 0
 	attachRules = 1,1,1,1,0
 
-	bulkheadProfiles = size1
+	bulkheadProfiles = size0
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2

--- a/GameData/KerbalismConfig/Parts/LifeSupport/kerbalism-lifesupportmodule.cfg
+++ b/GameData/KerbalismConfig/Parts/LifeSupport/kerbalism-lifesupportmodule.cfg
@@ -25,7 +25,7 @@ PART
 	node_attach  = -0.44, -0.752, 0.0, -1.0, 0.0, 0.0, 0
 	attachRules = 1,1,1,1,0
 
-	bulkheadProfiles = size1
+	bulkheadProfiles = size0
 	dragModelType = default
 	maximum_drag = 0.2
 	minimum_drag = 0.2

--- a/GameData/KerbalismConfig/Support/Restock.cfg
+++ b/GameData/KerbalismConfig/Support/Restock.cfg
@@ -1,0 +1,39 @@
+@PART[kerbalism-lifesupportmodule]:NEEDS[ReStock]:AFTER[ReStock]
+{
+	!mesh = 0
+	MODEL
+	{
+		model = ReStock/Assets/Resource/restock-isru-125-1
+		scale = 0.28, 0.28, 0.28
+	}
+	%rescaleFactor = 1
+	@node_stack_top = 0.0, 0.2632, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.2632, 0.0, 0.0, -1.0, 0.0, 0
+	@node_attach  = -0.154, -0.2632, 0.0, -1.0, 0.0, 0.0, 0
+	MODULE
+	{
+		name = ModuleRestockISRUAnimation
+		deployAnimationName = heater
+		needsEC = false
+	}
+}
+
+@PART[kerbalism-chemicalplant]:NEEDS[ReStock]:AFTER[ReStock]
+{
+	!mesh = 0
+	MODEL
+	{
+		model = ReStock/Assets/Resource/restock-isru-25-1
+		scale = 0.14, 0.168, 0.14
+	}
+	%rescaleFactor = 1
+	@node_stack_top = 0.0, 0.2632, 0.0, 0.0, 1.0, 0.0, 0
+	@node_stack_bottom = 0.0, -0.2632, 0.0, 0.0, -1.0, 0.0, 0
+	@node_attach  = -0.154, -0.2632, 0.0, -1.0, 0.0, 0.0, 0
+	MODULE
+	{
+		name = ModuleRestockISRUAnimation
+		deployAnimationName = heater
+		needsEC = false
+	}
+}


### PR DESCRIPTION
When Restock is installed, use rescaled Restock models for the 1.25m for ECLSS and 2.5m ISRU for chemical plant instead of Roverdude-derived assets. This is in the spirit of addressing the wishlist [here](https://github.com/Kerbalism/Kerbalism/wiki/Dev-~-Parts-Needed): 

> Better parts for the chemical plant and external ECLSS modules. Currently we're using a scaled stock ISRU model with adjusted textures.

This also adjusts the bulkhead profiles for both parts from 1.25m to 0.625m, which more closely reflects their actual size and makes them easier to distinguish when e.g. using VAB Organizer. 