### PR TITLE
SupplementaryElectricEngines Support

### DIFF
--- a/GameData/KerbalismConfig/Support/SupplementaryElectricEngines.cfg
+++ b/GameData/KerbalismConfig/Support/SupplementaryElectricEngines.cfg
@@ -1,0 +1,17 @@
+//@PART[*]:HAS[@MODULE[ModuleEngines*]:HAS[@PROPELLANT[Caesium]]]:NEEDS[FeatureReliability]:AFTER[KerbalismDefault]
+//{
+//	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+//		@rated_operation_duration = 0
+//		@turnon_failure_probability = 0.002
+//		@repair = Engineer@2
+//	}
+//}
+
+@PART[SEE_FEEP_engine]:HAS[@MODULE[ModuleEngines*]]:NEEDS[SupplementaryElectricEngines,FeatureReliability]:AFTER[KerbalismDefault]
+{
+	@MODULE[Reliability]:HAS[#type[ModuleEngines*]] {
+		@rated_operation_duration = 0
+		@turnon_failure_probability = 0.002
+		@repair = Engineer@2
+	}
+}


### PR DESCRIPTION
Configure the FEEP, an electric engine that runs on Cesium, like xenon-based engines. 

SEE has other electric engines that run on Monoprop or SolidFuel and so are already covered by autoconfiguration based on propellant. 