### PR TITLE
Refactor HoursInDay to use GameSettings

### DIFF
--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -310,9 +310,6 @@ namespace KERBALISM
 		{
 			get
 			{
-				if (!GameSettings.KERBIN_TIME)
-					return 24.0;
-
 				if (hoursInDay == -1.0)
 				{
 					if (FlightGlobals.ready || IsEditor())
@@ -322,9 +319,8 @@ namespace KERBALISM
 					}
 					else
 					{
-						return 6.0;
+						return GameSettings.KERBIN_TIME ? 6.0 : 24.0;
 					}
-
 				}
 				return hoursInDay;
 			}


### PR DESCRIPTION
It fixes the planner time not matching calendar time for planet packs that don't use Kerbin as home planet and do not have neither 24 or 6 hour days.