### PR TITLE
Make clicking on PAW buttons toggle windows

### DIFF
--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -418,8 +418,11 @@ namespace KERBALISM
 				}
 			}
 
-			// open the window
-			UI.Open(Window_body);
+			// toggle the window
+			if (UI.window.IsCurrentRefreshTarget(Window_body))
+				UI.window.Close();
+			else
+				UI.Open(Window_body);
 		}
 
 

--- a/src/Kerbalism/UI/Science/ExperimentPopup.cs
+++ b/src/Kerbalism/UI/Science/ExperimentPopup.cs
@@ -59,17 +59,18 @@ namespace KERBALISM
 		KsmGuiHeader rndArchiveHeader;
 		ExperimentSubjectList rndArchiveView;
 
-		private static List<long> activePopups = new List<long>();
+		private static Dictionary<long, KsmGuiWindow> activePopups = new Dictionary<long, KsmGuiWindow>();
 		private long popupId;
 
 		public ExperimentPopup(Vessel v, Experiment moduleOrPrefab, uint partId, string partName, ProtoPartModuleSnapshot protoModule = null)
 		{
 			popupId = partId + moduleOrPrefab.experiment_id.GetHashCode();
 
-			if (activePopups.Contains(popupId))
+			if (activePopups.TryGetValue(popupId, out KsmGuiWindow existingWindow))
+			{
+				existingWindow.Close();
 				return;
-
-			activePopups.Add(popupId);
+			}
 
 			if (protoModule == null)
 			{
@@ -92,6 +93,7 @@ namespace KERBALISM
 
 			// create the window
 			window = new KsmGuiWindow(KsmGuiWindow.LayoutGroupType.Vertical, true, KsmGuiStyle.defaultWindowOpacity, true, 0, TextAnchor.UpperLeft, 5f);
+			activePopups.Add(popupId, window);
 			window.OnClose = () => activePopups.Remove(popupId);
 			window.SetLayoutElement(false, false, -1, -1, -1, 150);
 			window.SetUpdateAction(GetData);

--- a/src/Kerbalism/UI/Window.cs
+++ b/src/Kerbalism/UI/Window.cs
@@ -37,6 +37,11 @@ namespace KERBALISM
 			this.refresh = refresh;
 		}
 
+		public bool IsCurrentRefreshTarget(Action<Panel> refresh)
+		{
+			return this.refresh != null && this.refresh.Target == refresh.Target && this.refresh.Method == refresh.Method;
+		}
+
 		public void Close()
 		{
 			// clear input locks


### PR DESCRIPTION
I always found it annoying to have to go hunt for the smol close button in the corner of the window after I'm done with double checking the contents.