### PR TITLE
Do not evaluate Reliability when that feature is disabled

### DIFF
--- a/src/Kerbalism/Database/VesselData.cs
+++ b/src/Kerbalism/Database/VesselData.cs
@@ -913,8 +913,16 @@ namespace KERBALISM
 			crewCapacity = Lib.CrewCapacity(Vessel);
 
 			// malfunction stuff
-			malfunction = Reliability.HasMalfunction(Vessel);
-			critical = Reliability.HasCriticalFailure(Vessel);
+			if (Features.Reliability)
+			{
+				malfunction = Reliability.HasMalfunction(Vessel);
+				critical = Reliability.HasCriticalFailure(Vessel);
+			}
+			else
+			{
+				malfunction = false;
+				critical = false;
+			}
 
 			// communications info
 			CommHandler.UpdateConnection(connection);


### PR DESCRIPTION
ROKerbalism configs do not use the Reliability feature and thus it would be nice to save many hundreds of milliseconds by not running the related code at all.