### PR TITLE
Configure: dropdown UI with conflict highlights

### DIFF
--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -26,6 +26,10 @@ namespace KERBALISM
 
 	public class Configure : PartModule, IPartCostModifier, IPartMassModifier, IModuleInfo, ISpecifics, IConfigurable
 	{
+		// dropdown colour markers for setups already present on the craft
+		const string COLOR_SAME_MODULE = "#ff5555";  // already selected by another slot of this Configure module
+		const string COLOR_SAME_VESSEL = "#ffcc55";  // experiment_id already running on a different part of the vessel
+
 		// config
 		[KSPField] public string title = string.Empty;           // short description (may be a #loc key; display via Localizer.Format)
 		[KSPField] public string configureId = string.Empty;     // stable MM-safe id (no #); use HAS[#configureId[...]] instead of HAS[#title[#loc]]
@@ -50,6 +54,8 @@ namespace KERBALISM
 		bool initialized;                                         // keep track of first configuration
 		CrewSpecs reconfigure_cs;                                 // in-flight reconfiguration crew specs
 		Dictionary<int, int> changes;                             // store 'deferred' changes to avoid problems with unity gui
+		HashSet<int> expanded_slots;                              // per-slot dropdown expansion state
+		HashSet<string> vesselExperimentIds_cache;                // populated each Window_body() refresh; consulted for yellow overlap highlight
 
 		// used to avoid infinite recursion when dealing with symmetry group
 		static bool avoid_inf_recursion;
@@ -101,6 +107,7 @@ namespace KERBALISM
 
 			// store configuration changes
 			changes = new Dictionary<int, int>();
+			expanded_slots = new HashSet<int>();
 		}
 
 
@@ -564,6 +571,11 @@ namespace KERBALISM
 				if (GetInstanceID() == 0) return;
 			}
 
+			// compute the vessel-wide set of running experiment_ids once per refresh; both
+			// the section titles and the expanded dropdown rows consult it for the yellow
+			// "already running elsewhere" highlight.
+			vesselExperimentIds_cache = CollectVesselExperimentIds();
+
 			// for each selected setup
 			for (int selected_i = 0; selected_i < selected.Count; ++selected_i)
 			{
@@ -590,37 +602,173 @@ namespace KERBALISM
 			//       see comment inside generate_details() to understand why this was necessary instead
 			setup.Generate_details(this);
 
-			// render panel title
-			// only allow reconfiguration if there are more setups than slots
-			string setupTitle = Localizer.Format(setup.title);
-			string setupDesc = Localizer.Format(setup.desc);
-			if (unlocked.Count <= selected.Count)
+			// reconfiguration is only available when more setups are unlocked than slots
+			bool canReconfigure = unlocked.Count > selected.Count;
+			bool isExpanded = canReconfigure && expanded_slots.Contains(selected_i);
+			string indicator = canReconfigure ? (isExpanded ? "  ▲" : "  ▼") : string.Empty;
+
+			// colour the section title (the user's current pick) the same way the dropdown
+			// rows are coloured so the warning is visible even when the dropdown is closed.
+			// setup.title/desc may be #loc keys, display via Localizer.Format.
+			string titleColor = SetupHighlightColor(setup, selected_i);
+			string titleText = Lib.Ellipsis(Localizer.Format(setup.title), Styles.ScaleStringLength(70));
+			if (titleColor != null) titleText = "<color=" + titleColor + ">" + titleText + "</color>";
+			titleText += indicator;
+
+			// section title doubles as the dropdown toggle when reconfiguration is allowed.
+			// hide the currently-selected setup's description while expanded — the option
+			// is right there in the list with its own row and the description is just noise.
+			int capturedSlot = selected_i;
+			string sectionDesc = isExpanded ? string.Empty : Localizer.Format(setup.desc);
+			if (canReconfigure)
 			{
-				p.AddSection(Lib.Ellipsis(setupTitle, Styles.ScaleStringLength(70)), setupDesc);
+				p.AddSection(titleText, sectionDesc, click: () => Toggle_expansion(capturedSlot));
 			}
 			else
 			{
-				p.AddSection(Lib.Ellipsis(setupTitle, Styles.ScaleStringLength(70)), setupDesc, () => Change_setup(-1, selected_i, ref setup_i), () => Change_setup(1, selected_i, ref setup_i));
+				p.AddSection(titleText, sectionDesc);
 			}
 
-			// render details
-			foreach (var det in setup.details)
+			if (isExpanded)
 			{
-				p.AddContent(det.label, det.value);
+				// list every unlocked setup as a selectable row instead of the existing details.
+				// keeps the panel from doubling in height and avoids the prev/next click-cycle
+				// where you can't tell how many options remain or end up looping past one you wanted.
+				for (int i = 0; i < unlocked.Count; ++i)
+				{
+					ConfigureSetup option = unlocked[i];
+					// hide the "None 2", "None 3", … padding entries that KerbalismConfig
+					// generates so multi-slot Configure modules can have every slot empty —
+					// they're noise to the user. Always show the currently-selected one even
+					// if it happens to be a padded variant.
+					if (i != setup_i && IsNonePaddingName(option.name)) continue;
+					int capturedIndex = i;
+					bool isCurrent = i == setup_i;
+					string optionTitle = Lib.Ellipsis(Localizer.Format(option.title), Styles.ScaleStringLength(60));
+
+					// don't colour the currently-selected row — that's the user's own
+					// choice and would just be noise. The section title carries the
+					// duplicate-warning colour separately when needed.
+					string optionColor = isCurrent ? null : SetupHighlightColor(option, capturedSlot);
+					if (optionColor != null) optionTitle = "<color=" + optionColor + ">" + optionTitle + "</color>";
+					if (isCurrent) optionTitle = "<b>" + optionTitle + "</b>";
+
+					string marker = isCurrent ? "✓" : string.Empty;
+					p.AddContent(optionTitle, marker, Localizer.Format(option.desc), () => Select_setup(capturedSlot, capturedIndex));
+				}
+			}
+			else
+			{
+				// render details for the selected setup (collapsed view)
+				foreach (var det in setup.details)
+				{
+					p.AddContent(det.label, det.value);
+				}
 			}
 		}
 
-		// utility, used as callback in panel select
-		void Change_setup(int change, int selected_i, ref int setup_i)
+		void Toggle_expansion(int slot)
 		{
+			if (!expanded_slots.Remove(slot)) expanded_slots.Add(slot);
+		}
 
+		// "None", "None 2", "None 3", … are functionally identical empty-slot placeholders
+		// generated by config to satisfy the unique-name-per-slot constraint. Treat the
+		// numbered ones as padding and hide them from the dropdown so users only see one
+		// "None" option.
+		static bool IsNonePaddingName(string name)
+		{
+			if (string.IsNullOrEmpty(name) || !name.StartsWith("None ", StringComparison.Ordinal)) return false;
+			string rest = name.Substring(5).Trim();
+			return int.TryParse(rest, out _);
+		}
 
+		static bool IsNoneName(string name)
+		{
+			return name == "None" || IsNonePaddingName(name);
+		}
 
+		// Returns the highlight colour (red/yellow) that should be applied to a setup
+		// from this Configure module — used for both the section title (the current
+		// selection) and the rows in the expanded dropdown. Empty/"None" setups never
+		// get a colour; same-module duplication beats same-vessel duplication.
+		string SetupHighlightColor(ConfigureSetup setup, int slot)
+		{
+			if (setup == null || IsNoneName(setup.name)) return null;
+			if (IsSetupInOtherSlot(setup.name, slot)) return COLOR_SAME_MODULE;
+			if (vesselExperimentIds_cache != null && SetupOverlapsExperimentIds(setup, vesselExperimentIds_cache)) return COLOR_SAME_VESSEL;
+			return null;
+		}
 
-			if (setup_i + change == unlocked.Count) setup_i = 0;
-			else if (setup_i + change < 0) setup_i = unlocked.Count - 1;
-			else setup_i += change;
-			changes.Add(selected_i, setup_i);
+		// True if `setupName` is already selected by some other slot of THIS Configure
+		// module (i.e., picking it would have the same experiment running twice on the
+		// same part).
+		bool IsSetupInOtherSlot(string setupName, int currentSlot)
+		{
+			for (int i = 0; i < selected.Count; ++i)
+			{
+				if (i == currentSlot) continue;
+				if (selected[i] == setupName) return true;
+			}
+			return false;
+		}
+
+		// Pull the experiment_ids of every Experiment module attached to a SETUP.
+		static IEnumerable<string> SetupExperimentIds(ConfigureSetup setup)
+		{
+			if (setup == null || setup.modules == null) yield break;
+			foreach (ConfigureModule m in setup.modules)
+			{
+				if (m.type == nameof(Experiment) && m.id_field == "experiment_id" && !string.IsNullOrEmpty(m.id_value))
+					yield return m.id_value;
+			}
+		}
+
+		static bool SetupOverlapsExperimentIds(ConfigureSetup setup, HashSet<string> ids)
+		{
+			if (ids.Count == 0) return false;
+			foreach (string id in SetupExperimentIds(setup))
+				if (ids.Contains(id)) return true;
+			return false;
+		}
+
+		// Walk the rest of the vessel (editor or flight) and collect every experiment_id
+		// already selected via some other Configure module. Used to colour dropdown
+		// options yellow when another part on the same craft is already carrying that
+		// experiment.
+		HashSet<string> CollectVesselExperimentIds()
+		{
+			var ids = new HashSet<string>();
+			List<Part> parts = null;
+			if (HighLogic.LoadedSceneIsEditor && EditorLogic.fetch != null && EditorLogic.fetch.ship != null)
+				parts = EditorLogic.fetch.ship.parts;
+			else if (part.vessel != null)
+				parts = part.vessel.parts;
+			if (parts == null) return ids;
+
+			foreach (Part p in parts)
+			{
+				if (p == part) continue;
+				foreach (PartModule pm in p.Modules)
+				{
+					if (!(pm is Configure other) || other.selected == null) continue;
+					foreach (string selectedName in other.selected)
+					{
+						ConfigureSetup s = other.setups?.Find(k => k.name == selectedName);
+						if (s == null) continue;
+						foreach (string id in SetupExperimentIds(s)) ids.Add(id);
+					}
+				}
+			}
+			return ids;
+		}
+
+		// callback for "click a row in the dropdown to select that setup"
+		void Select_setup(int slot, int setup_i)
+		{
+			// use indexer (not Add) so a second click in the same frame doesn't throw
+			changes[slot] = setup_i;
+			expanded_slots.Remove(slot);
 		}
 
 		// access setups

--- a/src/Kerbalism/UI/Panel.cs
+++ b/src/Kerbalism/UI/Panel.cs
@@ -73,7 +73,7 @@ namespace KERBALISM
 			}
 		}
 
-		public void AddSection(string title, string desc = "", Action left = null, Action right = null, Boolean sort = false)
+		public void AddSection(string title, string desc = "", Action left = null, Action right = null, Boolean sort = false, Action click = null)
 		{
 			Section p = new Section
 			{
@@ -81,6 +81,7 @@ namespace KERBALISM
 				desc = desc,
 				left = left,
 				right = right,
+				click = click,
 				sort = sort,
 				needsSort = false,
 				entries = new List<Entry>()
@@ -161,6 +162,7 @@ namespace KERBALISM
 					if (Lib.IsClicked()) callbacks.Add(p.left);
 				}
 				GUILayout.Label(p.title, Styles.section_text);
+				if (p.click != null && Lib.IsClicked()) callbacks.Add(p.click);
 				if (p.right != null)
 				{
 					GUILayout.Label(Textures.right_arrow, Styles.right_icon);
@@ -183,16 +185,32 @@ namespace KERBALISM
 				}
 				foreach (Entry e in p.entries)
 				{
-					GUILayout.BeginHorizontal(Styles.entry_container);
+					// Clickable rows (dropdown items) can hold long titles that need to wrap.
+					// They use the no-fixed-height container with a MinHeight floor matching
+					// the original 16-px row, so single-line rows look identical to the rest
+					// of the panel and only wrapped rows grow taller.
+					bool wrapRow = e.click != null;
+					if (wrapRow)
+						GUILayout.BeginHorizontal(Styles.entry_container_wrap, GUILayout.MinHeight(Styles.entry_container.fixedHeight));
+					else
+						GUILayout.BeginHorizontal(Styles.entry_container);
 					if (e.leftIcon != null)
 					{
 						GUILayout.Label(new GUIContent(e.leftIcon.texture, e.leftIcon.tooltip), Styles.left_icon);
 						if (e.leftIcon.click != null && Lib.IsClicked())
 							callbacks.Add(e.leftIcon.click);
 					}
-					GUILayout.Label(new GUIContent(e.label, e.tooltip), Styles.entry_label, GUILayout.Height(Styles.entry_label.fontSize));
+					if (wrapRow)
+						GUILayout.Label(new GUIContent(e.label, e.tooltip), Styles.entry_label);
+					else
+						GUILayout.Label(new GUIContent(e.label, e.tooltip), Styles.entry_label, GUILayout.Height(Styles.entry_label.fontSize));
+					// detect click on the label too so the whole row is clickable, not just the value column
+					if (e.click != null && Lib.IsClicked()) callbacks.Add(e.click);
 					if (e.hover != null && Lib.IsHover()) callbacks.Add(e.hover);
-					GUILayout.Label(new GUIContent(e.value, e.tooltip), Styles.entry_value, GUILayout.Height(Styles.entry_value.fontSize));
+					if (wrapRow)
+						GUILayout.Label(new GUIContent(e.value, e.tooltip), Styles.entry_value);
+					else
+						GUILayout.Label(new GUIContent(e.value, e.tooltip), Styles.entry_value, GUILayout.Height(Styles.entry_value.fontSize));
 					if (e.click != null && Lib.IsClicked()) callbacks.Add(e.click);
 					if (e.hover != null && Lib.IsHover()) callbacks.Add(e.hover);
 					foreach (Icon i in e.icons)
@@ -201,6 +219,20 @@ namespace KERBALISM
 						if (i.click != null && Lib.IsClicked()) callbacks.Add(i.click);
 					}
 					GUILayout.EndHorizontal();
+
+					// hover highlight: when the cursor is over the row, draw a subtle
+					// translucent box over it so the user can see what they're about to click.
+					if (e.click != null && Event.current.type == EventType.Repaint)
+					{
+						Rect rowRect = GUILayoutUtility.GetLastRect();
+						if (rowRect.Contains(Event.current.mousePosition))
+						{
+							Color prev = GUI.color;
+							GUI.color = new Color(1f, 1f, 1f, 0.12f);
+							GUI.DrawTexture(rowRect, Texture2D.whiteTexture);
+							GUI.color = prev;
+						}
+					}
 				}
 
 				// spacing
@@ -307,6 +339,7 @@ namespace KERBALISM
 			public string desc;
 			public Action left;
 			public Action right;
+			public Action click;
 			public Boolean sort;
 			public Boolean needsSort;
 			public List<Entry> entries;

--- a/src/Kerbalism/UI/Styles.cs
+++ b/src/Kerbalism/UI/Styles.cs
@@ -71,6 +71,15 @@ namespace KERBALISM
 				fixedHeight = ScaleFloat(16.0f)
 			};
 
+			// like entry_container but with no fixedHeight, so rows containing labels that
+			// wrap to multiple lines grow vertically instead of squeezing the wrap into the
+			// gap between adjacent rows. Used by clickable rows (dropdown items) where
+			// long titles are expected.
+			entry_container_wrap = new GUIStyle
+			{
+				stretchWidth = true
+			};
+
 			// entry label text
 			entry_label = new GUIStyle(HighLogic.Skin.label)
 			{
@@ -253,6 +262,7 @@ namespace KERBALISM
 		public static GUIStyle section_container;         // container for a section subtitle
 		public static GUIStyle section_text;              // text for a section subtitle
 		public static GUIStyle entry_container;           // container for a row
+		public static GUIStyle entry_container_wrap;      // row container that allows the row to grow vertically when labels wrap
 		public static GUIStyle entry_label;               // left content for a row
 		public static GUIStyle entry_label_nowrap;        // left content for a row that doesn't wrap
 		public static GUIStyle entry_value;               // right content for a row

--- a/src/Kerbalism/UI/Tooltip.cs
+++ b/src/Kerbalism/UI/Tooltip.cs
@@ -58,10 +58,21 @@ namespace KERBALISM
 			// correct for non-origin screen rect
 			mouse_pos -= new Vector2(screen_rect.xMin, screen_rect.yMin);
 
-			// calculate tooltip size
+			// calculate tooltip size. CalcSize gives the natural width; cap to popup width
+			// so long text wraps inside the window. If wrapping actually kicks in, widen to
+			// the full popup width so the wrapped text uses available horizontal space
+			// instead of stacking up vertically.
 			GUIContent tooltip_content = new GUIContent(tooltip);
 			Vector2 tooltip_size = Styles.tooltip.CalcSize(tooltip_content);
+			float max_width = Math.Max(50f, screen_rect.width - 20f);
+			if (tooltip_size.x > max_width) tooltip_size.x = max_width;
 			tooltip_size.y = Styles.tooltip.CalcHeight(tooltip_content, tooltip_size.x);
+			float single_line_h = Styles.tooltip.CalcHeight(new GUIContent("X"), max_width);
+			if (tooltip_size.y > single_line_h * 1.25f && tooltip_size.x < max_width)
+			{
+				tooltip_size.x = max_width;
+				tooltip_size.y = Styles.tooltip.CalcHeight(tooltip_content, tooltip_size.x);
+			}
 
 			// calculate tooltip position, default vertical position is above the cursor
 			Rect tooltip_rect = new Rect(mouse_pos.x - Mathf.Floor(tooltip_size.x / 2.0f), mouse_pos.y - tooltip_size.y - 10.0f, tooltip_size.x, tooltip_size.y);

--- a/src/Kerbalism/UI/Tooltip.cs
+++ b/src/Kerbalism/UI/Tooltip.cs
@@ -58,21 +58,10 @@ namespace KERBALISM
 			// correct for non-origin screen rect
 			mouse_pos -= new Vector2(screen_rect.xMin, screen_rect.yMin);
 
-			// calculate tooltip size. CalcSize gives the natural width; cap to popup width
-			// so long text wraps inside the window. If wrapping actually kicks in, widen to
-			// the full popup width so the wrapped text uses available horizontal space
-			// instead of stacking up vertically.
+			// calculate tooltip size
 			GUIContent tooltip_content = new GUIContent(tooltip);
 			Vector2 tooltip_size = Styles.tooltip.CalcSize(tooltip_content);
-			float max_width = Math.Max(50f, screen_rect.width - 20f);
-			if (tooltip_size.x > max_width) tooltip_size.x = max_width;
 			tooltip_size.y = Styles.tooltip.CalcHeight(tooltip_content, tooltip_size.x);
-			float single_line_h = Styles.tooltip.CalcHeight(new GUIContent("X"), max_width);
-			if (tooltip_size.y > single_line_h * 1.25f && tooltip_size.x < max_width)
-			{
-				tooltip_size.x = max_width;
-				tooltip_size.y = Styles.tooltip.CalcHeight(tooltip_content, tooltip_size.x);
-			}
 
 			// calculate tooltip position, default vertical position is above the cursor
 			Rect tooltip_rect = new Rect(mouse_pos.x - Mathf.Floor(tooltip_size.x / 2.0f), mouse_pos.y - tooltip_size.y - 10.0f, tooltip_size.x, tooltip_size.y);


### PR DESCRIPTION
## Summary

Replaces the prev/next cycle arrows on each slot of the `Configure` PartModule with an expandable dropdown listing every unlocked setup. The cycle made it impossible to tell how many options were available, and rapid clicks could loop past the one you wanted; the dropdown shows the full list at once and a single click selects.

<img width="491" height="1143" alt="Screenshot 2026-05-21 173834" src="https://github.com/user-attachments/assets/4fc313fc-f67d-4161-97ad-55e0036d77cc" />

<img width="505" height="172" alt="Screenshot 2026-05-21 161620" src="https://github.com/user-attachments/assets/be34095d-0270-4511-baf3-5dcb080d8063" />

Particularly noticeable on RP-1 capsules / probes where the "Configure Experiments" Configure module can hold 4–8 slots out of a dozen unlocked experiments — the cycle was painful, the dropdown is much faster.

## What the user sees

Section title doubles as the expand/collapse toggle (▼ / ▲) when more setups are unlocked than slots. While expanded the selected setup's description is hidden — the option is in the list with its own row and the description would just be noise.

Padding entries (`None 2`, `None 3`, …) that KerbalismConfig generates so multi-slot modules can hold `None` in every slot are hidden from the dropdown; only a single `None` appears.

For experiment-style Configure modules the dropdown rows are colored so duplicates jump out:
- **Red (`#ff5555`)** — the option is already selected by another slot of *this* Configure module (picking it would run the same setup twice on this part).
- **Yellow (`#ffcc55`)** — the option's `Experiment` setup module has an `experiment_id` that's already running on a *different* part of the vessel.

The same colour is applied to the section title, so a problematic current selection stays visible when the dropdown is collapsed.

## Implementation notes

- `Configure.Render_panel` rewritten to call `AddSection` with a `click` callback that toggles per-slot expansion state stored in a new `HashSet<int> expanded_slots`, and to either render the setup's existing detail entries (collapsed) or the new option list (expanded). The detail-rendering code path is unchanged.
- Conflict colours come from `SetupHighlightColor(setup, slot)`. `IsSetupInOtherSlot` walks the local `selected` list; `CollectVesselExperimentIds` walks the editor's `EditorLogic.fetch.ship.parts` (or the live `vessel.parts`) and unions every other `Configure` module's selected setups' `Experiment`-type `id_value`s into a `HashSet<string>`. Computed once per `Window_body()` refresh and stashed in `vesselExperimentIds_cache` for the per-row lookup.
- `Panel.AddSection` gains an optional `click` callback (separate from the existing left/right arrow callbacks) that fires when the section title is clicked. Used to drive the dropdown toggle.
- `Panel.Render` makes the whole row of a clickable entry clickable (label *and* value, not just the value column) and draws a subtle translucent overlay over the row when the cursor is on it.
- `Styles.entry_container_wrap` (new) is a no-`fixedHeight` variant of `entry_container` used by clickable rows so long titles can wrap and grow the row vertically instead of squeezing into the gap between adjacent rows. A `GUILayout.MinHeight` floor matching the original `entry_container.fixedHeight` keeps single-line rows visually identical to before.
- `Tooltip.Render_tooltip` caps the tooltip width to the popup width so long descriptions wrap inside the window instead of clipping off the edges; when wrapping kicks in we widen to the full popup width so the wrap uses available horizontal space.

## Test plan

- [x] Editor: cycle arrows replaced by dropdown; click title to expand/collapse; click an option to select.
- [x] Editor: opening multiple slots and choosing the same setup colours the duplicate red on the other slot.
- [x] Editor: placing the same experiment-bearing setup on two parts colours the second yellow.
- [x] Editor: `None` and `None`-padding entries hidden except for the slot currently holding one.
- [x] Editor: collapsed section title keeps the conflict colour.
- [x] Long titles wrap inside the row without overlapping adjacent rows; non-wrapped rows look identical to before.
- [x] Long tooltips wrap inside the popup window.
- Flight (with `reconfigure = true`): same behaviour as editor. (Default Kerbalism behaviour is editor-only; flight access requires the part config to opt in via `reconfigure = <trait>` and a satisfying kerbal on the vessel.)

Drafted while I shake out any edge cases.