### PR TITLE
Fix invalid Emitter radiation value on NFE rtg-0625

### DIFF
--- a/GameData/KerbalismConfig/Support/NFElectric.cfg
+++ b/GameData/KerbalismConfig/Support/NFElectric.cfg
@@ -539,7 +539,7 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 	MODULE:NEEDS[FeatureRadiation]
 	{
 		name = Emitter
-		radiation = 0.00002222 ~0.031 rad/h
+		radiation = 0.00002222 // ~0.031 rad/h
 	}
 
 	MODULE:NEEDS[ProfileDefault]


### PR DESCRIPTION
Move the ~0.031 rad/h note to a comment so PartLoader can parse the radiation field.