### PR TITLE
Adapt NFElectric support for NFE 2.0 and zKerbalismBridge compatibility

### DIFF
--- a/GameData/KerbalismConfig/Localization/en-us.cfg
+++ b/GameData/KerbalismConfig/Localization/en-us.cfg
@@ -342,6 +342,20 @@ Localization
 		#KERBALISM_Process_ZeroGravityShower = zero gravity shower
 		#KERBALISM_Process_WasherDryer = washer-dryer
 
+		// Near Future Electrical — nuclear recycler (NFElectric.cfg)
+		#KERBALISM_NFE_NuclearProcessor_title = Nuclear Processor
+		#KERBALISM_NFE_UraniumReprocessor_title = Uranium Reprocessor
+		#KERBALISM_NFE_UraniumReprocessor_desc = Reprocess <b>DepletedFuel</b> into <b>EnrichedUranium</b>.
+		#KERBALISM_NFE_XenonExtractor_title = Xenon Extractor
+		#KERBALISM_NFE_XenonExtractor_desc = Extract <b>XenonGas</b> from <b>DepletedFuel</b>.
+		#KERBALISM_NFE_UraniumExtractor_title = Uranium Extractor
+		#KERBALISM_NFE_UraniumExtractor_desc = Refine <b>Ore</b> into <b>EnrichedUranium</b>.
+		#KERBALISM_NFE_UraniniteCentrifuge_title = Uraninite Centrifuge
+		#KERBALISM_NFE_UraniniteCentrifuge_desc = Extract <b>EnrichedUranium</b> out of <b>Uraninite</b>.
+		#KERBALISM_NFE_BreederReactor_title = Breeder Reactor
+		#KERBALISM_NFE_BreederReactor_desc = Extract <b>EnrichedUranium</b> out of <b>DepletedFuel</b>.
+		#KERBALISM_NFE_FissionReactor_title = Fission reactor
+
 		//Radiation Scan
 		#KERBALISM_EXPERIMENT_Radiation_title = Radiation Scan
 		//Experiment results

--- a/GameData/KerbalismConfig/Localization/ru.cfg
+++ b/GameData/KerbalismConfig/Localization/ru.cfg
@@ -342,6 +342,20 @@ Localization
 		#KERBALISM_Process_ZeroGravityShower = душ с нулевой гравитацией
 		#KERBALISM_Process_WasherDryer = стиральная машина-сушилка
 
+		// Near Future Electrical — nuclear recycler (NFElectric.cfg)
+		#KERBALISM_NFE_NuclearProcessor_title = Ядерный переработчик
+		#KERBALISM_NFE_UraniumReprocessor_title = Переработчик урана
+		#KERBALISM_NFE_UraniumReprocessor_desc = Переработать <b>отработавшее топливо</b> в <b>обогащённый уран</b>.
+		#KERBALISM_NFE_XenonExtractor_title = Экстрактор ксенона
+		#KERBALISM_NFE_XenonExtractor_desc = Извлечь <b>ксенон</b> из <b>отработавшего топлива</b>.
+		#KERBALISM_NFE_UraniumExtractor_title = Экстрактор урана
+		#KERBALISM_NFE_UraniumExtractor_desc = Переработать <b>руду</b> в <b>обогащённый уран</b>.
+		#KERBALISM_NFE_UraniniteCentrifuge_title = Центрифуга уранинита
+		#KERBALISM_NFE_UraniniteCentrifuge_desc = Извлечь <b>обогащённый уран</b> из <b>уранинита</b>.
+		#KERBALISM_NFE_BreederReactor_title = Реактор-размножитель
+		#KERBALISM_NFE_BreederReactor_desc = Извлечь <b>обогащённый уран</b> из <b>отработавшего топлива</b>.
+		#KERBALISM_NFE_FissionReactor_title = Ядерный реактор
+
 		//Radiation Scan
 		#KERBALISM_EXPERIMENT_Radiation_title = Радиационное сканирование
 		//Experiment results

--- a/GameData/KerbalismConfig/Localization/zh-cn.cfg
+++ b/GameData/KerbalismConfig/Localization/zh-cn.cfg
@@ -342,6 +342,20 @@ Localization
 		#KERBALISM_Process_ZeroGravityShower = 零重力浴室
 		#KERBALISM_Process_WasherDryer = 洗衣烘干机
 
+		// Near Future Electrical — 核燃料再处理器 (NFElectric.cfg)
+		#KERBALISM_NFE_NuclearProcessor_title = 核燃料处理器
+		#KERBALISM_NFE_UraniumReprocessor_title = 铀燃料再处理器
+		#KERBALISM_NFE_UraniumReprocessor_desc = 将<b>乏燃料</b>再处理为<b>浓缩铀</b>.
+		#KERBALISM_NFE_XenonExtractor_title = 氙气提取器
+		#KERBALISM_NFE_XenonExtractor_desc = 从<b>乏燃料</b>中提取<b>氙气</b>.
+		#KERBALISM_NFE_UraniumExtractor_title = 铀提取器
+		#KERBALISM_NFE_UraniumExtractor_desc = 将<b>矿石</b>精炼为<b>浓缩铀</b>.
+		#KERBALISM_NFE_UraniniteCentrifuge_title = 铀矿离心机
+		#KERBALISM_NFE_UraniniteCentrifuge_desc = 从<b>铀矿</b>中提取<b>浓缩铀</b>.
+		#KERBALISM_NFE_BreederReactor_title = 增殖反应堆
+		#KERBALISM_NFE_BreederReactor_desc = 从<b>乏燃料</b>中提取<b>浓缩铀</b>.
+		#KERBALISM_NFE_FissionReactor_title = 裂变反应堆
+
 		//Radiation Scan
 		#KERBALISM_EXPERIMENT_Radiation_title = 辐射扫描
 		//Experiment results

--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -1341,13 +1341,6 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 
   MODULE
   {
-    name = PlannerController
-    title = #KERBALISM_FuelCell_title//Fuel Cell
-    considered = true
-  }
-
-  MODULE
-  {
     name = ProcessController
     resource = _FuelCell
     title = #KERBALISM_H2O2FuelCell_title//H2+O2 fuel cell
@@ -1420,13 +1413,6 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 
   MODULE
   {
-    name = PlannerController
-    title = #KERBALISM_FuelCell_title//Fuel Cell
-    considered = true
-  }
-
-  MODULE
-  {
     name = ProcessController
     resource = _FuelCell
     title = #KERBALISM_H2O2FuelCell_title//H2+O2 fuel cell
@@ -1486,6 +1472,12 @@ PARTUPGRADE:NEEDS[ProfileDefault]
     extra_cost = 1.0
     extra_mass = 0.5
   }
+}
+
+// Planner.cfg adds PlannerController to ModuleResourceConverter parts before they are replaced above.
+@PART[FuelCell|FuelCellArray]:NEEDS[ProfileDefault]:AFTER[KerbalismDefault]
+{
+  !MODULE[PlannerController],* {}
 }
 
 

--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -309,6 +309,7 @@ Profile
     modifier = _RTG
     input = _RTG@0.000000001888 // 28.8 kerbin-year half-life
     output = ElectricCharge@1.0
+    dump = ElectricCharge
   }
 
   Process
@@ -1335,7 +1336,15 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 @PART[FuelCell]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
 {
   !MODULE[ModuleResourceConverter] {}
+  !MODULE[PlannerController],* {}
   !RESOURCE[ElectricCharge] {}
+
+  MODULE
+  {
+    name = PlannerController
+    title = #KERBALISM_FuelCell_title//Fuel Cell
+    considered = true
+  }
 
   MODULE
   {
@@ -1406,7 +1415,15 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 @PART[FuelCellArray]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
 {
   !MODULE[ModuleResourceConverter] {}
+  !MODULE[PlannerController],* {}
   !RESOURCE[ElectricCharge] {}
+
+  MODULE
+  {
+    name = PlannerController
+    title = #KERBALISM_FuelCell_title//Fuel Cell
+    considered = true
+  }
 
   MODULE
   {

--- a/GameData/KerbalismConfig/Support/NFElectric.cfg
+++ b/GameData/KerbalismConfig/Support/NFElectric.cfg
@@ -23,36 +23,53 @@ Profile
 		refill_message = $VESSEL Enriched Uranium storage refilled@<i>Nuclear Reactors back online</i>
 	}
 
+	// NFE recycler converters @ capacity 1, scaled 0.1× for realism (dedicated recycler-25-1 uses capacity 10 to match stock NFE)
+	// https://github.com/post-kerbin-mining-corporation/NearFutureElectrical/blob/master/GameData/NearFutureElectrical/Parts/Resources/nfe-nuclear-recycler-25-1.cfg
 	Process
 	{
-		name = uraninite centrifuge
-		modifier = _Centrifuge
-		input = ElectricCharge@4.48
-		input = Uraninite@0.0000408
-		output = EnrichedUranium@0.00000825
-		output = Ore@0.00002832
-		dump_valve = Ore
-	}
-
-	Process
-	{
-		name = breeder reactor
-		modifier = _Breeder
-		input = DepletedFuel@0.00000218
-		output = ElectricCharge@5.039146
-		output = EnrichedUranium@0.000000772
+		name = nfe depleted fuel reprocess
+		title = #KERBALISM_NFE_UraniumReprocessor_title
+		modifier = _NfeDepletedReprocess
+		input = DepletedFuel@0.01
+		input = ElectricCharge@20
+		output = EnrichedUranium@0.005
 		dump_valve = EnrichedUranium
 	}
 
 	Process
 	{
+		name = nfe xenon extract
+		title = #KERBALISM_NFE_XenonExtractor_title
+		modifier = _NfeXeExtract
+		input = DepletedFuel@0.001
+		input = ElectricCharge@10
+		output = XenonGas@0.025
+		dump_valve = XenonGas
+	}
+
+	Process
+	{
+		name = nfe ore refine
+		title = #KERBALISM_NFE_UraniumExtractor_title
+		modifier = _NfeOreRefine
+		input = Ore@0.1
+		input = ElectricCharge@20
+		output = EnrichedUranium@0.0001
+		dump_valve = EnrichedUranium
+	}
+
+	// NFE 2.0+ fission: 1:1 EnrichedUranium → DepletedFuel (no inline Xenon; use nfe xenon extract).
+	// Layer A + SystemHeat: KerbalismBridge zKerbalismProcess/NFE_FissionReactor_ProcessControllerSystemHeat.cfg
+	Process
+	{
 		name = fission reactor
+		title = #KERBALISM_NFE_FissionReactor_title
 		modifier = _Nukereactor
 		input = EnrichedUranium@0.000000046875
-		output = DepletedFuel@0.00000003125
-		output = XenonGas@0.000000015625
+		output = DepletedFuel@0.000000046875
 		output = ElectricCharge@10
-		dump_valve = XenonGas&DepletedFuel,XenonGas,DepletedFuel
+		// Default to dumping ElectricCharge so Planner reports generator capacity even when batteries are full.
+		dump_valve = ElectricCharge,DepletedFuel,ElectricCharge&DepletedFuel
 	}
 }
 
@@ -130,15 +147,16 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	{
 		name = ProcessController
 		resource = _Nukereactor
-		title = Fission reactor
+		title = #KERBALISM_NFE_FissionReactor_title
 		capacity = 1
+		valve_i = 1
 	}
 
 	MODULE:NEEDS[FeatureReliability]
 	{
 		name = Reliability
 		type = ProcessController
-		title = Fission Reactor
+		title = #KERBALISM_NFE_FissionReactor_title
 		redundancy = Power Generation
 		repair = Engineer
 		mtbf = 36288000
@@ -147,46 +165,62 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	}
 }
 
-@PART[nfe-reactor-0625]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+// NFE 2.0+ reactor names (capacity ×10 EC/s base process); legacy names kept for old craft files.
+@PART[nfe-reactor-tiny-1]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 6.0}  // 60 EC
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 0.5}  // 5 EC
 }
 
-@PART[nfe-reactor-125]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+@PART[nfe-reactor-tiny-2]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 40.0}  // 400 EC
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 1.5}  // 15 EC
+}
+
+@PART[nfe-reactor-0625-1,nfe-reactor-0625]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+{
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 6}  // 60 EC
+}
+
+@PART[nfe-reactor-125-1,nfe-reactor-125]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+{
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 20}  // 200 EC
+}
+
+@PART[nfe-reactor-1875-1]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+{
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 62.5}  // 625 EC
 }
 
 @PART[nfe-reactor-25-1]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 200.0}  // 2000 EC
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 200}  // 2000 EC
 }
 
 @PART[nfe-reactor-25-2]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 300.0}  // 3000 EC
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 300}  // 3000 EC
 }
 
-@PART[nfe-reactor-375]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+@PART[nfe-reactor-375-1,nfe-reactor-375]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 200.0}  // 2000 EC
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 500}  // 5000 EC
 }
 
 @PART[nfe-reactor-375-2]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
-	@MODULE[ProcessController]:HAS[#title[Fission?reactor]]{@capacity *= 600.0}  // 6000 EC
+	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 600}  // 6000 EC
 }
 
 // ============================================================================
-// Add Uraninite centrifuge and Breeder reactor to ISRU chemical plants and the NearFutureElectrical Nuclear Recycler
+// Add NFE nuclear recycler processes to ISRU chemical plants
 // ============================================================================
-@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:HAS[@MODULE[Configure]:HAS[!SETUP[Uraninite?Centrifuge]]]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:HAS[@MODULE[Configure]:HAS[!SETUP[Uranium?Reprocessor]]]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
 	MODULE
 	{
 		name = ProcessController
-		resource = _Centrifuge
-		title = Uraninite centrifuge
+		resource = _NfeDepletedReprocess
+		title = #KERBALISM_NFE_UraniumReprocessor_title
 		capacity = 1
 	}
 
@@ -194,27 +228,27 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	{
 		SETUP
 		{
-			name = Uraninite Centrifuge
-			desc = Extract <b>EnrichedUranium</b> out of <b>Uraninite</b>.
+			name = #KERBALISM_NFE_UraniumReprocessor_title
+			desc = #KERBALISM_NFE_UraniumReprocessor_desc
 			tech = advScienceTech
 
 			MODULE
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _Centrifuge
+				id_value = _NfeDepletedReprocess
 			}
 		}
 	}
 }
 
-@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:HAS[@MODULE[Configure]:HAS[!SETUP[Breeder?Reactor]]]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:HAS[@MODULE[Configure]:HAS[!SETUP[Xenon?Extractor]]]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
 	MODULE
 	{
 		name = ProcessController
-		resource = _Breeder
-		title = Breeder reactor
+		resource = _NfeXeExtract
+		title = #KERBALISM_NFE_XenonExtractor_title
 		capacity = 1
 	}
 
@@ -222,25 +256,81 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	{
 		SETUP
 		{
-			name = Breeder Reactor
-			desc = Extract <b>EnrichedUranium</b> out of <b>DepletedFuel</b>.
-			tech = experimentalScience
+			name = #KERBALISM_NFE_XenonExtractor_title
+			desc = #KERBALISM_NFE_XenonExtractor_desc
+			tech = advScienceTech
 
 			MODULE
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _Breeder
+				id_value = _NfeXeExtract
 			}
 		}
 	}
 }
 
-@PART[nfe-nuclear-recycler-25]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:HAS[@MODULE[Configure]:HAS[!SETUP[Uranium?Extractor]]]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
+	MODULE
+	{
+		name = ProcessController
+		resource = _NfeOreRefine
+		title = #KERBALISM_NFE_UraniumExtractor_title
+		capacity = 1
+	}
+
+	@MODULE[Configure]
+	{
+		SETUP
+		{
+			name = #KERBALISM_NFE_UraniumExtractor_title
+			desc = #KERBALISM_NFE_UraniumExtractor_desc
+			tech = advScienceTech
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _NfeOreRefine
+			}
+		}
+	}
+}
+
+@PART[kerbalism-chemicalplant]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+{
+	@MODULE[ProcessController]:HAS[#resource[_NfeDepletedReprocess]]{@capacity = 2.0}
+	@MODULE[ProcessController]:HAS[#resource[_NfeXeExtract]]{@capacity = 2.0}
+	@MODULE[ProcessController]:HAS[#resource[_NfeOreRefine]]{@capacity = 2.0}
+}
+
+@PART[MiniISRU]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+{
+	@MODULE[ProcessController]:HAS[#resource[_NfeDepletedReprocess]]{@capacity = 36}
+	@MODULE[ProcessController]:HAS[#resource[_NfeXeExtract]]{@capacity = 36}
+	@MODULE[ProcessController]:HAS[#resource[_NfeOreRefine]]{@capacity = 36}
+}
+
+@PART[ISRU]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+{
+	@MODULE[ProcessController]:HAS[#resource[_NfeDepletedReprocess]]{@capacity = 90}
+	@MODULE[ProcessController]:HAS[#resource[_NfeXeExtract]]{@capacity = 90}
+	@MODULE[ProcessController]:HAS[#resource[_NfeOreRefine]]{@capacity = 90}
+}
+
+// ============================================================================
+// NFE 2.0+ nfe-nuclear-recycler-25-1 — Layer A (dedicated nuclear recycler)
+// Replaces native ModuleSystemHeatConverter with Configure + ProcessController.
+// SystemHeat: KerbalismBridge zKerbalismProcess/NFERecycler_ProcessControllerSystemHeat.cfg
+// ============================================================================
+@PART[nfe-nuclear-recycler-25-1]:NEEDS[NearFutureElectrical,ProfileDefault,Kerbalism]:AFTER[NearFutureElectrical]
+{
+	!MODULE[ModuleSystemHeatConverter],* {}
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay],* {}
 	!MODULE[ModuleCoreHeat],* {}
+	!MODULE[SystemHeatConverterKerbalismUpdater],* {}
 
 	MODULE:NEEDS[FeatureRadiation]
 	{
@@ -251,50 +341,72 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	MODULE
 	{
 		name = ProcessController
-		resource = _Centrifuge
-		title = Uraninite centrifuge
+		resource = _NfeDepletedReprocess
+		title = #KERBALISM_NFE_UraniumReprocessor_title
 		capacity = 1
 	}
 
 	MODULE
 	{
 		name = ProcessController
-		resource = _Breeder
-		title = Breeder reactor
+		resource = _NfeXeExtract
+		title = #KERBALISM_NFE_XenonExtractor_title
+		capacity = 1
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _NfeOreRefine
+		title = #KERBALISM_NFE_UraniumExtractor_title
 		capacity = 1
 	}
 
 	MODULE
 	{
 		name = Configure
-		title = Nuclear Processor
-		slots = 2
+		title = #KERBALISM_NFE_NuclearProcessor_title
+		slots = 3
 
 		SETUP
 		{
-			name = Uraninite Centrifuge
-			desc = Extract <b>EnrichedUranium</b> out of <b>Uraninite</b>.
+			name = #KERBALISM_NFE_UraniumReprocessor_title
+			desc = #KERBALISM_NFE_UraniumReprocessor_desc
 			tech = advScienceTech
 
 			MODULE
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _Centrifuge
+				id_value = _NfeDepletedReprocess
 			}
 		}
 
 		SETUP
 		{
-			name = Breeder Reactor
-			desc = Extract <b>EnrichedUranium</b> out of <b>DepletedFuel</b>.
-			tech = experimentalScience
+			name = #KERBALISM_NFE_XenonExtractor_title
+			desc = #KERBALISM_NFE_XenonExtractor_desc
+			tech = advScienceTech
 
 			MODULE
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _Breeder
+				id_value = _NfeXeExtract
+			}
+		}
+
+		SETUP
+		{
+			name = #KERBALISM_NFE_UraniumExtractor_title
+			desc = #KERBALISM_NFE_UraniumExtractor_desc
+			tech = advScienceTech
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _NfeOreRefine
 			}
 		}
 	}
@@ -303,7 +415,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	{
 		name = Reliability
 		type = ProcessController
-		title = Nuclear Processor
+		title = #KERBALISM_NFE_NuclearProcessor_title
 		redundancy = Power Generation
 		repair = Engineer
 		mtbf = 36288000
@@ -312,29 +424,12 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	}
 }
 
-@PART[kerbalism-chemicalplant]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
+@PART[nfe-nuclear-recycler-25-1]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
-	@MODULE[ProcessController]:HAS[#title[Uraninite*]]{@capacity = 2.0}
-	@MODULE[ProcessController]:HAS[#title[Breeder*]]{@capacity = 2.0}
-}
-
-@PART[MiniISRU]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Uraninite*]]{@capacity = 36}
-	@MODULE[ProcessController]:HAS[#title[Breeder*]]{@capacity = 36}
-}
-
-@PART[ISRU]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	@MODULE[ProcessController]:HAS[#title[Uraninite*]]{@capacity = 90}
-	@MODULE[ProcessController]:HAS[#title[Breeder*]]{@capacity = 90}
-}
-
-@PART[nfe-nuclear-recycler-25]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
-{
-	// Better efficiency than using a generic ISRU Chemical Plant for processing
-	@MODULE[ProcessController]:HAS[#title[Uraninite*]]{@capacity = 110}
-	@MODULE[ProcessController]:HAS[#title[Breeder*]]{@capacity = 110}
+	// Profile rates are 0.1× stock NFE; capacity 10 restores recycler throughput
+	@MODULE[ProcessController]:HAS[#resource[_NfeDepletedReprocess]]{@capacity = 10}
+	@MODULE[ProcessController]:HAS[#resource[_NfeXeExtract]]{@capacity = 10}
+	@MODULE[ProcessController]:HAS[#resource[_NfeOreRefine]]{@capacity = 10}
 }
 
 // ============================================================================
@@ -418,6 +513,27 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 	isVisible = false
 }
 
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
+{
+	name = _NfeDepletedReprocess
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
+{
+	name = _NfeXeExtract
+	density = 0.0
+	isVisible = false
+}
+
+RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
+{
+	name = _NfeOreRefine
+	density = 0.0
+	isVisible = false
+}
+
 @RESOURCE_DEFINITION[DepletedFuel]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
 	@isTweakable = true
@@ -444,6 +560,7 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
+  !MODULE[PlannerController]:HAS[#title[generator]],* {}
 }
 
 @PART[nfe-rtg-gphs-1]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
@@ -466,6 +583,7 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
+  !MODULE[PlannerController]:HAS[#title[generator]],* {}
 }
 
 @PART[nfe-rtg-mmrtg-1]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
@@ -488,6 +606,7 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
+  !MODULE[PlannerController]:HAS[#title[generator]],* {}
 }
 
 @PART[nfe-rtg-snap27-1]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
@@ -510,6 +629,7 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
+  !MODULE[PlannerController]:HAS[#title[generator]],* {}
 }
 
 @PART[utility-pod-25]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
@@ -532,6 +652,7 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
+  !MODULE[PlannerController]:HAS[#title[generator]],* {}
 }
 
 @PART[rtg-0625]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
@@ -554,4 +675,5 @@ RESOURCE_DEFINITION:NEEDS[NearFutureElectrical,ProfileDefault]
 
 	!MODULE[ModuleGenerator] {}
 	!MODULE[ModuleCoreHeat] {}
+	!MODULE[PlannerController]:HAS[#title[generator]],* {}
 }

--- a/GameData/KerbalismConfig/Support/NFElectric.cfg
+++ b/GameData/KerbalismConfig/Support/NFElectric.cfg
@@ -136,6 +136,7 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 	!MODULE[FissionReactor],* {}
 	!MODULE[ModuleCoreHeatNoCatchup],* {}
 	!MODULE[ModuleUpdateOverride],* {}
+	!MODULE[PlannerController],* {}
 
 	MODULE:NEEDS[FeatureRadiation]
 	{
@@ -209,6 +210,11 @@ B9_TANK_TYPE:NEEDS[B9PartSwitch]
 @PART[nfe-reactor-375-2]:NEEDS[NearFutureElectrical,ProfileDefault]:AFTER[NearFutureElectrical]
 {
 	@MODULE[ProcessController]:HAS[#resource[_Nukereactor]]{@capacity = 600}  // 6000 EC
+}
+
+@PART[nfe-reactor-*]:NEEDS[NearFutureElectrical,ProfileDefault]:FINAL
+{
+	!MODULE[PlannerController],* {}
 }
 
 // ============================================================================

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -77,12 +77,6 @@ namespace KERBALISM.Planner
 			// get amount and capacity from parts
 			foreach (Part p in parts)
 			{
-				// PlannerController also gates Kerbalism pseudo-resources (e.g. _FuelCell)
-				// that drive profile process modifiers, not only stock PartModules below.
-				PlannerController ctrl = p.FindModuleImplementing<PlannerController>();
-				if (ctrl != null && !ctrl.considered)
-					continue;
-
 				for (int i = 0; i < p.Resources.Count; ++i)
 				{
 					Process_part(p, p.Resources[i].resourceName);

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -77,6 +77,12 @@ namespace KERBALISM.Planner
 			// get amount and capacity from parts
 			foreach (Part p in parts)
 			{
+				// PlannerController also gates Kerbalism pseudo-resources (e.g. _FuelCell)
+				// that drive profile process modifiers, not only stock PartModules below.
+				PlannerController ctrl = p.FindModuleImplementing<PlannerController>();
+				if (ctrl != null && !ctrl.considered)
+					continue;
+
 				for (int i = 0; i < p.Resources.Count; ++i)
 				{
 					Process_part(p, p.Resources[i].resourceName);


### PR DESCRIPTION
Updates Kerbalism's Near Future Electrical integration for **NFE 2.0** and aligns with **zKerbalismBridge** Layer A + SystemHeat patches.
- **Nuclear recycler processes**: Replaces legacy `_Centrifuge` / `_Breeder` with NFE 2.0–aligned processes (`_NfeDepletedReprocess`, `_NfeXeExtract`, `_NfeOreRefine`) on chemical plants, ISRU, and `nfe-nuclear-recycler-25-1` (3-slot Configure).
- **Fission reactors**: 1:1 EnrichedUranium → DepletedFuel (no inline Xenon); capacity patches for NFE 2.0 reactor part names, with legacy names kept for old crafts.
- **Planner fixes**: Strip redundant `PlannerController` from stock fuel cells, NFE fission reactors, and NFE RTGs so power is not double-counted; default fission `dump_valve` to `ElectricCharge` so Planner reports generator capacity when batteries are full; RTG process gets `dump = ElectricCharge`.
- **Localization**: Add en-us / ru / zh-cn strings for NFE nuclear processor UI.

