### PR TITLE
Prioritize drive already containing subject when selecting drive

### DIFF
--- a/src/Kerbalism/Science/Drive.cs
+++ b/src/Kerbalism/Science/Drive.cs
@@ -648,6 +648,11 @@ namespace KERBALISM
 				double available = drive.SampleCapacityAvailable(subject);
 				if (size > double.Epsilon && available < size)
 					continue;
+				if (drive.samples.ContainsKey(subject)) // Use the first drive that contains a matching subject, if one exists
+				{
+					result = drive;
+					break;
+				}
 				if (available > result.SampleCapacityAvailable(subject))
 					result = drive;
 			}


### PR DESCRIPTION
For issue https://github.com/Kerbalism/Kerbalism/issues/1047

If a drive has enough available space, and already contains the subject, load the experiment into that one, instead of the drive with the largest amount of free space.

Tested with the KH-9 satellite from my BDB support fork. This contains a long term experiment that generates a sample for every biome in space, and contains 5 sample supporting hard drives. Previously the same sample would be spread out across the different drives, wasting slots. After the change I observed 21/22 slots full, and an existing sample slot updating instead of taking up the last slot.
https://github.com/SerShrubert/Kerbalism/blob/dev/BDBScienceUpdate/GameData/KerbalismConfig/Support/Bluedog.cfg