### PR TITLE
Allow supply and configure to add to existing resources

### DIFF
--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -2612,7 +2612,7 @@ namespace KERBALISM
 		/// <summary> Adds the specified resource amount and capacity to a part,
 		/// the resource is created if it doesn't already exist </summary>
 		///<summary>poached from https://github.com/blowfishpro/B9PartSwitch/blob/master/B9PartSwitch/Extensions/PartExtensions.cs
-		public static PartResource AddResource(Part p, string res_name, double amount, double capacity, bool append_amount = false)
+		public static PartResource AddResource(Part p, string res_name, double amount, double capacity, bool addToExisting = false)
 		{
 			var reslib = PartResourceLibrary.Instance.resourceDefinitions;
 			// if the resource is not known, log a warning and do nothing
@@ -2652,25 +2652,21 @@ namespace KERBALISM
 			}
 			else
 			{
-				if (append_amount) // Add to existing resource instead of overriding it
+				PartResource simulationResource = p.SimulationResources?[resourceDefinition.name];
+
+				if (addToExisting)
 				{
 					resource.maxAmount += capacity;
-
-					PartResource simulationResource = p.SimulationResources?[resourceDefinition.name];
-					if (simulationResource != null) simulationResource.maxAmount += capacity;
-
-					resource.amount += amount;
+					resource.amount = Math.Min(resource.amount + amount, resource.maxAmount);
 				}
-				else // Default behavior
+				else
 				{
 					resource.maxAmount = capacity;
-
-					PartResource simulationResource = p.SimulationResources?[resourceDefinition.name];
-					if (simulationResource != null) simulationResource.maxAmount = capacity;
-
 					resource.amount = amount;
 				}
 
+				if (simulationResource != null)
+					simulationResource.maxAmount = resource.maxAmount;
 			}
 
 			return resource;
@@ -2686,12 +2682,8 @@ namespace KERBALISM
 			if (resource == null || resource.info == null)
 				return;
 
-			// reduce amount and capacity
-			resource.amount -= amount;
+			// reduce capacity
 			resource.maxAmount -= capacity;
-
-			// clamp amount to capacity just in case
-			resource.amount = Math.Min(resource.amount, resource.maxAmount);
 
 			// if the resource is empty
 			if (resource.maxAmount <= 0.005) //< deal with precision issues
@@ -2700,6 +2692,17 @@ namespace KERBALISM
 				p.SimulationResources?.dict.Remove(resource.info.id);
 
 				GameEvents.onPartResourceListChange.Fire(p);
+				return;
+			}
+
+			// reduce amount and clamp it to the remaining capacity
+			resource.amount = Math.Max(0.0, Math.Min(resource.amount - amount, resource.maxAmount));
+
+			PartResource simulationResource = p.SimulationResources?[res_name];
+			if (simulationResource != null)
+			{
+				simulationResource.maxAmount = resource.maxAmount;
+				simulationResource.amount = Math.Max(0.0, Math.Min(simulationResource.amount, simulationResource.maxAmount));
 			}
 		}
 

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -2612,7 +2612,7 @@ namespace KERBALISM
 		/// <summary> Adds the specified resource amount and capacity to a part,
 		/// the resource is created if it doesn't already exist </summary>
 		///<summary>poached from https://github.com/blowfishpro/B9PartSwitch/blob/master/B9PartSwitch/Extensions/PartExtensions.cs
-		public static PartResource AddResource(Part p, string res_name, double amount, double capacity)
+		public static PartResource AddResource(Part p, string res_name, double amount, double capacity, bool append_amount = false)
 		{
 			var reslib = PartResourceLibrary.Instance.resourceDefinitions;
 			// if the resource is not known, log a warning and do nothing
@@ -2652,12 +2652,25 @@ namespace KERBALISM
 			}
 			else
 			{
-				resource.maxAmount = capacity;
+				if (append_amount) // Add to existing resource instead of overriding it
+				{
+					resource.maxAmount += capacity;
 
-				PartResource simulationResource = p.SimulationResources?[resourceDefinition.name];
-				if (simulationResource != null) simulationResource.maxAmount = capacity;
+					PartResource simulationResource = p.SimulationResources?[resourceDefinition.name];
+					if (simulationResource != null) simulationResource.maxAmount += capacity;
 
-				resource.amount = amount;
+					resource.amount += amount;
+				}
+				else // Default behavior
+				{
+					resource.maxAmount = capacity;
+
+					PartResource simulationResource = p.SimulationResources?[resourceDefinition.name];
+					if (simulationResource != null) simulationResource.maxAmount = capacity;
+
+					resource.amount = amount;
+				}
+
 			}
 
 			return resource;

--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -281,7 +281,7 @@ namespace KERBALISM
 
 							// add the resources
 							// - in flight, do not add amount
-							Lib.AddResource(part, cr.name, Lib.IsFlight() ? 0.0 : amount * count, capacity * count);
+							Lib.AddResource(part, cr.name, Lib.IsFlight() ? 0.0 : amount * count, capacity * count, true);
 						}
 					}
 

--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -270,7 +270,7 @@ namespace KERBALISM
 
 							// remove the resources
 							prev_count = prev_count == 0 ? 1 : prev_count;
-							Lib.RemoveResource(part, cr.name, amount * prev_count, capacity * prev_count);
+							Lib.RemoveResource(part, cr.name, 0.0, capacity * prev_count);
 						}
 
 						// if selected

--- a/src/Kerbalism/Profile/Supply.cs
+++ b/src/Kerbalism/Profile/Supply.cs
@@ -98,7 +98,7 @@ namespace KERBALISM
 			double quantity = on_pod * (double)prefab.CrewCapacity;
 
 			// add the resource
-			Lib.AddResource(prefab, resource, empty ? 0.0 : quantity, quantity);
+			Lib.AddResource(prefab, resource, empty ? 0.0 : quantity, quantity, true);
 
 			// add resource cost
 			p.cost += (float)(Lib.GetDefinition(resource).unitCost * (empty ? 0.0 : quantity));


### PR DESCRIPTION
For https://github.com/Kerbalism/Kerbalism/issues/1051
Add optional parameter to Lib.AddResource that will allow existing resources to be added to, instead of overwritten. 

This option will be used in two cases:
1. When adding a resource defined in supply in SetupPod (Not on_rescue). This will be added to the existing resources on that part, so that life support resources can be configured on a per part basis. A 3 kerbal command pod could be configured to contain an extra 10 days of food for example. This adds some parity to the life support patches used by other mods for other life support systems.
2. Resources defined in the setup for a configure module. This does not apply to pseudoresources, only for the RESOURCE nodes inside a SETUP.

VAB testing:
Two 3 kerbal command pods with different amounts of food
<img width="558" height="463" alt="Capture4" src="https://github.com/user-attachments/assets/35bf67af-ac4d-4ea8-babe-312f56ede2c2" />

A configure option that adds additional amount of EC capacity. The extra capacity is correctly removed when switching to a different option

<img width="628" height="274" alt="Capture1" src="https://github.com/user-attachments/assets/7e3389ee-ba88-4051-956b-850417028585" />
<img width="661" height="218" alt="Capture2" src="https://github.com/user-attachments/assets/879d5bc4-11b2-4a9e-9573-5062c6553cd0" />
<img width="625" height="291" alt="Capture3" src="https://github.com/user-attachments/assets/62dc986e-f575-4c9a-9164-909628d89869" />

I originally tested this using += in all cases, but this caused some issues with habitat and pseudoresources, mostly when undocking 2 command pods and kerbal EVA. The default behavior is retained for all other cases.