### PR TITLE
Make live KSP GameData deploy opt-in via Kerbalism_DeployToKsp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,12 +304,13 @@ Kerbalism uses [KSPBuildTools](https://github.com/KSPModdingLibs/KSPBuildTools) 
 1. Install the [.NET SDK](https://dotnet.microsoft.com/download) (8.x or later).
 2. Copy `Kerbalism.props.user.example` to `Kerbalism.props.user` in the repository root.
 3. Edit `Kerbalism.props.user` and set `KSPBT_GameRoot` to your KSP 1.12 install path.
-4. Install [Harmony2](https://github.com/KSPModdingLibs/HarmonyKSP) (and other dependencies) into that KSP install via CKAN or manually.
-5. Build from the repository root:
+4. Optionally set `Kerbalism_DeployToKsp` to `true` if you want the build to copy `GameData/Kerbalism` and `GameData/KerbalismConfig` into that install (off by default).
+5. Install [Harmony2](https://github.com/KSPModdingLibs/HarmonyKSP) (and other dependencies) into that KSP install via CKAN or manually.
+6. Build from the repository root:
 
        dotnet build -c Release src/Kerbalism/Kerbalism.csproj
 
-The compiled `Kerbalism.dll` is written to `GameData/Kerbalism/`. When `KSPBT_GameRoot` is set, the build also deploys `GameData/Kerbalism` and `GameData/KerbalismConfig` to your KSP install.
+The compiled `Kerbalism.dll` is written to `GameData/Kerbalism/`. Live-install deployment only runs when `Kerbalism_DeployToKsp` is `true`.
 
 Open `Kerbalism.slnx` in Visual Studio or Rider for IDE debugging.
 

--- a/Kerbalism.props.user.example
+++ b/Kerbalism.props.user.example
@@ -3,5 +3,7 @@
   <PropertyGroup>
     <!-- Copy to Kerbalism.props.user and set your local KSP install path. -->
     <KSPBT_GameRoot>C:\Program Files (x86)\Steam\steamapps\common\Kerbal Space Program</KSPBT_GameRoot>
+    <!-- Optional: also copy GameData/Kerbalism + KerbalismConfig into that install on build. -->
+    <Kerbalism_DeployToKsp>true</Kerbalism_DeployToKsp>
   </PropertyGroup>
 </Project>

--- a/src/Kerbalism/Kerbalism.csproj
+++ b/src/Kerbalism/Kerbalism.csproj
@@ -12,6 +12,8 @@
 
     <KSPBT_ModRoot>$(ProjectRootDir)GameData\Kerbalism</KSPBT_ModRoot>
     <KSPBT_ModPluginFolder>.</KSPBT_ModPluginFolder>
+    <!-- Opt-in: copy GameData to the live KSP install. Set in Kerbalism.props.user. -->
+    <Kerbalism_DeployToKsp Condition=" '$(Kerbalism_DeployToKsp)' == '' ">false</Kerbalism_DeployToKsp>
 
     <LangVersion>latest</LangVersion>
     <DebugType>portable</DebugType>
@@ -58,7 +60,8 @@
     </None>
   </ItemGroup>
 
-  <Target Name="DeployGameDataToKsp" AfterTargets="KSPBT_CopyDLLsToPluginFolder" Condition=" '$(KSPBT_GameRoot)' != '' ">
+  <Target Name="DeployGameDataToKsp" AfterTargets="KSPBT_CopyDLLsToPluginFolder"
+          Condition=" '$(Kerbalism_DeployToKsp)' == 'true' And '$(KSPBT_GameRoot)' != '' ">
     <PropertyGroup>
       <_KspKerbalismDeployDir>$(KSPBT_GameRoot)/GameData/Kerbalism</_KspKerbalismDeployDir>
       <_KspKerbalismConfigDeployDir>$(KSPBT_GameRoot)/GameData/KerbalismConfig</_KspKerbalismConfigDeployDir>


### PR DESCRIPTION

- Add `Kerbalism_DeployToKsp` (default false) so builds do not auto-copy into the live KSP install.
- Empty `KSPBT_GameRoot` still falls through to Steam/ReferencePath discovery, so a separate switch is needed.