### PR TITLE
Fix false solar-panel In Shadow and SolarPanelFixer NREs

### DIFF
--- a/Kerbalism.slnx
+++ b/Kerbalism.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Configurations>
+    <BuildType Name="Debug" />
     <BuildType Name="Release" />
   </Configurations>
   <Project Path="src/Kerbalism/Kerbalism.csproj" Id="7cf587a9-6e49-46e8-ab3f-87b80a6276da" />

--- a/src/Kerbalism/Modules/SolarPanelFixer.cs
+++ b/src/Kerbalism/Modules/SolarPanelFixer.cs
@@ -639,7 +639,7 @@ namespace KERBALISM
 			if (!prefab.isInitialized) prefab.OnStart(StartState.None);
 
 			// OnStart may fail to bind a supported panel module (e.g. prefab part has SolarPanelFixer but no usable target).
-			if (prefab.SolarPanel == null || vd.EnvSunsInfo == null)
+			if (prefab.SolarPanel == null || !prefab.isEnabled || vd.EnvSunsInfo == null)
 			{
 				Profiler.EndSample();
 				return;

--- a/src/Kerbalism/Modules/SolarPanelFixer.cs
+++ b/src/Kerbalism/Modules/SolarPanelFixer.cs
@@ -446,8 +446,8 @@ namespace KERBALISM
 			// get vessel data from cache
 			VesselData vd = vessel.KerbalismData();
 
-			// do nothing if vessel is invalid
-			if (!vd.IsSimulated)
+			// do nothing if vessel is invalid, or sun info not ready yet (first FixedUpdates after load)
+			if (!vd.IsSimulated || vd.EnvSunsInfo == null)
 			{
 				Profiler.EndSample();
 				return;
@@ -638,6 +638,13 @@ namespace KERBALISM
 			// this is ugly spaghetti code but initializing the prefab at loading time is messy because the targeted solar panel module may not be loaded yet
 			if (!prefab.isInitialized) prefab.OnStart(StartState.None);
 
+			// OnStart may fail to bind a supported panel module (e.g. prefab part has SolarPanelFixer but no usable target).
+			if (prefab.SolarPanel == null || vd.EnvSunsInfo == null)
+			{
+				Profiler.EndSample();
+				return;
+			}
+
 			// check if the panel is broken by Reliability
 			// If Reliability targets ModuleDeployableSolarPanel, SolarPanelFixer (this module) remains enabled
 			// so we have to manually check if the target module is broken
@@ -646,7 +653,7 @@ namespace KERBALISM
 				if (p.modules[i].moduleName == "Reliability" && Lib.Proto.GetBool(p.modules[i], "broken"))
 				{
 					string type = Lib.Proto.GetString(p.modules[i], "type");
-					if (type == "SolarPanelFixer" || (prefab.SolarPanel != null && prefab.SolarPanel.TargetModule != null && type == prefab.SolarPanel.TargetModule.moduleName))
+					if (type == "SolarPanelFixer" || (prefab.SolarPanel.TargetModule != null && type == prefab.SolarPanel.TargetModule.moduleName))
 					{
 						Profiler.EndSample();
 						return;
@@ -738,6 +745,11 @@ namespace KERBALISM
 			}
 
 			if (trackedSunInfo == null && vd.EnvSunsInfo.Count > 0) trackedSunInfo = vd.EnvSunsInfo[0];
+			if (trackedSunInfo == null)
+			{
+				Profiler.EndSample();
+				return;
+			}
 
 			double powerFactor = CalculateMultiStarPowerAnalytic(v, vd.EnvSunsInfo, trackedSunInfo, prefab.SolarPanel.Type, isTracking);
 			efficiencyFactor = powerFactor;
@@ -1263,6 +1275,9 @@ namespace KERBALISM
 					if (sunCatcherPosition == null)
 						sunCatcherPosition = panelModule.part.FindModelTransform(panelModule.secondaryTransformName);
 
+					if (sunCatcherPosition == null)
+						return occludingFactor;
+
 					Physics.Raycast(sunCatcherPosition.position + (sunDir * panelModule.raycastOffset), sunDir, out raycastHit, 10000f);
 				}
 				else
@@ -1297,7 +1312,15 @@ namespace KERBALISM
 				{
 					case ModuleDeployableSolarPanel.PanelType.FLAT:
 						if (!analytic)
+						{
+							// trackingDotTransform can be null for a few FixedUpdates after vessel unpack
+							if (panelModule.trackingDotTransform == null)
+								return 0.0;
 							return Math.Max(Vector3d.Dot(sunDir, panelModule.trackingDotTransform.forward), 0.0);
+						}
+
+						if (sunCatcherPivot == null)
+							return 0.0;
 
 						if (panelModule.isTracking)
 							return Math.Cos(1.57079632679 - Math.Acos(Vector3d.Dot(sunDir, sunCatcherPivot.up)));
@@ -1305,6 +1328,8 @@ namespace KERBALISM
 							return Math.Max(Vector3d.Dot(sunDir, sunCatcherPivot.forward), 0.0);
 
 					case ModuleDeployableSolarPanel.PanelType.CYLINDRICAL:
+						if (panelModule.trackingDotTransform == null)
+							return 0.0;
 						return Math.Max((1.0 - Math.Abs(Vector3d.Dot(sunDir, panelModule.trackingDotTransform.forward))) * (1.0 / Math.PI), 0.0);
 					case ModuleDeployableSolarPanel.PanelType.SPHERICAL:
 						return 0.25;

--- a/src/Kerbalism/Sim.cs
+++ b/src/Kerbalism/Sim.cs
@@ -457,6 +457,12 @@ namespace KERBALISM
 		/// <param name="endNegOffset">distance from which the ray will stop before hitting the 'end' point, put the body radius here if the end point is a CB</param>
 		public static bool RaytracePhysic(Vessel vessel, Vector3d vesselPos, Vector3d end, double endNegOffset = 0.0)
 		{
+			return RaytracePhysic(vessel, vesselPos, end, endNegOffset, null);
+		}
+
+		/// <summary>Return true if there is no CelestialBody between the vessel position and the 'end' point. Hits on <paramref name="ignoreBody"/> are treated as reaching the ray target.</summary>
+		public static bool RaytracePhysic(Vessel vessel, Vector3d vesselPos, Vector3d end, double endNegOffset, CelestialBody ignoreBody)
+		{
 			// for unloaded vessels, position in scaledSpace is 1 fixedUpdate frame desynchronized :
 			if (!vessel.loaded)
 				vesselPos += vessel.mainBody.position - vessel.mainBody.getTruePositionAtUT(Planetarium.GetUniversalTime() + TimeWarp.fixedDeltaTime);
@@ -465,9 +471,39 @@ namespace KERBALISM
 			ScaledSpace.LocalToScaledSpace(ref vesselPos);
 			ScaledSpace.LocalToScaledSpace(ref end);
 			Vector3d dir = end - vesselPos;
-			if (endNegOffset > 0) dir -= dir.normalized * (endNegOffset * ScaledSpace.InverseScaleFactor);
 
-			return !Physics.Raycast(vesselPos, dir, (float)dir.magnitude, planetaryLayerMask);
+			if (endNegOffset > 0.0)
+				dir -= dir.normalized * (endNegOffset * ScaledSpace.InverseScaleFactor);
+
+			float maxDist = (float)dir.magnitude;
+			if (maxDist <= 0f)
+				return true;
+
+			if (!Physics.Raycast(vesselPos, dir, out RaycastHit hit, maxDist, planetaryLayerMask))
+				return true;
+
+			// Hitting the target body itself means the line of sight reached it - not occlusion.
+			if (ignoreBody != null && IsScaledBodyCollider(hit.collider, ignoreBody))
+				return true;
+
+			return false;
+		}
+
+		/// <summary>True if <paramref name="col"/> belongs to <paramref name="body"/>'s scaled-space hierarchy.</summary>
+		static bool IsScaledBodyCollider(Collider col, CelestialBody body)
+		{
+			if (col == null || body == null || body.scaledBody == null)
+				return false;
+
+			Transform root = body.scaledBody.transform;
+			Transform t = col.transform;
+			while (t != null)
+			{
+				if (t == root)
+					return true;
+				t = t.parent;
+			}
+			return false;
 		}
 
 		/// <summary> return true if the ray 'dir' starting at 'start' and of length 'dist' doesn't hit 'body'</summary>
@@ -503,8 +539,10 @@ namespace KERBALISM
 
 			// for very small bodies the analytic method is very unreliable at high latitudes
 			// we use a physic raycast (a lot slower)
+			// Pass body as ignoreBody: the ray targets that CB (usually a sun/star); hitting its
+			// own scaled mesh must not count as occlusion (#1053).
 			if (Lib.Landed(vessel) && vessel.mainBody.Radius < 100000.0 && (vessel.latitude < -45.0 || vessel.latitude > 45.0))
-				return RaytracePhysic(vessel, vesselPos, body.position, body.Radius);
+				return RaytracePhysic(vessel, vesselPos, body.position, body.Radius, body);
 
 			// check if the ray intersect one of the provided bodies
 			foreach (CelestialBody occludingBody in occludingBodies)


### PR DESCRIPTION
Mainly fix issue #1053
1. Small-body high latitudes: raycast hitting the sun's own scaled collider was treated as occlusion → false In Shadow
2. Treat hits on the target body as visible instead
3. Guard SolarPanelFixer against null transforms / missing sun info after load
4. Skip background update when the panel module was disabled by OnStart
5. Added the debug build type, which was previously forgotten