### PR TITLE
Fix `Sim.Init` crash when Kopernicus bodies have null scaledBody

### DIFF
--- a/src/Kerbalism/Sim.cs
+++ b/src/Kerbalism/Sim.cs
@@ -13,6 +13,10 @@ namespace KERBALISM
 			// Search for "LightShifter" components, added by Kopernicus to bodies that are stars
 			foreach (CelestialBody body in FlightGlobals.Bodies)
 			{
+				// Some Kopernicus bodies (e.g. invisible barycenters) have no scaledBody
+				if (body.scaledBody == null)
+					continue;
+
 				foreach (var c in body.scaledBody.GetComponentsInChildren<MonoBehaviour>(true))
 				{
 					if (c.GetType().ToString().Contains("LightShifter"))


### PR DESCRIPTION
Skip bodies without a scaledBody while discovering LightShifter stars so invisible barycenters (e.g. KSS2) no longer abort Kerbalism core init.
For details, see #1042