### PR TITLE
Fix planner solar output for cylindrical and spherical panels (#774)

### DIFF
--- a/src/Kerbalism/Modules/SolarPanelFixer.cs
+++ b/src/Kerbalism/Modules/SolarPanelFixer.cs
@@ -1143,6 +1143,23 @@ namespace KERBALISM
 			/// <summary>Type of the panel</summary>
 			public virtual ModuleDeployableSolarPanel.PanelType Type => ModuleDeployableSolarPanel.PanelType.FLAT;
 
+			/// <summary>
+			/// Peak cosine/exposure factor for planner nominal estimates.
+			/// SPHERICAL is fixed at 0.25; CYLINDRICAL peaks at 1/π; FLAT peaks at 1.
+			/// </summary>
+			public virtual double GetMaxCosineFactor()
+			{
+				switch (Type)
+				{
+					case ModuleDeployableSolarPanel.PanelType.SPHERICAL:
+						return 0.25;
+					case ModuleDeployableSolarPanel.PanelType.CYLINDRICAL:
+						return 1.0 / Math.PI;
+					default:
+						return 1.0;
+				}
+			}
+
 			/// <summary>Kopernicus stars support : must set the animation tracked body</summary>
 			public virtual void SetTrackedBody(CelestialBody body) { }
 
@@ -1216,7 +1233,7 @@ namespace KERBALISM
 		// - we still reuse most of the stock calculations
 		// - we let the module fixedupdate/update handle animations/suncatching
 		// - we prevent stock EC generation by reseting the reshandler rate
-		// - we don't support cylindrical/spherical panel types
+		// - FLAT / CYLINDRICAL / SPHERICAL panel types are supported via GetCosineFactor
 		private class StockPanel : SupportedPanel<ModuleDeployableSolarPanel>
 		{
 			private Transform sunCatcherPosition;   // middle point of the panel surface (usually). Use only position, panel surface direction depend on the pivot transform, even for static panels.
@@ -1344,6 +1361,9 @@ namespace KERBALISM
 							return Math.Max(Vector3d.Dot(sunDir, sunCatcherPivot.forward), 0.0);
 
 					case ModuleDeployableSolarPanel.PanelType.CYLINDRICAL:
+						// An orientable cylindrical panel can reach peak exposure when the sun is perpendicular to its axis
+						if (analytic && panelModule.isTracking)
+							return 1.0 / Math.PI;
 						if (panelModule.trackingDotTransform == null)
 							return 0.0;
 						return Math.Max((1.0 - Math.Abs(Vector3d.Dot(sunDir, panelModule.trackingDotTransform.forward))) * (1.0 / Math.PI), 0.0);

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -879,13 +879,14 @@ namespace KERBALISM.Planner
 
 		void Process_solarPanel(SolarPanelFixer spf, EnvironmentAnalyzer env)
 		{
-			if (spf.part.editorStarted && spf.isInitialized && spf.isEnabled && spf.editorEnabled)
+			if (spf.part.editorStarted && spf.isInitialized && spf.isEnabled && spf.editorEnabled && spf.SolarPanel != null)
 			{
 				double editorOutput = 0.0;
 				switch (Planner.Sunlight)
 				{
 					case Planner.SunlightState.SunlightNominal:
-						editorOutput = spf.nominalRate * (env.solar_flux / Sim.SolarFluxAtHome);
+						// Apply panel-type peak exposure (CYLINDRICAL = 1/π, SPHERICAL = 0.25, FLAT = 1)
+						editorOutput = spf.nominalRate * spf.SolarPanel.GetMaxCosineFactor() * (env.solar_flux / Sim.SolarFluxAtHome);
 						if (editorOutput > 0.0) Resource("ElectricCharge").Produce(editorOutput, Local.Planner_source_solarpanel_nominal);
 						break;
 					case Planner.SunlightState.SunlightSimulated:


### PR DESCRIPTION
Cylindrical example (Maximum approximately `1/π ≈ 0.318`):
<img width="901" height="564" alt="3" src="https://github.com/user-attachments/assets/42c12624-726c-4dc1-b958-56a04fcfff33" />

| Before | After |
| :---: | :---: |
| <img width="800" alt="Before cylindrical" src="https://github.com/user-attachments/assets/26b9cffc-af0b-42a5-99dd-e7d32437cb1b" /> | <img width="800" alt="After cylindrical" src="https://github.com/user-attachments/assets/b2ddfff7-e50e-426c-a9cb-8df1904c0451" /> |
| <img width="800" alt="Before spherical" src="https://github.com/user-attachments/assets/0d226dea-b045-4828-8cdc-c874fee0e4e6" /> | <img width="800" alt="After spherical" src="https://github.com/user-attachments/assets/27a659d0-4d87-4e89-9325-44d10e40da72" /> |

---

Spherical example (Fixed 0.25):
<img width="908" height="568" alt="4" src="https://github.com/user-attachments/assets/a58273b8-8423-48e4-b5c7-5bd86ae42f6c" />

| Before | After |
| :---: | :---: |
| <img width="800" alt="Before" src="https://github.com/user-attachments/assets/ff672ae2-5e3b-43c0-9c44-893e2f692f42" /> | <img width="800" alt="After" src="https://github.com/user-attachments/assets/bfc97217-205b-4fdf-9b7e-34bb9c926d5f" /> |
| <img width="800" alt="Before" src="https://github.com/user-attachments/assets/5c60e52b-c565-4ba8-8b62-edfdfbffa084" /> | <img width="800" alt="After" src="https://github.com/user-attachments/assets/56997eb8-7f79-4c03-9a56-c047a66e9c12" /> |



