### PR TITLE
Complete Kerbalism logic for existing US2 modules and parts, and fix SH issues

### DIFF
--- a/GameData/KerbalismConfig/Support/SystemHeat.cfg
+++ b/GameData/KerbalismConfig/Support/SystemHeat.cfg
@@ -221,9 +221,71 @@ KERBALISM_BRIDGE_SETTINGS
 // ============================================================================
 // KerbalismBridge integration: SystemHeatRadiators.cfg
 // ============================================================================
+// Universal Storage 2 radiators not converted by SystemHeat itself.
+// The microsatellite uses a normal stock radiator and can be converted in-place.
+@PART[USAdvancedMicroSatWedge]:HAS[@MODULE[ModuleActiveRadiator]]:NEEDS[Kerbalism,SystemHeat,UniversalStorage2]:BEFORE[zzzzzz_KerbalismProcess]
+{
+	%MODULE[ModuleSystemHeat]
+	{
+		%volume = #$/mass$
+		%moduleID = default
+		%iconName = Icon_Radiator
+		%ignoreTemperature = true
+	}
+
+	@MODULE[ModuleActiveRadiator]
+	{
+		@name = ModuleSystemHeatRadiator
+		%moduleID = radiator
+		%systemHeatModuleID = default
+		%maxRadiatorTemperature = 350
+		%emissivity = 0.9
+		%convectiveArea = 0.5
+		!temperatureCurve {}
+		temperatureCurve
+		{
+			key = 0 0
+			key = 400 20
+		}
+	}
+}
+
+// USRadiatorSwitch also controls the structural/radiator mesh variant, so it
+// must remain on the part. Add a real SystemHeat radiator and synchronize it
+// from the switch through SystemHeatRadiatorKerbalism.
+@PART[USAdaptorShroud1250Vostok]:HAS[@MODULE[USRadiatorSwitch],!MODULE[ModuleSystemHeatRadiator]]:NEEDS[Kerbalism,SystemHeat,UniversalStorage2]:BEFORE[zzzzzz_KerbalismProcess]
+{
+	%MODULE[ModuleSystemHeat]
+	{
+		%volume = #$/mass$
+		%moduleID = default
+		%iconName = Icon_Radiator
+		%ignoreTemperature = true
+	}
+
+	MODULE
+	{
+		name = ModuleSystemHeatRadiator
+		moduleID = us2Radiator
+		systemHeatModuleID = default
+		maxRadiatorTemperature = 350
+		emissivity = 0.9
+		convectiveArea = 1
+		maxEnergyTransfer = 5000
+		overcoolFactor = 0.25
+		isCoreRadiator = true
+		parentCoolingOnly = true
+		temperatureCurve
+		{
+			key = 0 0
+			key = 400 100
+		}
+	}
+}
+
 // SystemHeat radiators keep their native module for actual loop rejection.
 // Kerbalism sidecar only takes over resource accounting/background/planner handling.
-@PART[*]:HAS[@MODULE[ModuleSystemHeatRadiator],!MODULE[SystemHeatRadiatorKerbalism]]:NEEDS[Kerbalism,SystemHeat]:FOR[zzzzzz_KerbalismProcess]
+@PART[*]:HAS[@MODULE[ModuleSystemHeatRadiator],!MODULE[USRadiatorSwitch],!MODULE[SystemHeatRadiatorKerbalism]]:NEEDS[Kerbalism,SystemHeat]:FOR[zzzzzz_KerbalismProcess]
 {
 	MODULE
 	{
@@ -258,9 +320,35 @@ KERBALISM_BRIDGE_SETTINGS
 	}
 }
 
+// Universal Storage 2 mesh-switch radiators
+@PART[*]:HAS[@MODULE[USRadiatorSwitch],!MODULE[SystemHeatRadiatorKerbalism]]:NEEDS[Kerbalism,SystemHeat,UniversalStorage2]:FOR[zzzzzz_KerbalismProcess]
+{
+	MODULE
+	{
+		name = SystemHeatRadiatorKerbalism
+		radiatorModuleName = USRadiatorSwitch
+		systemHeatRadiatorModuleID = us2Radiator
+	}
+	!MODULE[PlannerController],* {}
+	MODULE
+	{
+		name = PlannerController
+		plannerId = radiator
+		title = #KERBALISM_Brokers_Radiator
+		considered = true
+	}
+}
+
 @PART[*]:HAS[@MODULE[SystemHeatRadiatorKerbalism],!MODULE[ModuleActiveRadiator],@MODULE[Reliability]:HAS[#type[ModuleActiveRadiator]]]:NEEDS[FeatureReliability,SystemHeat]:FOR[zzzzzz_KerbalismProcess]
 {
 	@MODULE[Reliability]:HAS[#type[ModuleActiveRadiator]]
+	{
+		@type = SystemHeatRadiatorKerbalism
+	}
+}
+@PART[*]:HAS[@MODULE[SystemHeatRadiatorKerbalism],@MODULE[Reliability]:HAS[#type[USRadiatorSwitch]]]:NEEDS[FeatureReliability,SystemHeat,UniversalStorage2]:FOR[zzzzzz_KerbalismProcess]
+{
+	@MODULE[Reliability]:HAS[#type[USRadiatorSwitch]]
 	{
 		@type = SystemHeatRadiatorKerbalism
 	}
@@ -1329,8 +1417,16 @@ KERBALISM_BRIDGE_SETTINGS
     }
 }
 
-// UniversalStorage2 Reliability
-@PART[USElektron,USSabatier,USWaterPurifier]:NEEDS[Kerbalism,SystemHeat,UniversalStorage2,FeatureReliability]:FINAL
+// UniversalStorage2 Reliability — remap ProcessController → ProcessControllerSystemHeat
+@PART[USElektron,USSabatier,USWaterPurifier]:HAS[@MODULE[Reliability]:HAS[#type[ProcessController]]]:NEEDS[Kerbalism,SystemHeat,UniversalStorage2,FeatureReliability]:FINAL
+{
+    @MODULE[Reliability]:HAS[#type[ProcessController]]
+    {
+        @type = ProcessControllerSystemHeat
+    }
+}
+
+@PART[USElektron,USSabatier,USWaterPurifier]:HAS[!MODULE[Reliability]:HAS[#type[ProcessControllerSystemHeat]],!MODULE[Reliability]:HAS[#type[ProcessController]]]:NEEDS[Kerbalism,SystemHeat,UniversalStorage2,FeatureReliability]:FINAL
 {
     MODULE
     {

--- a/GameData/KerbalismConfig/Support/UniversalStorage2.cfg
+++ b/GameData/KerbalismConfig/Support/UniversalStorage2.cfg
@@ -9,6 +9,32 @@
 	}
 }
 
+// Mesh-switch radiators (USRadiatorSwitch) — planner toggle + reliability
+@PART[*]:HAS[@MODULE[USRadiatorSwitch]]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = PlannerController
+		plannerId = radiator
+		title = #KERBALISM_Planner_source_radiator
+		considered = true
+	}
+}
+
+@PART[*]:HAS[@MODULE[USRadiatorSwitch]]:NEEDS[FeatureReliability]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Reliability
+		type = USRadiatorSwitch
+		title = #KERBALISM_Reliability_title_Radiator
+		repair = Engineer
+		mtbf = 72576000
+		extra_cost = 1.0
+		extra_mass = 0.25
+	}
+}
+
 // Stock FuelCell mass 0.05t / capacity 1 (H2) and 5 (monoprop)
 // US small wedge mass 0.05t → same as stock
 @PART[USFuelCellSmal]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
@@ -172,6 +198,17 @@
     // Full (0.96/0.04)*2 = 48 would beat MiniISRU (36). Cap at 12 (~1/3 MiniISRU).
     capacity = 12
   }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = #KERBALISM_WaterElectrolysis_title
+    repair = Engineer
+    mtbf = 72576000
+    extra_cost = 1.0
+    extra_mass = 0.2
+  }
 }
 
 @PART[USRTGWedge]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
@@ -189,6 +226,18 @@
 
   !MODULE[ModuleGenerator] {}
   !MODULE[ModuleCoreHeat] {}
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = #KERBALISM_RTG_title
+    redundancy = Power Generation
+    repair = Engineer
+    mtbf = 72576000
+    extra_cost = 1.0
+    extra_mass = 0.2
+  }
 }
 
 @PART[USRTGWedge]:NEEDS[FeatureRadiation]:FOR[KerbalismDefault]
@@ -212,6 +261,17 @@
     capacity = 18 // part is 0.24t, ECLSS is 0.04 for capacity = 3
     running = false
   }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = #KERBALISM_WaterRecycler_title
+    repair = Engineer
+    mtbf = 72576000
+    extra_cost = 1.0
+    extra_mass = 0.2
+  }
 }
 
 @PART[USSabatier]:NEEDS[ProfileDefault]:FOR[KerbalismDefault]
@@ -226,5 +286,16 @@
     capacity = 13.2 // part is 0.528t, ECLSS is 0.04 for capacity = 1
     valve_i = 2 // workaround until we have a better way to deal with dump valves
     running = false
+  }
+
+  MODULE:NEEDS[FeatureReliability]
+  {
+    name = Reliability
+    type = ProcessController
+    title = #KERBALISM_SabatierProcess_title
+    repair = Engineer
+    mtbf = 72576000
+    extra_cost = 1.0
+    extra_mass = 0.2
   }
 }

--- a/GameData/KerbalismConfig/Support/UniversalStorage2_Science.cfg
+++ b/GameData/KerbalismConfig/Support/UniversalStorage2_Science.cfg
@@ -19,6 +19,10 @@
 {
 	TechRequired = basicScience
 }
+@part[USFluidSpectroWedge]:NEEDS[UniversalStorage2,CommunityTechTree,!SETI,!RP-0,FeatureScience]:BEFORE[zzzKerbalismDefault]
+{
+	TechRequired = scienceTech
+}
 
 // ============================================================================
 // Experiment values for US-specific science defs
@@ -371,6 +375,17 @@
 	@MODULE[Experiment]:HAS[#experiment_id[seismicScan]]
 	{
 		%anim_deploy = AccelDeploy
+	}
+}
+
+// Stock atmosphereAnalysis on a wedge — no deploy anim on this part.
+// Keep unshrouded sampling; dual sample slots match other US science wedges.
+@PART[USFluidSpectroWedge]:NEEDS[UniversalStorage2,FeatureScience]:AFTER[zzzKerbalismDefault]
+{
+	@MODULE[Experiment]:HAS[#experiment_id[atmosphereAnalysis]]
+	{
+		%allow_shrouded = False
+		%sample_amount = 2
 	}
 }
 

--- a/src/Kerbalism/Integrations/SystemHeat/Native/Radiators/SHRadiatorKerbalism.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/Native/Radiators/SHRadiatorKerbalism.cs
@@ -35,11 +35,18 @@ namespace KERBALISM
 		[KSPField(isPersistant = false)]
 		public string radiatorModuleID = "";
 
+		[KSPField(isPersistant = false)]
+		public string systemHeatRadiatorModuleID = "";
+
 		public static string radiatorTitle = Localizer.Format("#KERBALISM_Brokers_Radiator");
 
 		public FloatCurve temperatureCurve;
 		List<InputResourceSnapshot> inputRateSnapshots;
 		FloatCurve baseTemperatureCurve;
+		int lastUSRadiatorSelection = -1;
+		float lastUSRadiatorScale = -1f;
+		bool lastSyncedSystemHeatCooling;
+		bool hasSyncedSystemHeatCooling;
 
 		public override void OnLoad(ConfigNode node)
 		{
@@ -50,16 +57,16 @@ namespace KERBALISM
 		public override void OnStart(StartState state)
 		{
 			base.OnStart(state);
-			SyncCoolingState();
 			CaptureInputRateSnapshots();
 			EnsureBaseTemperatureCurve();
 			if (scale != 1f)
 				RebuildTemperatureCurve();
+			SyncRadiatorState();
 		}
 
 		public override void OnSave(ConfigNode node)
 		{
-			SyncCoolingState();
+			SyncRadiatorState();
 			base.OnSave(node);
 		}
 
@@ -88,6 +95,125 @@ namespace KERBALISM
 			}
 
 			return fallback;
+		}
+
+		/// <summary>Native radiator modules controlled by this sidecar (used by Reliability break/repair).</summary>
+		public List<PartModule> FindNativeRadiatorsForReliability()
+		{
+			var radiators = new List<PartModule>();
+			PartModule nativeRadiator = FindNativeRadiatorModule();
+			if (nativeRadiator != null)
+				radiators.Add(nativeRadiator);
+
+			// USRadiatorSwitch must stay enabled for its mesh/function switching UI, so it
+			// can't be replaced in-place. Its linked SystemHeat radiator is a second native
+			// module and must follow the same Reliability state.
+			if (nativeRadiator?.moduleName == "USRadiatorSwitch")
+			{
+				PartModule systemHeatRadiator = FindLinkedSystemHeatRadiator();
+				if (systemHeatRadiator != null && !radiators.Contains(systemHeatRadiator))
+					radiators.Add(systemHeatRadiator);
+			}
+
+			return radiators;
+		}
+
+		/// <summary>Remove the last registered rejection flux before a failed native radiator is disabled.</summary>
+		public void ClearRadiatorFluxForReliability(PartModule radiator)
+		{
+			if (radiator == null || !SystemHeat.IsRadiator(radiator))
+				return;
+
+			string heatModuleId = SystemHeat.Get(radiator, "systemHeatModuleID", "");
+			PartModule heatModule = SystemHeat.FindHeatModule(part, heatModuleId);
+			SystemHeat.AddFlux(heatModule, SystemHeat.GetModuleId(radiator), 0f, 0f, false);
+		}
+
+		PartModule FindLinkedSystemHeatRadiator()
+		{
+			if (part == null)
+				return null;
+
+			PartModule fallback = null;
+			for (int i = 0; i < part.Modules.Count; i++)
+			{
+				PartModule module = part.Modules[i];
+				if (module == null || module.moduleName != "ModuleSystemHeatRadiator")
+					continue;
+
+				if (fallback == null)
+					fallback = module;
+
+				if (string.IsNullOrEmpty(systemHeatRadiatorModuleID)
+					|| SystemHeat.GetModuleId(module) == systemHeatRadiatorModuleID)
+					return module;
+			}
+
+			return fallback;
+		}
+
+		bool TryGetUSRadiatorSelection(PartModule radiator, out int selection, out float power)
+		{
+			selection = -1;
+			power = 0f;
+			if (radiator == null || radiator.moduleName != "USRadiatorSwitch")
+				return false;
+
+			string powersString = IntegrationReflection.GetString(radiator, "RadiatorPower");
+			if (string.IsNullOrEmpty(powersString))
+				return false;
+
+			string[] powers = powersString.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+			selection = IntegrationReflection.GetInt(radiator, "CurrentSelection", -1);
+			if (selection < 0 || selection >= powers.Length)
+				return false;
+
+			return float.TryParse(powers[selection].Trim(), System.Globalization.NumberStyles.Float,
+				System.Globalization.CultureInfo.InvariantCulture, out power)
+				&& !float.IsNaN(power) && !float.IsInfinity(power);
+		}
+
+		void SyncUSRadiatorSwitch()
+		{
+			PartModule radiator = FindNativeRadiatorModule();
+			PartModule systemHeatRadiator = FindLinkedSystemHeatRadiator();
+			if (radiator?.moduleName != "USRadiatorSwitch" || systemHeatRadiator == null
+				|| !TryGetUSRadiatorSelection(radiator, out int selection, out float stockTransferPower))
+				return;
+
+			// ModuleActiveRadiator maxEnergyTransfer/RadiatorPower is fifty times the
+			// equivalent SystemHeat temperature-curve output in kW.
+			float scaleFactor = (float)Math.Pow(scale, scaleEmissionPower);
+			float systemHeatPower = Math.Max(0f, stockTransferPower / 50f) * scaleFactor;
+			if (selection != lastUSRadiatorSelection || !Mathf.Approximately(scaleFactor, lastUSRadiatorScale))
+			{
+				var curve = new FloatCurve();
+				curve.Add(0f, 0f);
+				curve.Add(400f, systemHeatPower);
+				IntegrationReflection.SetField(systemHeatRadiator, "temperatureCurve", curve);
+				lastUSRadiatorSelection = selection;
+				lastUSRadiatorScale = scaleFactor;
+			}
+
+			// Vostok-style US radiators use AutoEnable=False and never call Enable(), so
+			// IsCooling stays false even on the radiator mesh. ActiveCooling is the
+			// persistent desired state; also honor ModuleSystemHeatRadiator PAW toggles.
+			bool hasRadiatorPower = systemHeatPower > 0f && radiator.isEnabled;
+			bool shCooling = IntegrationReflection.GetBool(systemHeatRadiator, "IsCooling", false);
+			bool desiredCooling = hasRadiatorPower
+				&& IntegrationReflection.GetBool(radiator, "ActiveCooling", true);
+
+			if (hasRadiatorPower && hasSyncedSystemHeatCooling && shCooling != lastSyncedSystemHeatCooling)
+			{
+				desiredCooling = shCooling;
+				IntegrationReflection.SetField(radiator, "ActiveCooling", desiredCooling);
+			}
+
+			IntegrationReflection.SetField(radiator, "IsCooling", desiredCooling);
+			IntegrationReflection.SetField(systemHeatRadiator, "IsCooling", desiredCooling);
+			IsCooling = desiredCooling;
+			lastSyncedSystemHeatCooling = desiredCooling;
+			hasSyncedSystemHeatCooling = true;
 		}
 
 		PartModule FindPrefabRadiatorModule(Part prefab)
@@ -124,6 +250,15 @@ namespace KERBALISM
 			IsCooling = NativeIsCooling();
 		}
 
+		void SyncRadiatorState()
+		{
+			PartModule radiator = FindNativeRadiatorModule();
+			if (radiator?.moduleName == "USRadiatorSwitch" && FindLinkedSystemHeatRadiator() != null)
+				SyncUSRadiatorSwitch();
+			else
+				SyncCoolingState();
+		}
+
 		void CaptureInputRateSnapshots()
 		{
 			IList inputResources = GetNativeInputResources();
@@ -149,8 +284,38 @@ namespace KERBALISM
 				CaptureInputRateSnapshots();
 		}
 
-		void AppendInputResourceRequests(List<KeyValuePair<string, double>> resourceChangeRequest, float scaleFactor, float scaleEmissionPowerFactor)
+		bool TryAppendUSRadiatorSwitchRequest(List<KeyValuePair<string, double>> resourceChangeRequest, float scaleFactor, float scaleEmissionPowerFactor, int? selectionOverride)
 		{
+			PartModule radiator = FindNativeRadiatorModule();
+			if (radiator == null || radiator.moduleName != "USRadiatorSwitch")
+				return false;
+
+			string ratesString = IntegrationReflection.GetString(radiator, "RadiatorEnergy");
+			if (string.IsNullOrEmpty(ratesString))
+				return false;
+
+			string[] rates = ratesString.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+			int selection = selectionOverride ?? IntegrationReflection.GetInt(radiator, "CurrentSelection", -1);
+			if (selection < 0 || selection >= rates.Length)
+				return false;
+
+			if (!double.TryParse(rates[selection].Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out double rate)
+				|| double.IsNaN(rate) || double.IsInfinity(rate))
+				return false;
+
+			if (rate > 0.0)
+			{
+				double emissionScale = Math.Pow(scaleFactor, scaleEmissionPowerFactor);
+				resourceChangeRequest.Add(new KeyValuePair<string, double>("ElectricCharge", -rate * emissionScale));
+			}
+			return true;
+		}
+
+		void AppendInputResourceRequests(List<KeyValuePair<string, double>> resourceChangeRequest, float scaleFactor, float scaleEmissionPowerFactor, int? selectionOverride = null)
+		{
+			if (TryAppendUSRadiatorSwitchRequest(resourceChangeRequest, scaleFactor, scaleEmissionPowerFactor, selectionOverride))
+				return;
+
 			EnsureInputRateSnapshots();
 			if (inputRateSnapshots == null)
 				return;
@@ -224,14 +389,40 @@ namespace KERBALISM
 			return radiatorTitle;
 		}
 
+		static bool IsRadiatorReliabilityBroken(ProtoPartSnapshot part)
+		{
+			if (part == null)
+				return false;
+
+			for (int i = 0; i < part.modules.Count; i++)
+			{
+				ProtoPartModuleSnapshot module = part.modules[i];
+				if (module.moduleName != "Reliability" || !Lib.Proto.GetBool(module, "broken"))
+					continue;
+
+				string type = Lib.Proto.GetString(module, "type");
+				if (type == "SystemHeatRadiatorKerbalism"
+					|| type == "ModuleSystemHeatRadiator"
+					|| type == "ModuleActiveRadiator"
+					|| type == "USRadiatorSwitch")
+					return true;
+			}
+			return false;
+		}
+
 		public static string BackgroundUpdate(Vessel v, ProtoPartSnapshot part_snapshot, ProtoPartModuleSnapshot module_snapshot, PartModule proto_part_module, Part proto_part, Dictionary<string, double> availableResources, List<KeyValuePair<string, double>> resourceChangeRequest, double elapsed_s)
 		{
-			if (Lib.Proto.GetBool(module_snapshot, "IsCooling", true))
+			if (!IsRadiatorReliabilityBroken(part_snapshot) && Lib.Proto.GetBool(module_snapshot, "IsCooling", true))
 			{
 				float scale = Lib.Proto.GetFloat(module_snapshot, "scale");
 				float scaleEmissionPower = Lib.Proto.GetFloat(module_snapshot, "scaleEmissionPower");
 				if (proto_part_module is SystemHeatRadiatorKerbalism radiator)
-					radiator.AppendInputResourceRequests(resourceChangeRequest, scale, scaleEmissionPower);
+				{
+					ProtoPartModuleSnapshot nativeRadiator = IntegrationUtils.TryFindPartModuleSnapshot(part_snapshot, radiator.radiatorModuleName);
+					int savedSelection = nativeRadiator == null ? -1 : Lib.Proto.GetInt(nativeRadiator, "CurrentSelection", -1);
+					int? selection = savedSelection < 0 ? (int?)null : savedSelection;
+					radiator.AppendInputResourceRequests(resourceChangeRequest, scale, scaleEmissionPower, selection);
+				}
 				else
 				{
 					IList inputResources = SystemHeat.GetResHandlerInputResources(proto_part_module);
@@ -253,7 +444,7 @@ namespace KERBALISM
 
 		public string ResourceUpdate(Dictionary<string, double> availableResources, List<KeyValuePair<string, double>> resourceChangeRequest)
 		{
-			SyncCoolingState();
+			SyncRadiatorState();
 			if (IsCooling)
 				AppendInputResourceRequests(resourceChangeRequest, scale, scaleEmissionPower);
 			return radiatorTitle;
@@ -261,7 +452,7 @@ namespace KERBALISM
 
 		public void FixedUpdate()
 		{
-			SyncCoolingState();
+			SyncRadiatorState();
 		}
 	}
 }

--- a/src/Kerbalism/Integrations/SystemHeat/SystemHeatBackgroundThermal.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/SystemHeatBackgroundThermal.cs
@@ -27,6 +27,8 @@ namespace KERBALISM
 		private const string FluxAnchorValidField = "backgroundFluxAnchorValid";
 		/// <summary>Hard floor for loop temperature integration (space baseline), not ambient environment.</summary>
 		private const float MinimumLoopTemperatureK = 4f;
+		/// <summary>Stock SystemHeat radiator patches reach their rated rejection at 400 K.</summary>
+		private const float StockRadiatorRatedTemperatureK = 400f;
 
 		public static void CaptureLoadedTemperatures(Vessel v)
 		{
@@ -321,6 +323,7 @@ namespace KERBALISM
 
 		private class RadiatorRejector
 		{
+			internal ProtoPartSnapshot part;
 			internal Part prefab;
 			internal ProtoPartModuleSnapshot module;
 		}
@@ -433,7 +436,7 @@ namespace KERBALISM
 					}
 					else if (module.moduleName == "SystemHeatRadiatorKerbalism")
 					{
-						if (!IsRadiatorOperational(part, module))
+						if (!IsRadiatorOperational(part, prefab, module))
 							continue;
 
 						int loopId = GetRadiatorLoopId(part, prefab, module);
@@ -442,7 +445,7 @@ namespace KERBALISM
 
 						EnsureLoop(loops, loopId, v);
 						LoopState loop = loops[loopId];
-						RegisterLoopRadiator(loop, prefab, module);
+						RegisterLoopRadiator(loop, part, prefab, module);
 					}
 					else if (module.moduleName == "ModuleSystemHeatRadiator" || module.moduleName == "ModuleActiveRadiator")
 					{
@@ -457,7 +460,7 @@ namespace KERBALISM
 							continue;
 
 						EnsureLoop(loops, loopId, v);
-						RegisterLoopRadiator(loops[loopId], prefab, module);
+						RegisterLoopRadiator(loops[loopId], part, prefab, module);
 					}
 					else if (module.moduleName == "SystemHeatConverterKerbalismUpdater")
 					{
@@ -834,10 +837,10 @@ namespace KERBALISM
 			return storedEnergy;
 		}
 
-		private static void RegisterLoopRadiator(LoopState loop, Part prefab, ProtoPartModuleSnapshot module)
+		private static void RegisterLoopRadiator(LoopState loop, ProtoPartSnapshot part, Part prefab, ProtoPartModuleSnapshot module)
 		{
 			loop.hasRadiator = true;
-			loop.radiators.Add(new RadiatorRejector { prefab = prefab, module = module });
+			loop.radiators.Add(new RadiatorRejector { part = part, prefab = prefab, module = module });
 		}
 
 		private static void SyncLoopNetFlux(LoopState loop)
@@ -863,7 +866,7 @@ namespace KERBALISM
 			for (int i = 0; i < count; i++)
 			{
 				RadiatorRejector radiator = loop.radiators[i];
-				total += GetRadiatorRejectPower(radiator.prefab, radiator.module, loopTemperature);
+				total += GetRadiatorRejectPower(radiator.part, radiator.prefab, radiator.module, loopTemperature);
 			}
 			return total;
 		}
@@ -1226,7 +1229,8 @@ namespace KERBALISM
 				string type = Lib.Proto.GetString(reliability, "type");
 				if (type == "SystemHeatRadiatorKerbalism"
 					|| type == "ModuleSystemHeatRadiator"
-					|| type == "ModuleActiveRadiator")
+					|| type == "ModuleActiveRadiator"
+					|| type == "USRadiatorSwitch")
 					return false;
 			}
 
@@ -1329,9 +1333,49 @@ namespace KERBALISM
 			}
 		}
 
-		private static bool IsRadiatorOperational(ProtoPartSnapshot part, ProtoPartModuleSnapshot radiatorModule)
+		private static string GetConfiguredRadiatorModuleName(Part prefab, ProtoPartModuleSnapshot radiatorModule)
+		{
+			PartModule wrapperPrefab = FindPrefabModule(prefab, "SystemHeatRadiatorKerbalism");
+			string fallback = IntegrationReflection.GetString(wrapperPrefab, "radiatorModuleName", "ModuleSystemHeatRadiator");
+			return Lib.Proto.GetString(radiatorModule, "radiatorModuleName", fallback);
+		}
+
+		private static bool TryGetUSRadiatorSelectedPower(ProtoPartSnapshot part, Part prefab, ProtoPartModuleSnapshot radiatorModule, out float selectedPower)
+		{
+			selectedPower = 0f;
+			if (GetConfiguredRadiatorModuleName(prefab, radiatorModule) != "USRadiatorSwitch")
+				return false;
+
+			PartModule nativePrefab = FindPrefabModule(prefab, "USRadiatorSwitch");
+			ProtoPartModuleSnapshot nativeSnapshot = IntegrationUtils.TryFindPartModuleSnapshot(part, "USRadiatorSwitch");
+			if (nativePrefab == null || nativeSnapshot == null)
+				return true;
+
+			int selection = Lib.Proto.GetInt(nativeSnapshot, "CurrentSelection", IntegrationReflection.GetInt(nativePrefab, "CurrentSelection", -1));
+			string powersString = IntegrationReflection.GetString(nativePrefab, "RadiatorPower");
+			if (string.IsNullOrEmpty(powersString))
+				return true;
+
+			string[] powers = powersString.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+			if (selection < 0 || selection >= powers.Length)
+				return true;
+
+			if (!float.TryParse(powers[selection].Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out selectedPower)
+				|| float.IsNaN(selectedPower) || float.IsInfinity(selectedPower))
+				selectedPower = 0f;
+			else
+				// Stock ModuleActiveRadiator transfer power is fifty times the
+				// equivalent SystemHeat temperature-curve output in kW.
+				selectedPower = Math.Max(0f, selectedPower / 50f);
+			return true;
+		}
+
+		private static bool IsRadiatorOperational(ProtoPartSnapshot part, Part prefab, ProtoPartModuleSnapshot radiatorModule)
 		{
 			if (!Lib.Proto.GetBool(radiatorModule, "IsCooling", true))
+				return false;
+
+			if (TryGetUSRadiatorSelectedPower(part, prefab, radiatorModule, out float selectedPower) && selectedPower <= 0f)
 				return false;
 
 			foreach (ProtoPartModuleSnapshot module in part.modules)
@@ -1342,7 +1386,8 @@ namespace KERBALISM
 				string type = Lib.Proto.GetString(module, "type");
 				if (type == "SystemHeatRadiatorKerbalism"
 					|| type == "ModuleSystemHeatRadiator"
-					|| type == "ModuleActiveRadiator")
+					|| type == "ModuleActiveRadiator"
+					|| type == "USRadiatorSwitch")
 					return false;
 			}
 
@@ -1452,13 +1497,19 @@ namespace KERBALISM
 			return null;
 		}
 
-		private static float GetRadiatorRejectPower(Part prefab, ProtoPartModuleSnapshot module, float loopTemperature)
+		private static float GetRadiatorRejectPower(ProtoPartSnapshot part, Part prefab, ProtoPartModuleSnapshot module, float loopTemperature)
 		{
 			float scale = Lib.Proto.GetFloat(module, "scale", 1f);
 			if (scale <= 0f)
 				scale = 1f;
 			float scaleEmissionPower = Lib.Proto.GetFloat(module, "scaleEmissionPower", 2f);
 			float scaleFactor = (float)Math.Pow(scale, scaleEmissionPower);
+
+			if (TryGetUSRadiatorSelectedPower(part, prefab, module, out float selectedPower))
+			{
+				float temperatureFactor = Mathf.Clamp01(loopTemperature / StockRadiatorRatedTemperatureK);
+				return selectedPower * temperatureFactor * scaleFactor;
+			}
 
 			float curvePower = EvaluateRadiatorCurvePower(prefab, module, loopTemperature, scaleFactor);
 			if (curvePower > 0f)

--- a/src/Kerbalism/Integrations/SystemHeat/SystemHeatHarmony.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/SystemHeatHarmony.cs
@@ -15,6 +15,7 @@ namespace KERBALISM
 			PatchPrefix(harmony, "SystemHeat.ModuleSystemHeatFissionEngine", "HandleResourceActivities", nameof(SkipWhenFissionEngineUpdaterPresent));
 			PatchPrefix(harmony, "SystemHeat.ModuleSystemHeatFissionEngine", "DoCatchup", nameof(SkipWhenFissionEngineUpdaterPresent));
 			PatchPrefix(harmony, "SystemHeat.ModuleSystemHeatRadiator", "FixedUpdate", nameof(SkipRadiatorRatesWhenKerbalismPresent));
+			PatchPrefix(harmony, "ModuleActiveRadiator", "FixedUpdate", nameof(SkipStockRadiatorRatesWhenKerbalismPresent));
 		}
 
 		private static void PatchPrefix(Harmony harmony, string typeName, string methodName, string prefixName)
@@ -74,6 +75,28 @@ namespace KERBALISM
 				return true;
 
 			ZeroResHandlerInputRates(radiator);
+			return true;
+		}
+
+		private static bool SkipStockRadiatorRatesWhenKerbalismPresent(object __instance)
+		{
+			PartModule radiator = __instance as PartModule;
+			if (radiator?.part == null)
+				return true;
+
+			SystemHeatRadiatorKerbalism wrapper = radiator.part.FindModuleImplementing<SystemHeatRadiatorKerbalism>();
+			if (wrapper == null)
+				return true;
+
+			ZeroResHandlerInputRates(radiator);
+
+			// A USRadiatorSwitch remains on the part to preserve mesh/function switching.
+			// Once a real SystemHeat radiator is linked, suppress its inherited stock heat
+			// transfer as well as its resource draw.
+			if (radiator.moduleName == "USRadiatorSwitch"
+				&& IntegrationUtils.FindModule(radiator.part, "ModuleSystemHeatRadiator") != null)
+				return false;
+
 			return true;
 		}
 

--- a/src/Kerbalism/Modules/Reliability.cs
+++ b/src/Kerbalism/Modules/Reliability.cs
@@ -38,6 +38,8 @@ namespace KERBALISM
 		[KSPField(isPersistant = true)] public double operation_duration = 0.0; // failure rate increases dramatically if this is exceeded
 		[KSPField(isPersistant = true)] public double fail_duration = 0.0;  // fail when operation_duration exceeds this
 		[KSPField(isPersistant = true)] public int ignitions = 0;           // accumulated ignitions
+		[KSPField(isPersistant = true)] public bool radiator_state_stored;  // true after caching a switch radiator's pre-failure state
+		[KSPField(isPersistant = true)] public bool radiator_was_cooling;   // switch radiator state restored after repair
 
 		// status ui
 		[KSPField(guiActive = true, guiActiveEditor = true, guiName = "_", groupName = "Reliability", groupDisplayName = "#KERBALISM_Group_Reliability")]//Reliability
@@ -62,6 +64,14 @@ namespace KERBALISM
 			if (!Lib.IsFlight()) return;
 
 			if (last_inspection <= 0) last_inspection = Planetarium.GetUniversalTime();
+
+			if (part.FindModuleImplementing<SystemHeatRadiatorKerbalism>() != null
+				&& (type == "USRadiatorSwitch" || type == "ModuleActiveRadiator" || type == "ModuleSystemHeatRadiator"))
+			{
+				// Migrate persistent Reliability fields on vessels saved before the
+				// SystemHeat sidecar remap.
+				type = "SystemHeatRadiatorKerbalism";
+			}
 
 			// cache list of modules
 			if(type.StartsWith("ModuleEngines", StringComparison.Ordinal))
@@ -210,6 +220,7 @@ namespace KERBALISM
 						m.enabled = false;
 						m.isEnabled = false;
 					}
+					EnforceBrokenRadiatorState();
 				}
 
 				// update ui
@@ -728,7 +739,17 @@ namespace KERBALISM
 			// get reliability module prefab
 			string type = Lib.Proto.GetString(m, "type", string.Empty);
 			Reliability reliability = p.partPrefab.FindModulesImplementing<Reliability>().Find(k => k.type == type);
+			if (reliability == null && (type == "USRadiatorSwitch"
+				|| type == "ModuleActiveRadiator"
+				|| type == "ModuleSystemHeatRadiator"))
+			{
+				// Existing vessels keep persistent Reliability fields from before the
+				// SystemHeat MM remap. Accept legacy radiator types as sidecar aliases.
+				reliability = p.partPrefab.FindModulesImplementing<Reliability>().Find(k => k.type == "SystemHeatRadiatorKerbalism");
+			}
 			if (reliability == null) return;
+			if (reliability.type != type)
+				Lib.Proto.Set(m, "type", reliability.type);
 
 			bool enforce_breakdown = Lib.Proto.GetBool(m, "enforce_breakdown", false);
 
@@ -741,6 +762,8 @@ namespace KERBALISM
 				// determine if this is a critical failure
 				bool critical = Lib.RandomDouble() < PreferencesReliability.Instance.criticalChance;
 				Lib.Proto.Set(m, "critical", critical);
+
+				ProtoStoreRadiatorState(p, m, reliability.type);
 
 				// for each associated module
 				foreach (var proto_module in p.modules.FindAll(k => k.moduleName == reliability.type))
@@ -764,6 +787,22 @@ namespace KERBALISM
 							if (res != null) res.flowState = false;
 						}
 						break;
+
+					case "SystemHeatRadiatorKerbalism":
+						ProtoDisableSystemHeatNativeRadiators(p);
+						break;
+
+					case "USRadiatorSwitch":
+						foreach (var proto_module in p.modules.FindAll(k => k.moduleName == "USRadiatorSwitch"
+							|| k.moduleName == "SystemHeatRadiatorKerbalism"
+							|| k.moduleName == "ModuleSystemHeatRadiator"))
+						{
+							Lib.Proto.Set(proto_module, "isEnabled", false);
+							Lib.Proto.Set(proto_module, "IsCooling", false);
+							if (proto_module.moduleName == "USRadiatorSwitch")
+								Lib.Proto.Set(proto_module, "ActiveCooling", false);
+						}
+						break;
 				}
 
 				// show message
@@ -785,6 +824,36 @@ namespace KERBALISM
 			{
 				Incentive_redundancy(v, reliability.redundancy);
 			}
+		}
+
+		static void ProtoStoreRadiatorState(ProtoPartSnapshot part, ProtoPartModuleSnapshot reliability, string reliabilityType)
+		{
+			if (reliabilityType != "SystemHeatRadiatorKerbalism" && reliabilityType != "USRadiatorSwitch")
+				return;
+
+			string nativeModuleName = reliabilityType;
+			if (reliabilityType == "SystemHeatRadiatorKerbalism" && part.partPrefab != null)
+			{
+				SystemHeatRadiatorKerbalism wrapper = part.partPrefab.FindModuleImplementing<SystemHeatRadiatorKerbalism>();
+				if (wrapper != null && !string.IsNullOrEmpty(wrapper.radiatorModuleName))
+					nativeModuleName = wrapper.radiatorModuleName;
+			}
+
+			bool wasCooling = true;
+			ProtoPartModuleSnapshot wrapperSnapshot = IntegrationUtils.TryFindPartModuleSnapshot(part, "SystemHeatRadiatorKerbalism");
+			if (wrapperSnapshot != null)
+				wasCooling = Lib.Proto.GetBool(wrapperSnapshot, "IsCooling", wasCooling);
+
+			ProtoPartModuleSnapshot nativeSnapshot = IntegrationUtils.TryFindPartModuleSnapshot(part, nativeModuleName);
+			if (nativeSnapshot != null)
+			{
+				wasCooling = nativeModuleName == "USRadiatorSwitch"
+					? Lib.Proto.GetBool(nativeSnapshot, "ActiveCooling", Lib.Proto.GetBool(nativeSnapshot, "IsCooling", wasCooling))
+					: Lib.Proto.GetBool(nativeSnapshot, "IsCooling", wasCooling);
+			}
+
+			Lib.Proto.Set(reliability, nameof(radiator_was_cooling), wasCooling);
+			Lib.Proto.Set(reliability, nameof(radiator_state_stored), true);
 		}
 
 		// part tooltip
@@ -894,6 +963,27 @@ namespace KERBALISM
 			return false;
 		}
 
+		static bool GetRadiatorCoolingState(PartModule radiator, bool fallback)
+		{
+			if (radiator == null)
+				return fallback;
+
+			bool isCooling = IntegrationReflection.GetBool(radiator, "IsCooling", fallback);
+			return radiator.moduleName == "USRadiatorSwitch"
+				? IntegrationReflection.GetBool(radiator, "ActiveCooling", isCooling)
+				: isCooling;
+		}
+
+		static void SetRadiatorCoolingState(PartModule radiator, bool isCooling)
+		{
+			if (radiator == null)
+				return;
+
+			IntegrationReflection.SetField(radiator, "IsCooling", isCooling);
+			if (radiator.moduleName == "USRadiatorSwitch")
+				IntegrationReflection.SetField(radiator, "ActiveCooling", isCooling);
+		}
+
 		// apply type-specific hacks to enable/disable the module
 		protected void Apply(bool b)
 		{
@@ -930,6 +1020,75 @@ namespace KERBALISM
 					{
 						part.FindModelComponents<Animation>().ForEach(k => k.Stop());
 					}
+					break;
+
+				case "USRadiatorSwitch":
+					foreach (PartModule m in modules)
+					{
+						if (b && !radiator_state_stored)
+						{
+							radiator_was_cooling = GetRadiatorCoolingState(m, false);
+							radiator_state_stored = true;
+						}
+						SetRadiatorCoolingState(m, b ? false : radiator_was_cooling);
+					}
+					foreach (SystemHeatRadiatorKerbalism wrapper in part.FindModulesImplementing<SystemHeatRadiatorKerbalism>())
+					{
+						if (wrapper.radiatorModuleName != "USRadiatorSwitch")
+							continue;
+
+						if (b && !radiator_state_stored)
+						{
+							radiator_was_cooling = wrapper.IsCooling;
+							radiator_state_stored = true;
+						}
+						wrapper.isEnabled = !b;
+						wrapper.enabled = !b;
+						wrapper.IsCooling = b ? false : radiator_was_cooling;
+						foreach (PartModule nativeRadiator in wrapper.FindNativeRadiatorsForReliability())
+						{
+							if (b)
+								wrapper.ClearRadiatorFluxForReliability(nativeRadiator);
+							nativeRadiator.isEnabled = !b;
+							nativeRadiator.enabled = !b;
+							SetRadiatorCoolingState(nativeRadiator, b ? false : radiator_was_cooling);
+						}
+					}
+					if (!b)
+						radiator_state_stored = false;
+					break;
+
+				case "SystemHeatRadiatorKerbalism":
+					// Reliability type is remapped to the Kerbalism sidecar; also shut down the
+					// native SystemHeat / stock radiator so loaded vessels stop rejecting heat.
+					foreach (PartModule m in modules)
+					{
+						SystemHeatRadiatorKerbalism wrapper = m as SystemHeatRadiatorKerbalism;
+						if (wrapper == null)
+							continue;
+
+						List<PartModule> nativeRadiators = wrapper.FindNativeRadiatorsForReliability();
+						PartModule nativeRadiator = nativeRadiators.Count > 0 ? nativeRadiators[0] : null;
+						if (b && !radiator_state_stored)
+						{
+							radiator_was_cooling = nativeRadiator != null
+								? GetRadiatorCoolingState(nativeRadiator, wrapper.IsCooling)
+								: wrapper.IsCooling;
+							radiator_state_stored = true;
+						}
+
+						foreach (PartModule radiator in nativeRadiators)
+						{
+							if (b)
+								wrapper.ClearRadiatorFluxForReliability(radiator);
+							radiator.isEnabled = !b;
+							radiator.enabled = !b;
+							SetRadiatorCoolingState(radiator, b ? false : radiator_was_cooling);
+						}
+						wrapper.IsCooling = b ? false : radiator_was_cooling;
+					}
+					if (!b)
+						radiator_state_stored = false;
 					break;
 
 				case "ModuleLight":
@@ -991,6 +1150,83 @@ namespace KERBALISM
 			}
 
 			API.Failure.Notify(part, type, b);
+		}
+
+		/// <summary>
+		/// When SystemHeatRadiatorKerbalism fails unloaded, also disable its native radiator snapshot
+		/// so packed vessels do not keep IsCooling / rejection state armed until reload.
+		/// </summary>
+		static void ProtoDisableSystemHeatNativeRadiators(ProtoPartSnapshot part)
+		{
+			// radiatorModuleName is not persistent on the wrapper; read from the part prefab.
+			string radiatorModuleName = "ModuleSystemHeatRadiator";
+			if (part.partPrefab != null)
+			{
+				SystemHeatRadiatorKerbalism prefabWrapper = part.partPrefab.FindModuleImplementing<SystemHeatRadiatorKerbalism>();
+				if (prefabWrapper != null && !string.IsNullOrEmpty(prefabWrapper.radiatorModuleName))
+					radiatorModuleName = prefabWrapper.radiatorModuleName;
+			}
+
+			foreach (ProtoPartModuleSnapshot wrapper in part.modules)
+			{
+				if (wrapper.moduleName == "SystemHeatRadiatorKerbalism")
+					Lib.Proto.Set(wrapper, "IsCooling", false);
+			}
+
+			foreach (ProtoPartModuleSnapshot native in part.modules)
+			{
+				if (native.moduleName != radiatorModuleName
+					&& !(radiatorModuleName == "ModuleSystemHeatRadiator" && native.moduleName == "ModuleActiveRadiator")
+					&& !(radiatorModuleName == "ModuleActiveRadiator" && native.moduleName == "ModuleSystemHeatRadiator")
+					&& !(radiatorModuleName == "USRadiatorSwitch" && native.moduleName == "ModuleSystemHeatRadiator"))
+					continue;
+
+				Lib.Proto.Set(native, "isEnabled", false);
+				Lib.Proto.Set(native, "IsCooling", false);
+				if (native.moduleName == "USRadiatorSwitch")
+					Lib.Proto.Set(native, "ActiveCooling", false);
+			}
+		}
+
+		void EnforceBrokenRadiatorState()
+		{
+			if (type == "USRadiatorSwitch")
+			{
+				foreach (SystemHeatRadiatorKerbalism wrapper in part.FindModulesImplementing<SystemHeatRadiatorKerbalism>())
+				{
+					if (wrapper.radiatorModuleName != "USRadiatorSwitch")
+						continue;
+
+					wrapper.enabled = false;
+					wrapper.isEnabled = false;
+					wrapper.IsCooling = false;
+					foreach (PartModule radiator in wrapper.FindNativeRadiatorsForReliability())
+					{
+						wrapper.ClearRadiatorFluxForReliability(radiator);
+						radiator.enabled = false;
+						radiator.isEnabled = false;
+						SetRadiatorCoolingState(radiator, false);
+					}
+				}
+			}
+			else if (type == "SystemHeatRadiatorKerbalism")
+			{
+				foreach (PartModule module in modules)
+				{
+					SystemHeatRadiatorKerbalism wrapper = module as SystemHeatRadiatorKerbalism;
+					if (wrapper == null)
+						continue;
+
+					wrapper.IsCooling = false;
+					foreach (PartModule radiator in wrapper.FindNativeRadiatorsForReliability())
+					{
+						wrapper.ClearRadiatorFluxForReliability(radiator);
+						radiator.enabled = false;
+						radiator.isEnabled = false;
+						SetRadiatorCoolingState(radiator, false);
+					}
+				}
+			}
 		}
 
 

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -165,6 +165,11 @@ namespace KERBALISM.Planner
 							case "ModuleActiveRadiator":
 								Process_radiator(m as ModuleActiveRadiator);
 								break;
+							case "USRadiatorSwitch":
+								// SystemHeatRadiatorKerbalism owns resource accounting when present.
+								if (p.FindModuleImplementing<SystemHeatRadiatorKerbalism>() == null)
+									Process_usRadiatorSwitch(m);
+								break;
 							case "ModuleWheelMotor":
 								Process_wheel_motor(m as ModuleWheelMotor);
 								break;
@@ -578,6 +583,50 @@ namespace KERBALISM.Planner
 			foreach (ModuleResource res in radiator.resHandler.inputResources)
 			{
 				Resource(res.name).Consume(res.rate, Local.Planner_source_radiator);
+			}
+		}
+
+		/// <summary>
+		/// Universal Storage 2 mesh-switch radiator. EC rate follows RadiatorEnergy[CurrentSelection]
+		/// (structural variants are 0). Falls back to ModuleActiveRadiator / resHandler.
+		/// </summary>
+		void Process_usRadiatorSwitch(PartModule module)
+		{
+			try
+			{
+				int selection = Lib.ReflectionValue<int>(module, "CurrentSelection");
+				string energyStr = Lib.ReflectionValue<string>(module, "RadiatorEnergy");
+				if (!string.IsNullOrEmpty(energyStr))
+				{
+					string[] energies = energyStr.Split(new char[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
+					if (selection >= 0 && selection < energies.Length
+						&& double.TryParse(energies[selection].Trim(), System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out double rate)
+						&& !double.IsNaN(rate) && !double.IsInfinity(rate))
+					{
+						if (rate > 0.0)
+							Resource("ElectricCharge").Consume(rate, Local.Planner_source_radiator);
+						return;
+					}
+				}
+			}
+			catch (Exception)
+			{
+				// fall through to resHandler
+			}
+
+			ModuleActiveRadiator stock = module as ModuleActiveRadiator;
+			if (stock != null)
+			{
+				Process_radiator(stock);
+				return;
+			}
+
+			if (module.resHandler != null)
+			{
+				foreach (ModuleResource res in module.resHandler.inputResources)
+				{
+					Resource(res.name).Consume(res.rate, Local.Planner_source_radiator);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes [#668]: Universal Storage 2 radiator support.

- Add `USRadiatorSwitch` planner / reliability / background handling
- Convert Advanced Sub-Satellite and Vostok shroud for SystemHeat
- Keep radiator cooling state consistent on failure, repair, and mesh variants
- Add Reliability for Elektron / Sabatier / Water Purifier / RTG, plus FluidSpectro science tweak