### PR TITLE
Fix editor PAW lag from Planner GetManifest polling

### DIFF
--- a/src/Kerbalism/Integrations/SystemHeat/Process/HarvesterSystemHeat.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/Process/HarvesterSystemHeat.cs
@@ -79,7 +79,7 @@ namespace KERBALISM
 
 			resourceChangeRequest.Add(new KeyValuePair<string, double>(
 				resource,
-				Harvester.AdjustedRate(this, engineerSpecs, GetEditorCrew(), simulated_abundance) * thermalEff));
+				Harvester.AdjustedRate(this, engineerSpecs, Lib.GetEditorCrew(), simulated_abundance) * thermalEff));
 
 			return title;
 		}
@@ -133,14 +133,6 @@ namespace KERBALISM
 				return;
 			lastPlannerThermalEff = thermalEff;
 			Lib.RefreshPlanner();
-		}
-
-		private static List<ProtoCrewMember> GetEditorCrew()
-		{
-			if (KSP.UI.CrewAssignmentDialog.Instance == null)
-				return new List<ProtoCrewMember>();
-			VesselCrewManifest manifest = KSP.UI.CrewAssignmentDialog.Instance.GetManifest();
-			return manifest != null ? manifest.GetAllCrew(false).FindAll(k => k != null) : new List<ProtoCrewMember>();
 		}
 	}
 }

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -1786,6 +1786,38 @@ namespace KERBALISM
 			return 0;
 		}
 
+		/// <summary>
+		/// Cached editor crew manifest. Prefer this over <c>CrewAssignmentDialog.GetManifest()</c>,
+		/// which is extremely expensive since KSP 1.11 (inventories) and can dirty PAWs every call.
+		/// See https://github.com/Kerbalism/Kerbalism/issues/864
+		/// </summary>
+		public static VesselCrewManifest EditorShipManifest => ShipConstruction.ShipManifest;
+
+		private static int editorCrewCacheFrame = -1;
+		private static List<ProtoCrewMember> editorCrewCache = new List<ProtoCrewMember>();
+
+		/// <summary>
+		/// Assigned editor crew members (non-null seats only), or an empty list.
+		/// The result is cached for the current Unity frame and must not be modified by callers.
+		/// </summary>
+		public static List<ProtoCrewMember> GetEditorCrew()
+		{
+			int frame = Time.frameCount;
+			if (editorCrewCacheFrame == frame)
+				return editorCrewCache;
+
+			editorCrewCacheFrame = frame;
+			VesselCrewManifest manifest = ShipConstruction.ShipManifest;
+			if (manifest == null)
+			{
+				editorCrewCache = new List<ProtoCrewMember>();
+				return editorCrewCache;
+			}
+
+			editorCrewCache = manifest.GetAllCrew(false).FindAll(k => k != null);
+			return editorCrewCache;
+		}
+
 		///<summary>return true if a part is manned, even in the editor</summary>
 		public static bool IsCrewed(Part p)
 		{

--- a/src/Kerbalism/UI/Planner/Planner.cs
+++ b/src/Kerbalism/UI/Planner/Planner.cs
@@ -120,8 +120,9 @@ namespace KERBALISM.Planner
 		///<summary> Run simulators and update the planner UI sub-panels </summary>
 		internal static void Update()
 		{
-			// get vessel crew manifest
-			VesselCrewManifest manifest = KSP.UI.CrewAssignmentDialog.Instance.GetManifest();
+			// Use the cached editor manifest. CrewAssignmentDialog.GetManifest() is extremely
+			// expensive since KSP 1.11 and was forcing PAW rebuilds every frame while Planner is open.
+			VesselCrewManifest manifest = Lib.EditorShipManifest;
 			if (manifest == null)
 				return;
 

--- a/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
+++ b/src/Kerbalism/UI/Planner/VesselAnalyzer.cs
@@ -29,8 +29,8 @@ namespace KERBALISM.Planner
 		{
 			// get number of kerbals assigned to the vessel in the editor
 			// note: crew manifest is not reset after root part is deleted
-			VesselCrewManifest manifest = KSP.UI.CrewAssignmentDialog.Instance.GetManifest();
-			crew = manifest.GetAllCrew(false).FindAll(k => k != null);
+			// Prefer ShipConstruction.ShipManifest over CrewAssignmentDialog.GetManifest() (#864)
+			crew = Lib.GetEditorCrew();
 			crew_count = (uint)crew.Count;
 			crew_engineer = crew.Find(k => k.trait == "Engineer") != null;
 			crew_scientist = crew.Find(k => k.trait == "Scientist") != null;


### PR DESCRIPTION
- Stop calling `CrewAssignmentDialog.GetManifest()` from Planner / VesselAnalyzer / SystemHeat Harvester paths.
- Prefer the cached `ShipConstruction.ShipManifest` via `Lib.EditorShipManifest` / `Lib.GetEditorCrew()`.
- Frame-cache editor crew lists so Planner simulation loops reuse one result per frame.

This finishes the leftover hot path from #864: `Lib.CrewCount()` was already fixed, but Planner still polled `GetManifest()` every frame while open, which could dirty PAWs and tank FPS with a Kerbalism-heavy part PAW. Same root cause also matches the crew-tab performance issue in #1076.