### PR TITLE
Fix Auto control for Habitat centrifuges (#1029)

### DIFF
--- a/src/Kerbalism/Automation/Computer.cs
+++ b/src/Kerbalism/Automation/Computer.cs
@@ -270,6 +270,7 @@ namespace KERBALISM
 						}
 						case "Sickbay":                      device = new SickbayDevice(m as Sickbay);                           break;
 						case "Greenhouse":                   device = new GreenhouseDevice(m as Greenhouse);                     break;
+						case "Habitat":                      device = new HabitatDevice(m as Habitat);                           break;
 						case "GravityRing":                  device = new RingDevice(m as GravityRing);                          break;
 						case "Emitter":                      device = new EmitterDevice(m as Emitter);                           break;
 						case "Harvester":                    device = new HarvesterDevice(m as Harvester);                         break;
@@ -345,6 +346,7 @@ namespace KERBALISM
 								break;
 							case "Sickbay":                      device = new ProtoSickbayDevice(module_prefab as Sickbay, p, m);                  break;
 							case "Greenhouse":                   device = new ProtoGreenhouseDevice(module_prefab as Greenhouse, p, m);            break;
+							case "Habitat":                      device = new ProtoHabitatDevice(module_prefab as Habitat, p, m);                  break;
 							case "GravityRing":                  device = new ProtoRingDevice(module_prefab as GravityRing, p, m);                 break;
 							case "Emitter":                      device = new ProtoEmitterDevice(module_prefab as Emitter, p, m);                  break;
 							case "Harvester":                    device = new ProtoHarvesterDevice(module_prefab as Harvester, p, m);              break;

--- a/src/Kerbalism/Automation/Devices/Habitat.cs
+++ b/src/Kerbalism/Automation/Devices/Habitat.cs
@@ -1,0 +1,81 @@
+namespace KERBALISM
+{
+	public sealed class HabitatDevice : LoadedDevice<Habitat>
+	{
+		private readonly bool hasGravityRing;
+
+		public HabitatDevice(Habitat module) : base(module)
+		{
+			hasGravityRing = module.part.FindModuleImplementing<GravityRing>() != null;
+		}
+
+		// keep Name English for stable device Id hashing across languages
+		public override string Name => "habitat";
+		// Centrifuges previously appeared as "gravity ring" in Auto; keep that label while
+		// routing control through Habitat's inflate/enable flow.
+		public override string DisplayName => hasGravityRing ? Local.Brokers_GravityRing : Local.StatuToggle_Habitat;
+
+		public override bool IsVisible => module.toggle && module.state != Habitat.State.evaKerbal;
+
+		public override string Status => Habitat.AutomationStatus(module.state);
+
+		public override void Ctrl(bool value)
+		{
+			if (!IsVisible) return;
+			if (Habitat.IsEnabledOrEnabling(module.state) == value) return;
+			module.Toggle();
+		}
+
+		public override void Toggle()
+		{
+			if (!IsVisible) return;
+			module.Toggle();
+		}
+	}
+
+	public sealed class ProtoHabitatDevice : ProtoDevice<Habitat>
+	{
+		private readonly bool hasGravityRing;
+
+		public ProtoHabitatDevice(Habitat prefab, ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot protoModule)
+			: base(prefab, protoPart, protoModule)
+		{
+			hasGravityRing = protoPart.FindModule("GravityRing") != null;
+		}
+
+		// keep Name English for stable device Id hashing across languages
+		public override string Name => "habitat";
+		public override string DisplayName => hasGravityRing ? Local.Brokers_GravityRing : Local.StatuToggle_Habitat;
+
+		public override bool IsVisible
+		{
+			get
+			{
+				if (!prefab.toggle) return false;
+				Habitat.State state = Lib.Proto.GetEnum(protoModule, nameof(Habitat.state), Habitat.State.disabled);
+				return state != Habitat.State.evaKerbal;
+			}
+		}
+
+		public override string Status
+		{
+			get
+			{
+				Habitat.State state = Lib.Proto.GetEnum(protoModule, nameof(Habitat.state), Habitat.State.disabled);
+				return Habitat.AutomationStatus(state);
+			}
+		}
+
+		public override void Ctrl(bool value)
+		{
+			if (!IsVisible) return;
+			Habitat.ProtoCtrl(protoPart, protoModule, prefab, value);
+		}
+
+		public override void Toggle()
+		{
+			if (!IsVisible) return;
+			Habitat.ProtoToggle(protoPart, protoModule, prefab);
+		}
+	}
+}

--- a/src/Kerbalism/Automation/Devices/Ring.cs
+++ b/src/Kerbalism/Automation/Devices/Ring.cs
@@ -2,7 +2,13 @@ namespace KERBALISM
 {
 	public sealed class RingDevice : LoadedDevice<GravityRing>
 	{
-		public RingDevice(GravityRing module) : base(module) { }
+		private readonly Habitat habitat;
+
+		public RingDevice(GravityRing module) : base(module)
+		{
+			if (module.isDeployedByHabitat)
+				habitat = module.part.FindModuleImplementing<Habitat>();
+		}
 
 		// keep Name English for stable device Id hashing across languages
 		public override string Name => "gravity ring";
@@ -15,7 +21,14 @@ namespace KERBALISM
 
 		public override void Ctrl(bool value)
 		{
-			if (module.isDeployedByHabitat) return;
+			// Keep the old gravity-ring device Id as a hidden compatibility alias for
+			// persisted scripts, but route control through Habitat's state machine.
+			if (module.isDeployedByHabitat)
+			{
+				if (habitat != null && Habitat.IsEnabledOrEnabling(habitat.state) != value)
+					habitat.Toggle();
+				return;
+			}
 			if (module.deployed != value)
 			{
 				module.Toggle();
@@ -32,11 +45,16 @@ namespace KERBALISM
 	public sealed class ProtoRingDevice : ProtoDevice<GravityRing>
 	{
 		private readonly bool deployedByHabitat;
+		private readonly Habitat habitatPrefab;
+		private readonly ProtoPartModuleSnapshot habitatModule;
 
 		public ProtoRingDevice(GravityRing prefab, ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot protoModule)
 			: base(prefab, protoPart, protoModule)
 		{
-			deployedByHabitat = protoPart.FindModule("Habitat") != null;
+			habitatModule = protoPart.FindModule("Habitat");
+			deployedByHabitat = habitatModule != null;
+			if (deployedByHabitat)
+				habitatPrefab = prefab.part.FindModuleImplementing<Habitat>();
 		}
 
 		// keep Name English for stable device Id hashing across languages
@@ -50,7 +68,14 @@ namespace KERBALISM
 
 		public override void Ctrl(bool value)
 		{
-			if (deployedByHabitat) return;
+			// Keep the old gravity-ring device Id as a hidden compatibility alias for
+			// persisted scripts, but route control through Habitat's state machine.
+			if (deployedByHabitat)
+			{
+				if (habitatPrefab != null)
+					Habitat.ProtoCtrl(protoPart, habitatModule, habitatPrefab, value);
+				return;
+			}
 			Lib.Proto.Set(protoModule, "deployed", value);
 		}
 

--- a/src/Kerbalism/Automation/Devices/Ring.cs
+++ b/src/Kerbalism/Automation/Devices/Ring.cs
@@ -1,13 +1,5 @@
-using System;
-using System.Collections.Generic;
-using UnityEngine;
-using KSP.Localization;
-
-
 namespace KERBALISM
 {
-
-
 	public sealed class RingDevice : LoadedDevice<GravityRing>
 	{
 		public RingDevice(GravityRing module) : base(module) { }
@@ -16,10 +8,14 @@ namespace KERBALISM
 		public override string Name => "gravity ring";
 		public override string DisplayName => Local.Brokers_GravityRing;
 
+		// Habitat-owned rings must be controlled via HabitatDevice (inflate/enable flow)
+		public override bool IsVisible => !module.isDeployedByHabitat;
+
 		public override string Status => Lib.Color(module.deployed, Local.Generic_DEPLOYED, Lib.Kolor.Green, Local.Generic_RETRACTED, Lib.Kolor.Yellow);
 
 		public override void Ctrl(bool value)
 		{
+			if (module.isDeployedByHabitat) return;
 			if (module.deployed != value)
 			{
 				module.Toggle();
@@ -35,17 +31,26 @@ namespace KERBALISM
 
 	public sealed class ProtoRingDevice : ProtoDevice<GravityRing>
 	{
+		private readonly bool deployedByHabitat;
+
 		public ProtoRingDevice(GravityRing prefab, ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot protoModule)
-			: base(prefab, protoPart, protoModule) { }
+			: base(prefab, protoPart, protoModule)
+		{
+			deployedByHabitat = protoPart.FindModule("Habitat") != null;
+		}
 
 		// keep Name English for stable device Id hashing across languages
 		public override string Name => "gravity ring";
 		public override string DisplayName => Local.Brokers_GravityRing;
 
+		// Habitat-owned rings must be controlled via HabitatDevice (inflate/enable flow)
+		public override bool IsVisible => !deployedByHabitat;
+
 		public override string Status => Lib.Color(Lib.Proto.GetBool(protoModule, "deployed"), Local.Generic_DEPLOYED, Lib.Kolor.Green, Local.Generic_RETRACTED, Lib.Kolor.Yellow);
 
 		public override void Ctrl(bool value)
 		{
+			if (deployedByHabitat) return;
 			Lib.Proto.Set(protoModule, "deployed", value);
 		}
 
@@ -54,6 +59,4 @@ namespace KERBALISM
 			Ctrl(!Lib.Proto.GetBool(protoModule, "deployed"));
 		}
 	}
-
-
-} // KERBALISM
+}

--- a/src/Kerbalism/Database/VesselHabitatInfo.cs
+++ b/src/Kerbalism/Database/VesselHabitatInfo.cs
@@ -459,6 +459,7 @@ namespace KERBALISM
 		public abstract bool NonPressurizable { get; }
 		public abstract bool InflateRequiresPressure { get; }
 		public abstract double Surface { get; }
+		public abstract void SetGravityRingDeployed(bool deployed);
 	}
 
 	public sealed class LoadedHabitat : HabitatWrapper
@@ -470,6 +471,13 @@ namespace KERBALISM
 		public override bool NonPressurizable => hab.nonPressurizable;
 		public override bool InflateRequiresPressure => hab.inflateRequiresPressure;
 		public override double Surface => hab.surface;
+
+		public override void SetGravityRingDeployed(bool deployed)
+		{
+			GravityRing ring = hab.part.FindModuleImplementing<GravityRing>();
+			if (ring != null)
+				ring.deployed = deployed;
+		}
 
 		public static bool TryCreate(Habitat hab, out LoadedHabitat wrapper)
 		{
@@ -495,6 +503,7 @@ namespace KERBALISM
 
 	public sealed class UnloadedHabitat : HabitatWrapper
 	{
+		private ProtoPartSnapshot protoPart;
 		private ProtoPartModuleSnapshot hab;
 		private Habitat habPrefab;
 		private State _cachedState;
@@ -523,12 +532,20 @@ namespace KERBALISM
 		public override bool InflateRequiresPressure => habPrefab.inflateRequiresPressure;
 		public override double Surface => habPrefab.surface;
 
+		public override void SetGravityRingDeployed(bool deployed)
+		{
+			ProtoPartModuleSnapshot ring = protoPart.FindModule("GravityRing");
+			if (ring != null)
+				Lib.Proto.Set(ring, "deployed", deployed);
+		}
+
 		public UnloadedHabitat(ProtoPartSnapshot habPart, ProtoPartModuleSnapshot hab, Habitat habPrefab)
 		{
+			this.protoPart = habPart;
 			this.hab = hab;
 			this.habPrefab = habPrefab;
-			_cachedState = Lib.Proto.GetEnum<State>(hab, nameof(Habitat.state));
-			_cachedPerctDeployed = Lib.Proto.GetDouble(hab, nameof(Habitat.state));
+			_cachedState = Lib.Proto.GetEnum(hab, nameof(Habitat.state), State.disabled);
+			_cachedPerctDeployed = Lib.Proto.GetDouble(hab, nameof(Habitat.perctDeployed));
 			for (int i = habPart.resources.Count; i-- > 0;)
 			{
 				ProtoPartResourceSnapshot res = habPart.resources[i];

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using CommNet;
 using KSP.Localization;
+using KSP.UI;
 using KSP.UI.Screens;
 
 namespace KERBALISM
@@ -1792,6 +1793,81 @@ namespace KERBALISM
 		/// See https://github.com/Kerbalism/Kerbalism/issues/864
 		/// </summary>
 		public static VesselCrewManifest EditorShipManifest => ShipConstruction.ShipManifest;
+
+		/// <summary>
+		/// Rebuild <see cref="ShipConstruction.ShipManifest"/> from live <see cref="Part.CrewCapacity"/>
+		/// and refresh the crew assignment UI. Stock only does this on attach/detach; Habitat changes
+		/// capacity when enabled/disabled without that, so seats would not appear until re-attached.
+		/// </summary>
+		public static void RefreshEditorCrewAssignment()
+		{
+			if (!IsEditor())
+				return;
+			if (EditorLogic.fetch == null || EditorLogic.fetch.ship == null)
+				return;
+			if (CrewAssignmentDialog.Instance == null)
+				return;
+
+			VesselCrewManifest oldManifest = ShipConstruction.ShipManifest;
+			VesselCrewManifest newManifest = new VesselCrewManifest();
+
+			List<Part> shipParts = EditorLogic.fetch.ship.parts;
+			for (int i = 0; i < shipParts.Count; i++)
+			{
+				Part p = shipParts[i];
+				if (p.partInfo == null)
+					continue;
+
+				PartCrewManifest pcm = new PartCrewManifest(newManifest);
+				// Publicized references expose PartInfo/PartID as get-only; set backing fields.
+				ReflectionValue(pcm, "partInfo", p.partInfo);
+				ReflectionValue(pcm, "partID", p.craftID);
+
+				// Live capacity — Habitat zeros this while disabled / deploying / inflating
+				int crewCapacity = Math.Max(0, p.CrewCapacity);
+				pcm.partCrew = new string[crewCapacity];
+				for (int j = 0; j < crewCapacity; j++)
+					pcm.partCrew[j] = string.Empty;
+
+				newManifest.SetPartManifest(pcm.PartID, pcm);
+			}
+
+			if (oldManifest != null)
+			{
+				HashSet<uint> allPartIds = null;
+				int oldCount = oldManifest.PartManifests.Count;
+				for (int i = 0; i < oldCount; i++)
+				{
+					PartCrewManifest oldPcm = oldManifest.PartManifests[i];
+					if (oldPcm.partCrew == null || oldPcm.partCrew.Length == 0)
+						continue;
+
+					uint oldPartId = oldPcm.PartID;
+
+					if (allPartIds == null)
+					{
+						List<Part> allParts = Part.allParts;
+						allPartIds = new HashSet<uint>(allParts.Count);
+						for (int j = allParts.Count; j-- > 0;)
+							allPartIds.Add(allParts[j].craftID);
+					}
+
+					if (!allPartIds.Contains(oldPartId))
+						continue;
+
+					PartCrewManifest newPcm = newManifest.GetPartCrewManifest(oldPartId);
+					if (newPcm == null || newPcm.partCrew == null || newPcm.partCrew.Length == 0)
+						continue;
+
+					newManifest.UpdatePartManifest(oldPartId, oldPcm);
+				}
+			}
+
+			ShipConstruction.ShipManifest = newManifest;
+			editorCrewCacheFrame = -1;
+			CrewAssignmentDialog.Instance.RefreshCrewLists(newManifest, false, true);
+			GameEvents.onEditorShipCrewModified.Fire(newManifest);
+		}
 
 		private static int editorCrewCacheFrame = -1;
 		private static List<ProtoCrewMember> editorCrewCache = new List<ProtoCrewMember>();

--- a/src/Kerbalism/Modules/Habitat.cs
+++ b/src/Kerbalism/Modules/Habitat.cs
@@ -110,6 +110,9 @@ namespace KERBALISM
 			{
 				if (!(state == State.inflating || state == State.waitingForPressure))
 					return false;
+				// Equalize is flight-only; editor parts have no Vessel / ResourceCache entry
+				if (!Lib.IsFlight() || vessel == null)
+					return false;
 				ResourceInfo vesselAtmoRes = ResourceCache.GetResource(vessel, AtmoResName);
 				// don't allow unless decent pressurization capacity is active, or we are in a breathable atmo
 				if (vesselAtmoRes.Rate < 1.0 && !vessel.KerbalismData().EnvBreathable)
@@ -766,12 +769,128 @@ namespace KERBALISM
 			}
 		}
 
+		/// <summary>True when habitat is enabled or transitioning toward enabled.</summary>
+		internal static bool IsEnabledOrEnabling(State state)
+		{
+			switch (state)
+			{
+				case State.enabled:
+				case State.inflating:
+				case State.deploying:
+				case State.waitingForPressure:
+				case State.inflatingAndEqualizing:
+				case State.waitingForPressureAndEqualizing:
+					return true;
+				default:
+					return false;
+			}
+		}
+
+		internal static string AutomationStatus(State state)
+		{
+			switch (state)
+			{
+				case State.enabled:
+					return Lib.Color(Local.Generic_ENABLED, Lib.Kolor.Green);
+				case State.inflating:
+				case State.inflatingAndEqualizing:
+					return Lib.Color(Local.Habitat_inflating, Lib.Kolor.Yellow);
+				case State.deploying:
+					return Lib.Color(Local.Habitat_deploying, Lib.Kolor.Yellow);
+				case State.waitingForPressure:
+				case State.waitingForPressureAndEqualizing:
+					return Lib.Color(Local.Habitat_pressurizing, Lib.Kolor.Yellow);
+				case State.retracting:
+					return Lib.Color(Local.Habitat_retracting, Lib.Kolor.Yellow);
+				case State.waitingForGravityRing:
+					return Lib.Color(Local.Habitat_stopRotation, Lib.Kolor.Yellow);
+				default:
+					return Lib.Color(Local.Generic_DISABLED, Lib.Kolor.Yellow);
+			}
+		}
+
+		/// <summary>Auto / script control for unloaded habitats. Goes through inflate/enable flow.</summary>
+		internal static void ProtoCtrl(ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot protoModule, Habitat prefab, bool value)
+		{
+			if (!prefab.toggle) return;
+			State state = Lib.Proto.GetEnum(protoModule, nameof(Habitat.state), State.disabled);
+			if (state == State.evaKerbal) return;
+			if (IsEnabledOrEnabling(state) == value) return;
+			ProtoToggle(protoPart, protoModule, prefab);
+		}
+
+		/// <summary>Auto / script toggle for unloaded habitats. Mirrors <see cref="Toggle"/>.</summary>
+		internal static void ProtoToggle(ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot protoModule, Habitat prefab)
+		{
+			if (!prefab.toggle) return;
+
+			UnloadedHabitat hab = new UnloadedHabitat(protoPart, protoModule, prefab);
+			if (hab.AtmoResource == null || hab.WasteAtmoResource == null || hab.ShieldingResource == null)
+				return;
+
+			State state = hab.State;
+			bool deployable = PrefabIsDeployable(prefab);
+			bool crewed = protoPart.protoModuleCrew != null && protoPart.protoModuleCrew.Count > 0;
+
+			switch (state)
+			{
+				case State.enabled:
+					if (crewed) return;
+					if (deployable && prefab.canRetract)
+						BackgroundSetStateRetracting(hab);
+					else
+						BackgroundSetStateDisabled(hab);
+					break;
+				case State.disabled:
+					if (deployable && hab.PerctDeployed < 1.0)
+					{
+						if (prefab.inflateRequiresPressure)
+							BackgroundSetStateInflating(hab);
+						else
+							BackgroundSetStateDeploying(hab);
+					}
+					else
+					{
+						BackgroundSetStateEnabled(hab);
+					}
+					break;
+				case State.inflating:
+				case State.deploying:
+				case State.waitingForPressure:
+				case State.inflatingAndEqualizing:
+				case State.waitingForPressureAndEqualizing:
+					if (crewed) return;
+					if (prefab.canRetract)
+						BackgroundSetStateRetracting(hab);
+					else
+						BackgroundSetStateDisabled(hab);
+					break;
+				case State.retracting:
+				case State.waitingForGravityRing:
+					if (prefab.inflateRequiresPressure)
+						BackgroundSetStateInflating(hab);
+					else
+						BackgroundSetStateDeploying(hab);
+					break;
+			}
+		}
+
+		private static bool PrefabIsDeployable(Habitat prefab)
+		{
+			if (!string.IsNullOrEmpty(prefab.inflate))
+				return true;
+
+			GravityRing ring = prefab.part.FindModuleImplementing<GravityRing>();
+			return ring != null && !string.IsNullOrEmpty(ring.deploy);
+		}
+
 		private static void BackgroundSetStateEnabled(HabitatWrapper hab)
 		{
 			hab.State = State.enabled;
 			hab.AtmoResource.FlowState = !hab.NonPressurizable;
 			hab.WasteAtmoResource.FlowState = true;
 			hab.ShieldingResource.FlowState = true;
+			hab.SetGravityRingDeployed(true);
 		}
 
 		private static void BackgroundSetStateWaitingForPressure(HabitatWrapper hab)
@@ -780,6 +899,7 @@ namespace KERBALISM
 			hab.AtmoResource.FlowState = !hab.NonPressurizable;
 			hab.WasteAtmoResource.FlowState = false;
 			hab.ShieldingResource.FlowState = false;
+			hab.SetGravityRingDeployed(false);
 		}
 
 		private static void BackgroundSetStateDisabled(HabitatWrapper hab)
@@ -788,6 +908,25 @@ namespace KERBALISM
 			hab.AtmoResource.FlowState = false;
 			hab.WasteAtmoResource.FlowState = false;
 			hab.ShieldingResource.FlowState = false;
+			hab.SetGravityRingDeployed(false);
+		}
+
+		private static void BackgroundSetStateInflating(HabitatWrapper hab)
+		{
+			hab.State = State.inflating;
+			hab.AtmoResource.FlowState = true;
+			hab.WasteAtmoResource.FlowState = false;
+			hab.ShieldingResource.FlowState = false;
+			hab.SetGravityRingDeployed(false);
+		}
+
+		private static void BackgroundSetStateDeploying(HabitatWrapper hab)
+		{
+			hab.State = State.deploying;
+			hab.AtmoResource.FlowState = false;
+			hab.WasteAtmoResource.FlowState = false;
+			hab.ShieldingResource.FlowState = false;
+			hab.SetGravityRingDeployed(false);
 		}
 
 		private static void BackgroundSetStateRetracting(HabitatWrapper hab)
@@ -944,7 +1083,14 @@ namespace KERBALISM
 			}
 			else
 			{
+				// PartTweaked alone does not refresh Kerbalism Planner / crew UI.
+				// Deploy/inflate finish in FixedUpdate after Toggle(), so notify the ship when
+				// habitat resource flowState changes, and rebuild the crew manifest for the
+				// live CrewCapacity (stock only refreshes seats on attach/detach).
 				GameEvents.onEditorPartEvent.Fire(ConstructionEventType.PartTweaked, part);
+				if (EditorLogic.fetch != null && EditorLogic.fetch.ship != null)
+					GameEvents.onEditorShipModified.Fire(EditorLogic.fetch.ship);
+				Lib.RefreshEditorCrewAssignment();
 			}
 
 			UIPartActionWindow paw = part.GetVisiblePAW();
@@ -1020,7 +1166,7 @@ namespace KERBALISM
 					prefab.Resources.dict.Remove(Lib.GetDefinition(AtmoResName).id);
 					prefab.Resources.dict.Remove(Lib.GetDefinition(WasteAtmoResName).id);
 
-					habitat.surface = 1.5; // human spacesuit surface ~ 4 m²
+					habitat.surface = 1.5; // human spacesuit surface ~ 4 m?
 				}
 
 				habitat.state = State.evaKerbal;


### PR DESCRIPTION
- Fix #1029: Auto no longer toggles habitat centrifuges via GravityRing alone (which skipped inflate/enable and desynced firm-ground / living space).
- Control them through Habitat instead; keep the old `gravity ring` device id as a hidden alias so existing scripts still work.
- Also refresh editor crew seats when habitat capacity changes.