### PR TITLE
Remove dead SolarPanelFixer.OnSave VesselData rebuild (#616)

### DIFF
--- a/src/Kerbalism/Modules/SolarPanelFixer.cs
+++ b/src/Kerbalism/Modules/SolarPanelFixer.cs
@@ -241,24 +241,6 @@ namespace KERBALISM
 			rateFormat = "F3";
 		}
 
-		public override void OnSave(ConfigNode node)
-		{
-			// vessel can be null in OnSave (ex : on vessel creation)
-			if (!Lib.IsFlight()
-				|| vessel == null
-				|| !isInitialized
-				|| SolarPanel == null
-				|| !Lib.Landed(vessel)
-				|| exposureState == ExposureState.Disabled) // don't to broken panels ! (issue #492)
-				return;
-
-			// get vessel data
-			VesselData vd = vessel.KerbalismData();
-
-			// do nothing if vessel is invalid
-			if (!vd.IsSimulated) return;
-		}
-
 		public void Update()
 		{
 			// sanity check


### PR DESCRIPTION
## Summary
- Remove the empty `SolarPanelFixer.OnSave` override left after `persistentFactor` was dropped in #986.
- That override still called `vessel.KerbalismData()` during stock `ProtoVessel` construction (e.g. crash/decouple), which was the entry point for #616.
- The original NRE in `Lib.CrewCount(null)` was already fixed via #833 (`8b9ad661`); this cleans up the remaining unsafe call site.

## Context
On vessel create/crash, KSP builds `ProtoVessel` while modules save. The old `OnSave` path could create `VesselData` before `vessel.protoVessel` existed. After #833 that no longer CTDs, but the method had no remaining save work and only retained the side effect.

