### PR TITLE
Fix Sterling ISRU processes missing with RationalResourcesKerbalism (#1103)

### DIFF
--- a/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersMode0.cfg
+++ b/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersMode0.cfg
@@ -1,5 +1,5 @@
 // Fission Foundry
-@PART[strl-isru-circ-fif-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-fif-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -173,7 +173,7 @@
 }
 
 // Thermodyne
-@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleOverheatDisplay] {}
 	!MODULE[ModuleResourceConverter] {}
@@ -367,7 +367,7 @@
 
 }
 
-@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	MODULE
 	{
 		name = ProcessController
@@ -537,7 +537,7 @@
 }
 
 // Titan Foundry
-@PART[strl-isru-circ-tif-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-tif-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -584,7 +584,7 @@
 }
 
 // Molten Metal Foundry
-@PART[strl-isru-circ-mmf-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-mmf-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -769,7 +769,7 @@
 }
 
 // General Chemistry Center
-@PART[strl-isru-circ-gcc-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-gcc-???]:HAS[#RefineryMode[0]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -1301,7 +1301,7 @@
 
 }
 
-@PART[strl-isru-circ-???-375|strl-isru-circ-???-500]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-???-375|strl-isru-circ-???-500]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@MODULE[Configure],*
 	{
 		@slots = 2

--- a/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersMode1.cfg
+++ b/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersMode1.cfg
@@ -1,5 +1,5 @@
 // General Chemistry Center
-@PART[strl-isru-circ-gcc-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-gcc-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}

--- a/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersMode1_SystemHeat.cfg
+++ b/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersMode1_SystemHeat.cfg
@@ -1,5 +1,5 @@
 // Fission Foundry
-@PART[strl-isru-circ-fif-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-fif-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -647,7 +647,7 @@
 }
 
 // Thermodyne
-@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleOverheatDisplay] {}
 	!MODULE[ModuleResourceConverter] {}
@@ -1146,7 +1146,7 @@
 
 }
 
-@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-thd-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	MODULE
 	{
 		name = ModuleSystemHeatConverter
@@ -1642,7 +1642,7 @@
 }
 
 // Titan Foundry
-@PART[strl-isru-circ-tif-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-tif-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -1735,7 +1735,7 @@
 }
 
 // Molten Metal Foundry
-@PART[strl-isru-circ-mmf-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]{
+@PART[strl-isru-circ-mmf-???]:HAS[#RefineryMode[1]]:NEEDS[Kerbalism,SystemHeat,SterlingSystems,RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}

--- a/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersNoRR.cfg
+++ b/GameData/KerbalismConfig/Support/SterlingSystems/ConvertersNoRR.cfg
@@ -1,7 +1,7 @@
 // Circular refineries without Rational Resources.
 
 // Fission Foundry
-@PART[strl-isru-circ-fif-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]{
+@PART[strl-isru-circ-fif-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -175,7 +175,7 @@
 }
 
 // General Chemistry Center
-@PART[strl-isru-circ-gcc-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]{
+@PART[strl-isru-circ-gcc-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -627,7 +627,7 @@
 }
 
 // Molten Metal Foundry
-@PART[strl-isru-circ-mmf-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]{
+@PART[strl-isru-circ-mmf-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -832,7 +832,7 @@
 }
 
 // Titan Foundry
-@PART[strl-isru-circ-tif-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,FarFutureTechnologies,!RationalResourcesKerbalism]{
+@PART[strl-isru-circ-tif-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,FarFutureTechnologies,!RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -879,7 +879,7 @@
 }
 
 // Thermodyne
-@PART[strl-isru-circ-thd-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]{
+@PART[strl-isru-circ-thd-???]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@tags ^= :$: _kerbalism
 	!MODULE[ModuleResourceConverter],* {}
 	!MODULE[ModuleOverheatDisplay] {}
@@ -1227,7 +1227,7 @@
 	}
 }
 
-@PART[strl-isru-circ-???-375|strl-isru-circ-???-500]:HAS[@MODULE[Configure]]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]{
+@PART[strl-isru-circ-???-375|strl-isru-circ-???-500]:HAS[@MODULE[Configure]]:NEEDS[Kerbalism,SterlingSystems,CommunityResourcePack,!RationalResourcesKerbalism]:FOR[KerbalismConfig]{
 	@MODULE[Configure],*
 	{
 		@slots = 2


### PR DESCRIPTION
## Summary
- Add `:FOR[KerbalismConfig]` to Sterling `ConvertersMode0` / `Mode1` / `NoRR` patches so they run after `01_ModeSelect` sets `RefineryMode`.
- Fixes circular refineries having no Kerbalism processes when Rational Resources Kerbalism is installed.
