### PR TITLE
Fix engineer specialist bonus for Process-based ISRU converters (#1100)

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -342,6 +342,7 @@ Profile
     name = water electrolysis
     title = #KERBALISM_Process_WaterElectrolysis
     modifier = _WaterElectrolysis
+    specialist_bonus = true
     input = ElectricCharge@2.4026694940
     input = Water@0.0008043014
     output = Hydrogen@1.0011122892
@@ -354,6 +355,7 @@ Profile
     name = waste incinerator
     title = #KERBALISM_Process_WasteIncinerator
     modifier = _WasteIncinerator
+    specialist_bonus = true
     input = Waste@0.0001082667 // H18C82
     input = Oxygen@0.1589194249
     output = CarbonDioxide@0.1497439605
@@ -367,6 +369,7 @@ Profile
     name = sabatier process   // LiquidFuel output balanced to match Anthraquinone Oxidizer output
     title = #KERBALISM_Process_SabatierProcess
     modifier = _Sabatier
+    specialist_bonus = true
     input = ElectricCharge@0.008082126 // calculated using 3.256 J/(g K) (sustained heating to 575K)
     input = CarbonDioxide@3.490273221
     input = Hydrogen@13.87826691
@@ -380,6 +383,7 @@ Profile
     name = haber process
     title = #KERBALISM_Process_HaberProcess
     modifier = _Haber
+    specialist_bonus = true
     input = ElectricCharge@0.00594773  // calculated using 2.9367 J/(g K) (sustained heating to 700K)
     input = Nitrogen@1.3315033550
     input = Hydrogen@4.0
@@ -391,6 +395,7 @@ Profile
     name = anthraquinone process   // Oxidizer output balanced to match Sabatier LiquidFuel output
     title = #KERBALISM_Process_AnthraquinoneProcess
     modifier = _Anthraquinone
+    specialist_bonus = true
     input = Hydrogen@2.0
     input = Oxygen@2.0241355411
     output = Oxidizer@0.0006067662   // (HydrogenPeroxide@0.0020922973) Note that Oxidizer has a density of 5Kg/Unit
@@ -403,6 +408,7 @@ Profile
     name = oxidizer decomposition
     title = #KERBALISM_Process_OxidizerDecomposition
     modifier = _OxDecomp
+    specialist_bonus = true
     input = Oxidizer@0.0006067662
     output = Water@0.0016068155
     output = Oxygen@1.012067733
@@ -414,6 +420,7 @@ Profile
     name = hydrazine production   // Peroxide process
     title = #KERBALISM_Process_HydrazineProduction
     modifier = _HydrazineProduction
+    specialist_bonus = true
     input = ElectricCharge@0.023871584  // calculated using 6.99 J/(g K) (sustained heating to 460K)
     input = Ammonia@4.7203389609
     input = Oxidizer@0.0014500000   // (HydrogenPeroxide@0.0050000000) Note that Oxidizer has a density of 5Kg/Unit
@@ -428,6 +435,7 @@ Profile
     name = hydrazine production N2 injection   // NitroPeroxide process
     title = #KERBALISM_Process_HydrazineProductionN2
     modifier = _NitroHydrazine
+    specialist_bonus = true
     input = ElectricCharge@0.059678961  // calculated using 6.99 J/(g K) (sustained heating to 460K)
     input = Ammonia@4.7203389609
     input = Oxidizer@0.0014500000   // (HydrogenPeroxide@0.0050000000) Note that Oxidizer has a density of 5Kg/Unit
@@ -442,6 +450,7 @@ Profile
     name = solid oxide electrolysis
     title = #KERBALISM_Process_SolidOxideElectrolysis
     modifier = _SOE
+    specialist_bonus = true
     input = ElectricCharge@0.010835259   // calculated using 10.1749 J/(g K)  (sustained heating to 1125K)
     input = CarbonDioxide@2.0
     output = Oxygen@2.0121270980
@@ -454,6 +463,7 @@ Profile
     name = molten regolith electrolysis
     title = #KERBALISM_Process_MoltenRegolithElectrolysis
     modifier = _MRE
+    specialist_bonus = true
     input = ElectricCharge@2.0 // 2 kW MRE reactor at 2300 K with heat corrosion resistant crucible
     input = Ore@0.00006342
     output = Oxygen@0.088843           // 42% of regolith is O2
@@ -467,6 +477,7 @@ Profile
     name = selective catalytic oxidation
     title = #KERBALISM_Process_SelectiveCatalyticOxidation
     modifier = _SCO
+    specialist_bonus = true
     input = ElectricCharge@0.007166717  // calculated using 2.9367 J/(g K) (sustained heating to 700K)
     input = Ammonia@2.0
     input = Oxygen@1.5371075987

--- a/GameData/KerbalismConfig/Settings.cfg
+++ b/GameData/KerbalismConfig/Settings.cfg
@@ -37,6 +37,8 @@ Kerbalism
   MaxLaborartoryBonus = 2.0           // Laboratory efficiency gain will never exceed this limit
   HarvesterCrewLevelBonus = 0.1       // Harvester efficiency gain for each level of an engineer on the vessel
   MaxHarvesterBonus = 1.5             // Harvester efficiency gain will never exceed this limit
+  ProcessCrewLevelBonus = 0.1         // Process efficiency gain for each level of an engineer (processes with specialist_bonus = true)
+  MaxProcessBonus = 1.5               // Process efficiency gain will never exceed this limit
 
   // misc
   EnforceCoherency = true             // detect and avoid issues at high timewarp in external modules

--- a/GameData/KerbalismConfig/Support/CryoTanks.cfg
+++ b/GameData/KerbalismConfig/Support/CryoTanks.cfg
@@ -67,6 +67,7 @@ Profile
 	{
 		name = CO2 methanation
 		modifier = _CO2Methanation
+		specialist_bonus = true
 		input = ElectricCharge@2.9		// 0.8 Wh ÷ 0.2778 ≈ 2.9 EC
 		input = CarbonDioxide@0.044		// 1 mol CO₂ (44 g/mol)
 		input = Hydrogen@0.008			// 4 mol H₂ (2 g/mol each)
@@ -81,6 +82,7 @@ Profile
 	{
 		name = methane pyrolosis
 		modifier = _CH4Pyrolosis
+		specialist_bonus = true
 		input = ElectricCharge@9.0		// 2.5 Wh ÷ 0.2778 ≈ 9.0 EC (Higher energy for thermal decomposition)
 		input = LqdMethane@0.016		// 1 mol CH₄ (16 g/mol)
 		output = Hydrogen@0.008			// 2 mol H₂ (2 g/mol each)
@@ -95,6 +97,7 @@ Profile
 	{
 		name = SE-RWGS
 		modifier = _RWGS
+		specialist_bonus = true
 		input = ElectricCharge@54.0		// 15.0 Wh ÷ 0.2778 ≈ 54.0 EC (High temperature process requires more energy)
 		input = CarbonDioxide@0.044		// 1 mol CO₂ (44 g/mol)
 		input = Hydrogen@0.008			// 4 mol H₂ (2 g/mol each)
@@ -110,6 +113,7 @@ Profile
 	{
 		name = algae bioreactor
 		modifier = _algae
+		specialist_bonus = true
 		input = ElectricCharge@1.8		// 0.5 Wh ÷ 0.2778 ≈ 1.8 EC (Energy for artificial lighting and pumps)
 		input = CarbonDioxide@0.044		// 1 mol CO₂ (44 g/mol)
 		input = WasteWater@0.018		// 1 mol H₂O (18 g/mol)

--- a/GameData/KerbalismConfig/Support/FarFutureTechnologies.cfg
+++ b/GameData/KerbalismConfig/Support/FarFutureTechnologies.cfg
@@ -62,6 +62,7 @@ Profile
 		name = FFTAntimatterLight
 		title = #KERBALISM_BranchLoc_Antimatter_Factory_Light_Elements
 		modifier = _FFTAMLite
+		specialist_bonus = true
 		input = LqdHydrogen@1
 		input = ElectricCharge@10000
 		output = Antimatter@5
@@ -72,6 +73,7 @@ Profile
 		name = FFTAntimatterHeavy
 		title = #KERBALISM_BranchLoc_Antimatter_Factory_Heavy_Elements
 		modifier = _FFTAMHeavy
+		specialist_bonus = true
 		input = FissionPellets@1
 		input = ElectricCharge@10000
 		output = Antimatter@500
@@ -82,6 +84,7 @@ Profile
 		name = FFTNuclearSaltWater
 		title = #KERBALISM_BranchLoc_Nuclear_Salt_Water
 		modifier = _FFTNSW
+		specialist_bonus = true
 		input = Ore@1
 		input = EnrichedUranium@0.005
 		input = ElectricCharge@15
@@ -93,6 +96,7 @@ Profile
 		name = FFTFissionDust
 		title = #KERBALISM_BranchLoc_Fission_Dust
 		modifier = _FFTFissionDust
+		specialist_bonus = true
 		input = EnrichedUranium@1
 		input = ElectricCharge@150
 		output = FissionParticles@10
@@ -103,6 +107,7 @@ Profile
 		name = FFTFissionPellets
 		title = #KERBALISM_BranchLoc_Fission_Pellets
 		modifier = _FFTFissionPellets
+		specialist_bonus = true
 		input = EnrichedUranium@1
 		input = ElectricCharge@150
 		output = FissionPellets@10

--- a/GameData/KerbalismConfig/Support/NFElectric.cfg
+++ b/GameData/KerbalismConfig/Support/NFElectric.cfg
@@ -30,6 +30,7 @@ Profile
 		name = nfe depleted fuel reprocess
 		title = #KERBALISM_NFE_UraniumReprocessor_title
 		modifier = _NfeDepletedReprocess
+		specialist_bonus = true
 		input = DepletedFuel@0.01
 		input = ElectricCharge@20
 		output = EnrichedUranium@0.005
@@ -41,6 +42,7 @@ Profile
 		name = nfe xenon extract
 		title = #KERBALISM_NFE_XenonExtractor_title
 		modifier = _NfeXeExtract
+		specialist_bonus = true
 		input = DepletedFuel@0.001
 		input = ElectricCharge@10
 		output = XenonGas@0.025
@@ -52,6 +54,7 @@ Profile
 		name = nfe ore refine
 		title = #KERBALISM_NFE_UraniumExtractor_title
 		modifier = _NfeOreRefine
+		specialist_bonus = true
 		input = Ore@0.1
 		input = ElectricCharge@20
 		output = EnrichedUranium@0.0001

--- a/GameData/KerbalismConfig/Support/SterlingSystems/Profile.cfg
+++ b/GameData/KerbalismConfig/Support/SterlingSystems/Profile.cfg
@@ -47,6 +47,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Fissile_Fuel
 		Tag = SS
 		modifier = _FiF
+		specialist_bonus = true
 		input = ElectricCharge@60.0
 		input = Uraninite@0.072
 		input = Minerals@1.04062
@@ -64,6 +65,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Refresh_Fizzled_Fuel
 		tag = SS
 		modifier = _RFiF
+		specialist_bonus = true
 		input = ElectricCharge@30.0
 		input = Uraninite@0.072
 		input = FizzledFuel@0.53074
@@ -77,6 +79,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Fissile_Pebbles
 		tag = SS
 		modifier = _FiP
+		specialist_bonus = true
 		input = ElectricCharge@30.0
 		input = Uraninite@0.10801
 		input = Silicon@0.03618
@@ -91,6 +94,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Uranium_Refiner
 		tag = SS
 		modifier = _UR
+		specialist_bonus = true
 		input = ElectricCharge@18.0
 		input = Uraninite@0.0015
 		output = EnrichedUranium@0.001
@@ -101,6 +105,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_FFT_Orion_Pulse_Crafting
 		Tag = SS
 		modifier = _FFTOrionPulse
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Metals@0.0002 // 50% efficient
 		input = RareMetals@0.00056 // 50% efficient
@@ -115,6 +120,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Uranium_Salter
 		tag = SS
 		modifier = _US
+		specialist_bonus = true
 		input = EnrichedUranium@0.0002
 		input = Water@1.0
 		input = ElectricCharge@18.0
@@ -126,6 +132,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Recycle_Depleted_Uranium
 		tag = SS
 		modifier = _RDUU
+		specialist_bonus = true
 		input = DepletedFuel@0.001
 		input = ElectricCharge@18.0
 		output = EnrichedUranium@0.0005
@@ -354,6 +361,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Fusion_Pellets
 		tag = SS
 		modifier = _FusionPellets
+		specialist_bonus = true
 		input = LqdDeuterium@0.1
 		input = LqdHe3@0.4
 		input = ElectricCharge@50
@@ -371,6 +379,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_True_Sabatier_Process
 		Tag = SS
 		modifier = _TrueSabatierProcess
+		specialist_bonus = true
 		input = ElectricCharge@0.008082126
 		input = CarbonDioxide@3.490273221
 		input = Hydrogen@13.87826691
@@ -384,6 +393,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Make_Konkrete
 		tag = SS
 		modifier = _MakeKonkrete
+		specialist_bonus = true
 		input = ElectricCharge@30
 		input = Water@0.50
 		input = Minerals@0.10
@@ -395,6 +405,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Rock_Melter
 		tag = SS
 		modifier = _RockMelter
+		specialist_bonus = true
 		input = ElectricCharge@100
 		input = Rock@0.50
 		output = Konkrete@0.25
@@ -405,6 +416,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_OPAL_Processor
 		tag = SS
 		modifier = _OPALProcessor
+		specialist_bonus = true
 		input = ElectricCharge@15
 		input = Ore@0.0014
 		output = Water@0.00036
@@ -415,6 +427,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Coolant_Processor
 		tag = SS
 		modifier = _CoolantProcessor
+		specialist_bonus = true
 		input = ElectricCharge@30
 		input = Water@1.0
 		input = Ore@5.0
@@ -428,6 +441,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Ammonia_Brewer
 		tag = CRP
 		modifier = _AmmoniaBrew
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = LqdHydrogen@0.8536
 		input = LqdNitrogen@0.3396
@@ -439,6 +453,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Ammonia_to_MonoPropellant
 		tag = CRP
 		modifier = _AmmoniaToMono
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = LqdAmmonia@0.4851
 		output = MonoPropellant@0.0427
@@ -451,6 +466,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Carbon_Fuser
 		tag = CRP
 		modifier = _CarbonFuser
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Carbon@0.024
 		input = Oxygen@22.69504
@@ -462,6 +478,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Carbon_Dioxide_Splitter
 		tag = CRP
 		modifier = _SplitterCO2
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = CarbonDioxide@22.5818
 		output = Oxygen@22.69504
@@ -474,6 +491,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Carbon_Monoxide_A
 		tag = CRP
 		modifier = _CarbonMonoA
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = CarbonDioxide@2255.7663
 		output = Oxygen@22.69504
@@ -486,6 +504,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Carbon_Monoxide_B
 		tag = CRP
 		modifier = _CarbonMonoB
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Carbon@0.5719
 		input = Water@1.8020
@@ -499,6 +518,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Hydrates_Splitter
 		tag = CRP
 		modifier = _SplitterHydrates
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Hydrates@0.3014
 		output = Water@0.209
@@ -514,6 +534,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Methane_Splitter
 		tag = CRP
 		modifier = _SplitterCH4
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = LqdMethane@0.3771
 		output = Hydrogen@449.3882
@@ -526,6 +547,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Ore_Splitter
 		tag = CRP
 		modifier = _SplitterOre
+		specialist_bonus = true
 		input = ElectricCharge@0.0084
 		input = Ore@0.4144
 		output = Oxygen@1361.7024
@@ -538,6 +560,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Water_Splitter
 		tag = CRP
 		modifier = _SplitterH2O
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Water@1.8
 		output = Hydrogen@4493.882
@@ -553,6 +576,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Alumina_Splitter
 		tag = CRP
 		modifier = _SplitterAl2O3
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Alumina@0.2562
 		output = Aluminium@0.1948
@@ -565,6 +589,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Monazite_Splitter
 		tag = CRP
 		modifier = _SplitterMona
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Monazite@0.15005
 		output = Oxygen@90.78014
@@ -578,6 +603,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Silicates_Splitter
 		tag = CRP
 		modifier = _SplitterSilica
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Silicates@0.0609
 		output = Silicon@0.0241
@@ -590,6 +616,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Spodumene_Splitter
 		tag = CRP
 		modifier = _SplitterSpod
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = Spodumene@0.6
 		output = Lithium@0.13
@@ -603,6 +630,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Minerals_Splitter
 		tag = CRP
 		modifier = _SplitterMins
+		specialist_bonus = true
 		input = ElectricCharge@60
 		input = Minerals@0.25495
 		output = LqdFluorine@0.02525
@@ -619,6 +647,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_ExoticMinerals_Splitter
 		tag = CRP
 		modifier = _SplitterExMins
+		specialist_bonus = true
 		input = ElectricCharge@60
 		input = ExoticMinerals@0.36358
 		output = LqdFluorine@0.02525
@@ -635,6 +664,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Metals_Smelter
 		tag = CRP
 		modifier = _ECHeatedMetalSmelter
+		specialist_bonus = true
 		input = ElectricCharge@0.0042
 		input = MetallicOre@0.086
 		input = Hydrogen@179.334
@@ -801,6 +831,7 @@ Profile:NEEDS[SterlingSystems]
 		title = #KERBALISM_BranchLoc_Fusion_Pellet_Foundry
 		tag = FFT
 		modifier = _DACFP
+		specialist_bonus = true
 		input = ElectricCharge@200.0
 		input = LqdHe3@1.6
 		input = LqdDeuterium@0.4

--- a/GameData/KerbalismConfig/Support/USI/USI_ReactorPack.cfg
+++ b/GameData/KerbalismConfig/Support/USI/USI_ReactorPack.cfg
@@ -43,6 +43,7 @@ Profile
 	{
 		name = uraninite centrifuge
 		modifier = _Centrifuge
+		specialist_bonus = true
 		input = ElectricCharge@4.48
 		input = Uraninite@0.0000408
 		output = EnrichedUranium@0.00000825
@@ -54,6 +55,7 @@ Profile
 	{
 		name = breeder reactor
 		modifier = _Breeder
+		specialist_bonus = true
 		input = DepletedFuel@0.00000218
 		output = ElectricCharge@5.039146
 		output = EnrichedUranium@0.000000772

--- a/src/Kerbalism/Profile/Process.cs
+++ b/src/Kerbalism/Profile/Process.cs
@@ -8,6 +8,8 @@ namespace KERBALISM
 
 	public sealed class Process
 	{
+		private static readonly CrewSpecs engineer_cs = new CrewSpecs("Engineer@0");
+
 		public Process(ConfigNode node)
 		{
 			name = Lib.ConfigValue(node, "name", string.Empty);
@@ -15,6 +17,7 @@ namespace KERBALISM
 			broker = ResourceBroker.GetOrCreate(name, ResourceBroker.BrokerCategory.Converter, title);
 			modifiers = Lib.Tokenize(Lib.ConfigValue(node, "modifier", string.Empty), ',');
 			isAtmoLeaks = Lib.ConfigValue(node, "isAtmoLeaks", name == "atmo leaks");
+			specialist_bonus = Lib.ConfigValue(node, "specialist_bonus", false);
 
 			// check that name is specified
 			if (name.Length == 0) throw new Exception("skipping unnamed process");
@@ -85,6 +88,17 @@ namespace KERBALISM
 			defaultDumpValve = new DumpSpecs.ActiveValve(dump);
 		}
 
+		/// <summary>
+		/// Engineer efficiency multiplier matching Harvester.AdjustedRate:
+		/// any engineer gives a base bump; higher levels scale further, clamped by settings.
+		/// </summary>
+		public static double SpecialistEfficiencyBonus(List<ProtoCrewMember> crew)
+		{
+			int bonus = engineer_cs.Bonus(crew, -2);
+			double crew_gain = 1.0 + bonus * Settings.ProcessCrewLevelBonus;
+			return Lib.Clamp(crew_gain, 1.0, Settings.MaxProcessBonus);
+		}
+
 		private void ExecuteRecipe(double k, VesselData vd, VesselResources resources, double elapsed_s)
 		{
 			// only execute processes if necessary
@@ -122,6 +136,8 @@ namespace KERBALISM
 			// if a given PartModule has a larger than 1 capacity for a process, then the multiplication happens here
 			// remember that when a process is enabled the units of process are stored in the PartModule as a pseudo-resource
 			double k = Modifiers.Evaluate(v, vd, resources, modifiers);
+			if (specialist_bonus)
+				k *= SpecialistEfficiencyBonus(Lib.CrewList(v));
 
 			ExecuteRecipe(k, vd, resources, elapsed_s);
 		}
@@ -137,9 +153,9 @@ namespace KERBALISM
 		public int defaultDumpValveIndex;
 		public ResourceBroker broker;
 		public bool isAtmoLeaks;
+		public bool specialist_bonus;                 // if true, engineers on the vessel improve process rate (ISRU-style)
 	}
 
 
 
 } // KERBALISM
-

--- a/src/Kerbalism/System/Settings.cs
+++ b/src/Kerbalism/System/Settings.cs
@@ -68,6 +68,8 @@ namespace KERBALISM
 			MaxLaborartoryBonus = Lib.ConfigValue(cfg, "MaxLaborartoryBonus", 2.0);
 			HarvesterCrewLevelBonus = Lib.ConfigValue(cfg, "HarvesterCrewLevelBonus", 0.1);
 			MaxHarvesterBonus = Lib.ConfigValue(cfg, "MaxHarvesterBonus", 2.0);
+			ProcessCrewLevelBonus = Lib.ConfigValue(cfg, "ProcessCrewLevelBonus", 0.1);
+			MaxProcessBonus = Lib.ConfigValue(cfg, "MaxProcessBonus", 2.0);
 
 			// misc
 			EnforceCoherency = Lib.ConfigValue(cfg, "EnforceCoherency", true);
@@ -173,6 +175,8 @@ namespace KERBALISM
 		public static double MaxLaborartoryBonus;               // max bonus to be gained by having skilled crew on a laboratory
 		public static double HarvesterCrewLevelBonus;           // factor for harvester speed gain per engineer level above minimum
 		public static double MaxHarvesterBonus;                 // max bonus to be gained by having skilled engineers on a mining rig
+		public static double ProcessCrewLevelBonus;             // factor for process speed gain per engineer level (when specialist_bonus is enabled)
+		public static double MaxProcessBonus;                   // max bonus to be gained by having skilled engineers on specialist processes
 
 		// misc
 		public static bool EnforceCoherency;                    // detect and avoid issues at high timewarp in external modules

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -370,6 +370,8 @@ namespace KERBALISM.Planner
 		{
 			// evaluate modifiers
 			double k = Modifiers.Evaluate(env, va, this, pr.modifiers);
+			if (pr.specialist_bonus)
+				k *= Process.SpecialistEfficiencyBonus(va.crew);
 			Process_process_inner_body(k, null, pr, env, va);
 		}
 


### PR DESCRIPTION
## Summary
- Restore engineer efficiency scaling for Kerbalism Process-based ISRU / chemical plant converters after stock `ModuleResourceConverter` was replaced by `ProcessController`.
- Add optional `specialist_bonus` on Process definitions, using the same crew bonus curve as Harvesters (`ProcessCrewLevelBonus` / `MaxProcessBonus`).
- Enable the bonus for Default ISRU/chem processes and related converter-style support processes (Sterling chemistry/refining, CryoTanks chemistry, NFE refine/reprocess, USI centrifuge/breeder, FFT factories).
- Wire the same bonus into Planner simulation so editor estimates match flight.
- Life support, fuel cells, reactors, and freeze/thaw phase-change processes are left unchanged (those are not stock-style ISRU chemical conversions).

## Notes
ISRU conversion here means chemical resource transformation (e.g. water electrolysis, Sabatier, MRE), not phase change between gas/liquid forms of the same resource (e.g. Oxygen ↔ LqdOxygen). Only the former gets `specialist_bonus`, matching stock `ConverterSkill` intent.
With default settings the engineer multiplier is:
- none: 1.0×
- 0★: 1.2×
- 1★: 1.3×
- 2★: 1.4×
- 3★+: 1.5× (capped by `MaxProcessBonus`)