### PR TITLE
Hide KsmGui in facilities and ignore Body Info hotkey while typing

### DIFF
--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -487,6 +487,10 @@ namespace KERBALISM
 			// prepare gui content
 			Profiler.BeginSample("UI.Update");
 			UI.Update(Callbacks.visible);
+			// KsmGui (Science Archive, etc.) ignores the IMGUI visible flag; sync its canvas
+			// so facility overlays (R&D, Admin, …) hide and restore open windows (#556).
+			if (KsmGui.KsmGuiMasterController.Instance != null)
+				KsmGui.KsmGuiMasterController.Instance.SetVisible(Callbacks.visible);
 			Profiler.EndSample();
 		}
 
@@ -883,7 +887,7 @@ namespace KERBALISM
 			}
 
 			// toggle body info window with keyboard
-			if (MapView.MapIsEnabled && Input.GetKeyDown(KeyCode.B))
+			if (MapView.MapIsEnabled && !IsTextInputFocused() && Input.GetKeyDown(KeyCode.B))
 			{
 				UI.Open(BodyInfo.Body_info);
 			}
@@ -906,6 +910,26 @@ namespace KERBALISM
 			{ vd.computer.Execute(v, ScriptType.action4); }
 			if (Input.GetKeyDown(KeyCode.Alpha5) || Input.GetKeyDown(KeyCode.Keypad5))
 			{ vd.computer.Execute(v, ScriptType.action5); }
+		}
+
+		/// <summary>true when an IMGUI or uGUI text field has keyboard focus</summary>
+		private static bool IsTextInputFocused()
+		{
+			if (global::InputLockManager.IsLocked(ControlTypes.KEYBOARDINPUT))
+				return true;
+
+			// uGUI / TMP input fields used by some mods
+			UnityEngine.EventSystems.EventSystem es = UnityEngine.EventSystems.EventSystem.current;
+			if (es == null || es.currentSelectedGameObject == null)
+				return false;
+
+			GameObject selected = es.currentSelectedGameObject;
+			UnityEngine.UI.InputField inputField = selected.GetComponent<UnityEngine.UI.InputField>();
+			if (inputField != null && inputField.isFocused)
+				return true;
+
+			TMPro.TMP_InputField tmpInputField = selected.GetComponent<TMPro.TMP_InputField>();
+			return tmpInputField != null && tmpInputField.isFocused;
 		}
 
 		// return true if the vessel is a rescue mission

--- a/src/Kerbalism/UI/KsmGui/KsmGuiMasterController.cs
+++ b/src/Kerbalism/UI/KsmGui/KsmGuiMasterController.cs
@@ -77,6 +77,16 @@ namespace KERBALISM.KsmGui
 			CanvasScaler.scaleFactor = Settings.UIScale * GameSettings.UI_SCALE;
 		}
 
+		public void SetVisible(bool visible)
+		{
+			if (KsmGuiCanvas == null || KsmGuiCanvas.activeSelf == visible)
+				return;
+
+			if (!visible && KsmGuiTooltipController.Instance != null)
+				KsmGuiTooltipController.Instance.HideTooltip();
+
+			KsmGuiCanvas.SetActive(visible);
+		}
 
 	}
 }

--- a/src/Kerbalism/UI/KsmGui/KsmGuiWindow.cs
+++ b/src/Kerbalism/UI/KsmGui/KsmGuiWindow.cs
@@ -56,6 +56,7 @@ namespace KERBALISM.KsmGui
 			void OnDisable()
 			{
 				global::InputLockManager.RemoveControlLock(inputLockId);
+				isLocked = false;
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Hide KsmGui (Science Archive, etc.) while Space Center facility overlays are open (R&D, Admin, …), and restore them when leaving (#556).
- Skip the Body Info `B` hotkey while a text field has keyboard focus, so renaming vessels in the Tracking Station no longer pops Body Info (#657).
- Clear tooltips and reset KsmGui input-lock state when the canvas is hidden.