### PR TITLE
Fix reliability Monitor icon lag after scene load (#714)

### DIFF
--- a/src/Kerbalism/Database/VesselData.cs
+++ b/src/Kerbalism/Database/VesselData.cs
@@ -518,6 +518,36 @@ namespace KERBALISM
 			reliabilityStatus = null;
 		}
 
+		/// <summary>
+		/// Recompute Malfunction/Critical from current module state so Monitor icons stay correct
+		/// without waiting for the next Evaluate pass (important after scene changes / repairs).
+		/// </summary>
+		public void RefreshReliabilityState()
+		{
+			if (!Features.Reliability)
+			{
+				malfunction = false;
+				critical = false;
+				return;
+			}
+
+			if (Vessel != null)
+				Reliability.GetVesselState(Vessel, out malfunction, out critical);
+		}
+
+		/// <summary>Same as RefreshReliabilityState, but usable during OnLoad when Vessel is still null.</summary>
+		public void RefreshReliabilityState(ProtoVessel pv)
+		{
+			if (!Features.Reliability)
+			{
+				malfunction = false;
+				critical = false;
+				return;
+			}
+
+			Reliability.GetVesselState(pv, out malfunction, out critical);
+		}
+
 		#endregion
 
 		#region core update handling
@@ -815,6 +845,10 @@ namespace KERBALISM
 				Load(node);
 				Lib.LogDebug("VesselData ctor (loaded from database) : id '" + VesselId + "' (" + protoVessel.vesselName + "), part count : " + parts.Count);
 			}
+
+			// Malfunction/Critical are not persisted; evaluate from proto immediately so Monitor
+			// reliability icons are correct after OnLoad / scene changes (issue #714).
+			RefreshReliabilityState(protoVessel);
 
 			InitializeCommHandler();
 

--- a/src/Kerbalism/Integrations/SystemHeat/SystemHeatBackgroundThermal.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/SystemHeatBackgroundThermal.cs
@@ -1457,6 +1457,8 @@ namespace KERBALISM
 				Lib.Proto.Set(reliability, "broken", true);
 				Lib.Proto.Set(reliability, "critical", true);
 			}
+
+			v.KerbalismData().RefreshReliabilityState();
 		}
 
 		private static void BreakNativeFissionReactor(Vessel v, ProtoPartSnapshot part, ProtoPartModuleSnapshot module)
@@ -1482,6 +1484,8 @@ namespace KERBALISM
 				Lib.Proto.Set(reliability, "broken", true);
 				Lib.Proto.Set(reliability, "critical", true);
 			}
+
+			v.KerbalismData().RefreshReliabilityState();
 		}
 
 		private static PartModule FindMatchingPrefabModule(Part prefab, ProtoPartModuleSnapshot module, string moduleName)

--- a/src/Kerbalism/Modules/Reliability.cs
+++ b/src/Kerbalism/Modules/Reliability.cs
@@ -653,6 +653,8 @@ namespace KERBALISM
 				// then repairing will enable all of them, messing up with the configuration
 				part.FindModulesImplementing<Configure>().ForEach(k => k.DoConfigure());
 
+				vessel.KerbalismData().RefreshReliabilityState();
+
 				// notify user
 				Message.Post
 				(
@@ -715,6 +717,8 @@ namespace KERBALISM
 
 				// type-specific hacks
 				Apply(true);
+
+				vessel.KerbalismData().RefreshReliabilityState();
 
 				// notify user
 				Broken_msg(vessel, title, critical);
@@ -818,6 +822,8 @@ namespace KERBALISM
 						}
 						break;
 				}
+
+				v.KerbalismData().RefreshReliabilityState();
 
 				// show message
 				Broken_msg(v, reliability.title, critical);
@@ -1409,11 +1415,10 @@ namespace KERBALISM
 		///<summary>evaluate the malfunction and critical failure state of a vessel in a single pass</summary>
 		public static void GetVesselState(Vessel v, out bool malfunction, out bool critical)
 		{
-			malfunction = false;
-			critical = false;
-
 			if (v.loaded)
 			{
+				malfunction = false;
+				critical = false;
 				foreach (Reliability m in PartModuleCache.GetModules<Reliability>(v))
 				{
 					malfunction |= m.broken;
@@ -1422,11 +1427,21 @@ namespace KERBALISM
 			}
 			else
 			{
-				foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(v.protoVessel, "Reliability"))
-				{
-					malfunction |= Lib.Proto.GetBool(m, "broken");
-					critical |= Lib.Proto.GetBool(m, "critical");
-				}
+				GetVesselState(v.protoVessel, out malfunction, out critical);
+			}
+		}
+
+		///<summary>evaluate malfunction/critical from a ProtoVessel (used on load / scene change before Vessel is available)</summary>
+		public static void GetVesselState(ProtoVessel pv, out bool malfunction, out bool critical)
+		{
+			malfunction = false;
+			critical = false;
+			if (pv == null) return;
+
+			foreach (ProtoPartModuleSnapshot m in ProtoPartModuleCache.GetModules(pv, "Reliability"))
+			{
+				malfunction |= Lib.Proto.GetBool(m, "broken");
+				critical |= Lib.Proto.GetBool(m, "critical");
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Refresh `Malfunction` / `Critical` from proto when `VesselData` is created on load/scene change, so the Monitor reliability wrench updates immediately instead of waiting for the unloaded Evaluate queue.
- Also refresh those flags right after break/repair (including SystemHeat reactor breaks), so the icon stays in sync without waiting for the next Evaluate pass.

