### PR TITLE
Fix greenhouse free artificial light when `ec_rate=0`

### DIFF
--- a/src/Kerbalism/Modules/Greenhouse.cs
+++ b/src/Kerbalism/Modules/Greenhouse.cs
@@ -203,14 +203,15 @@ namespace KERBALISM
 			g.Set_WACO2();
 
 			natural = vd.EnvSolarFluxTotal;
-			artificial = Math.Max(g.light_tolerance - natural, 0.0);
-
-			ResourceInfo ec = resources.GetResource(v, "ElectricCharge");
 			double lamp_ec_rate = g.ec_rate * g.ec_rate_mult;
-			bool lamps_needed = artificial > double.Epsilon && lamp_ec_rate > double.Epsilon;
-			if (lamps_needed && Available(ec) <= double.Epsilon)
-				artificial = 0.0;
+			// ec_rate == 0 disables lamps: no artificial light fill-in.
+			artificial = lamp_ec_rate > double.Epsilon
+				? Math.Max(g.light_tolerance - natural, 0.0)
+				: 0.0;
+			bool lamps_needed = artificial > double.Epsilon;
 
+			// Do not pre-check current EC. Lamp power is a recipe input, so same-step
+			// producers can supply it during ExecuteRecipes.
 			bool lighting = natural + artificial >= g.light_tolerance;
 			bool pressure = g.pressure_tolerance <= double.Epsilon || vd.Pressure >= g.pressure_tolerance;
 			bool radiation = g.radiation_tolerance <= double.Epsilon

--- a/src/Kerbalism/Modules/Greenhouse.cs
+++ b/src/Kerbalism/Modules/Greenhouse.cs
@@ -203,15 +203,16 @@ namespace KERBALISM
 			g.Set_WACO2();
 
 			natural = vd.EnvSolarFluxTotal;
+			ResourceInfo ec = resources.GetResource(v, "ElectricCharge");
 			double lamp_ec_rate = g.ec_rate * g.ec_rate_mult;
 			// ec_rate == 0 disables lamps: no artificial light fill-in.
 			artificial = lamp_ec_rate > double.Epsilon
 				? Math.Max(g.light_tolerance - natural, 0.0)
 				: 0.0;
 			bool lamps_needed = artificial > double.Epsilon;
+			if (lamps_needed && Available(ec) <= double.Epsilon)
+				artificial = 0.0;
 
-			// Do not pre-check current EC. Lamp power is a recipe input, so same-step
-			// producers can supply it during ExecuteRecipes.
 			bool lighting = natural + artificial >= g.light_tolerance;
 			bool pressure = g.pressure_tolerance <= double.Epsilon || vd.Pressure >= g.pressure_tolerance;
 			bool radiation = g.radiation_tolerance <= double.Epsilon

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -391,12 +391,13 @@ namespace KERBALISM.Planner
 			if (!g.active)
 				return;
 
-			// calculate natural and artificial lighting
+			// Natural lighting, plus artificial only when lamps exist (ec_rate > 0).
 			double natural = env.solar_flux;
-			double artificial = Math.Max(g.light_tolerance - natural, 0.0);
 			double lamp_ec_rate = g.ec_rate * g.ec_rate_mult;
-			bool lighting = natural >= g.light_tolerance
-				|| (artificial > double.Epsilon && lamp_ec_rate > double.Epsilon);
+			double artificial = lamp_ec_rate > double.Epsilon
+				? Math.Max(g.light_tolerance - natural, 0.0)
+				: 0.0;
+			bool lighting = natural + artificial >= g.light_tolerance;
 			bool pressure = va.pressurized || g.pressure_tolerance <= double.Epsilon;
 			bool radiation = g.radiation_tolerance <= double.Epsilon
 				|| (env.landed ? env.surface_rad : env.magnetopause_rad) * (1.0 - va.shielding) < g.radiation_tolerance;


### PR DESCRIPTION
Treat `ec_rate=0` as “no lamps”: do not fill in artificial light when natural lighting is below `light_tolerance`.
