### PR TITLE
Fix CryoTanks planner/monitor EC costs and add cooling automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
  * Added: Restock chemical plant and ECLSS models (#998, @LouisB3)
  * Added: SupplementaryElectricEngines support (#1000, @LouisB3)
  * Added: Stock, ReStock+, and NF Exploration antenna configs (#1003, @LouisB3)
+ * Fixed: CryoTanks planner/monitor EC and boiloff when CoolingCost is per-fuel in BOILOFFCONFIG (#534, @Aebestach)
+ * Added: CryoTanks cooling toggle as an Automation device (#264, @Aebestach)
  * Fixed: Planner power consumption for electric engines and RCS (#1036, @Aebestach)
  * Fixed: Multi-star solar panel energy output; added Universal Storage 2 configs (#986, @Aebestach)
  * Fixed: Radiation archives issue (#987, @Aebestach)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,6 @@
  * Added: Restock chemical plant and ECLSS models (#998, @LouisB3)
  * Added: SupplementaryElectricEngines support (#1000, @LouisB3)
  * Added: Stock, ReStock+, and NF Exploration antenna configs (#1003, @LouisB3)
- * Fixed: CryoTanks planner/monitor EC and boiloff when CoolingCost is per-fuel in BOILOFFCONFIG (#534, @Aebestach)
- * Added: CryoTanks cooling toggle as an Automation device (#264, @Aebestach)
  * Fixed: Planner power consumption for electric engines and RCS (#1036, @Aebestach)
  * Fixed: Multi-star solar panel energy output; added Universal Storage 2 configs (#986, @Aebestach)
  * Fixed: Radiation archives issue (#987, @Aebestach)

--- a/GameData/KerbalismConfig/Localization/de.cfg
+++ b/GameData/KerbalismConfig/Localization/de.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = Prozessinfo
 		#KERBALISM_Device_CapacitorCharge = Kondensatorladung
 		#KERBALISM_Device_CapacitorDischarge = Kondensatorentladung
+		#KERBALISM_Device_CryoTankCooling = Kryotank-Kühlung
 		#KERBALISM_FFT_low_Antimatter = Antimaterie niedrig auf $VESSEL
 		#KERBALISM_FFT_empty_Antimatter = Keine Antimaterie mehr auf $VESSEL
 		#KERBALISM_FFT_refill_Antimatter = $VESSEL Antimaterie aufgefüllt

--- a/GameData/KerbalismConfig/Localization/en-us.cfg
+++ b/GameData/KerbalismConfig/Localization/en-us.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = Process info
 		#KERBALISM_Device_CapacitorCharge = capacitor charge
 		#KERBALISM_Device_CapacitorDischarge = capacitor discharge
+		#KERBALISM_Device_CryoTankCooling = cryo tank cooling
 		#KERBALISM_FFT_low_Antimatter = Antimatter low on $VESSEL
 		#KERBALISM_FFT_empty_Antimatter = No antimatter left on $VESSEL
 		#KERBALISM_FFT_refill_Antimatter = $VESSEL antimatter refilled

--- a/GameData/KerbalismConfig/Localization/es-es.cfg
+++ b/GameData/KerbalismConfig/Localization/es-es.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = Info del proceso
 		#KERBALISM_Device_CapacitorCharge = carga del condensador
 		#KERBALISM_Device_CapacitorDischarge = descarga del condensador
+		#KERBALISM_Device_CryoTankCooling = refrigeración del tanque criogénico
 		#KERBALISM_FFT_low_Antimatter = Antimateria baja en $VESSEL
 		#KERBALISM_FFT_empty_Antimatter = Sin antimateria en $VESSEL
 		#KERBALISM_FFT_refill_Antimatter = $VESSEL antimateria rellenada

--- a/GameData/KerbalismConfig/Localization/fr-fr.cfg
+++ b/GameData/KerbalismConfig/Localization/fr-fr.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = Infos processus
 		#KERBALISM_Device_CapacitorCharge = charge du condensateur
 		#KERBALISM_Device_CapacitorDischarge = décharge du condensateur
+		#KERBALISM_Device_CryoTankCooling = refroidissement cryo-réservoir
 		#KERBALISM_FFT_low_Antimatter = Antimatière faible sur $VESSEL
 		#KERBALISM_FFT_empty_Antimatter = Plus d'antimatière sur $VESSEL
 		#KERBALISM_FFT_refill_Antimatter = Antimatière de $VESSEL rechargée

--- a/GameData/KerbalismConfig/Localization/it-it.cfg
+++ b/GameData/KerbalismConfig/Localization/it-it.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = Info processo
 		#KERBALISM_Device_CapacitorCharge = carica condensatore
 		#KERBALISM_Device_CapacitorDischarge = scarica condensatore
+		#KERBALISM_Device_CryoTankCooling = raffreddamento serbatoio criogenico
 		#KERBALISM_FFT_low_Antimatter = Antimateria in esaurimento su $VESSEL
 		#KERBALISM_FFT_empty_Antimatter = Nessuna antimateria rimasta su $VESSEL
 		#KERBALISM_FFT_refill_Antimatter = Antimateria di $VESSEL rifornita

--- a/GameData/KerbalismConfig/Localization/ko-kr.cfg
+++ b/GameData/KerbalismConfig/Localization/ko-kr.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = 공정 정보
 		#KERBALISM_Device_CapacitorCharge = 축전기 충전
 		#KERBALISM_Device_CapacitorDischarge = 축전기 방전
+		#KERBALISM_Device_CryoTankCooling = 극저온 탱크 냉각
 		#KERBALISM_FFT_low_Antimatter = $VESSEL: 반물질 부족
 		#KERBALISM_FFT_empty_Antimatter = $VESSEL: 반물질 고갈
 		#KERBALISM_FFT_refill_Antimatter = $VESSEL: 반물질 보충됨

--- a/GameData/KerbalismConfig/Localization/pt-br.cfg
+++ b/GameData/KerbalismConfig/Localization/pt-br.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = Info do processo
 		#KERBALISM_Device_CapacitorCharge = carga do capacitor
 		#KERBALISM_Device_CapacitorDischarge = descarga do capacitor
+		#KERBALISM_Device_CryoTankCooling = resfriamento do tanque criogênico
 		#KERBALISM_FFT_low_Antimatter = Antimatéria baixa em $VESSEL
 		#KERBALISM_FFT_empty_Antimatter = Sem antimatéria em $VESSEL
 		#KERBALISM_FFT_refill_Antimatter = $VESSEL antimatéria reabastecida

--- a/GameData/KerbalismConfig/Localization/ru.cfg
+++ b/GameData/KerbalismConfig/Localization/ru.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = Информация о процессе
 		#KERBALISM_Device_CapacitorCharge = зарядка конденсатора
 		#KERBALISM_Device_CapacitorDischarge = разрядка конденсатора
+		#KERBALISM_Device_CryoTankCooling = охлаждение криобака
 		#KERBALISM_FFT_low_Antimatter = $VESSEL: мало антиматерии
 		#KERBALISM_FFT_empty_Antimatter = $VESSEL: антиматерия закончилась
 		#KERBALISM_FFT_refill_Antimatter = $VESSEL: антиматерия пополнена

--- a/GameData/KerbalismConfig/Localization/zh-cn.cfg
+++ b/GameData/KerbalismConfig/Localization/zh-cn.cfg
@@ -601,6 +601,7 @@ Localization
 		#KERBALISM_Process_info = 工艺信息
 		#KERBALISM_Device_CapacitorCharge = 电容器充电
 		#KERBALISM_Device_CapacitorDischarge = 电容器放电
+		#KERBALISM_Device_CryoTankCooling = 低温罐冷却
 		#KERBALISM_FFT_low_Antimatter = $VESSEL：反物质储量不足
 		#KERBALISM_FFT_empty_Antimatter = $VESSEL：反物质已耗尽
 		#KERBALISM_FFT_refill_Antimatter = $VESSEL：反物质已补充

--- a/GameData/KerbalismConfig/Support/CryoTanks.cfg
+++ b/GameData/KerbalismConfig/Support/CryoTanks.cfg
@@ -557,6 +557,7 @@ RESOURCE_DEFINITION:NEEDS[CryoTanks,ProfileDefault]
 	}
 }
 
+// PlannerController: module-level CoolingCost > 0 (legacy CryoTanks configs)
 @PART[*]:HAS[@MODULE[ModuleCryoTank]:HAS[#CoolingCost[>0],#CoolingEnabled[*],~CoolingAllowed[*alse]],!MODULE[PlannerController]]:NEEDS[CryoTanks,ProfileDefault]:LAST[KerbalismBridge00Integration]
 {
 	MODULE
@@ -568,6 +569,27 @@ RESOURCE_DEFINITION:NEEDS[CryoTanks,ProfileDefault]
 }
 
 @PART[*]:HAS[@MODULE[ModuleCryoTank]:HAS[#CoolingCost[>0],~CoolingEnabled[],~CoolingAllowed[*alse]],!MODULE[PlannerController]]:NEEDS[CryoTanks,ProfileDefault]:LAST[KerbalismBridge00Integration]
+{
+	MODULE
+	{
+		name = PlannerController
+		title = #KERBALISM_Brokers_Cryotank
+		considered = true
+	}
+}
+
+// PlannerController: modern CryoTanks puts CoolingCost inside BOILOFFCONFIG (module CoolingCost is often 0)
+@PART[*]:HAS[@MODULE[ModuleCryoTank]:HAS[@BOILOFFCONFIG:HAS[#CoolingCost[>0]],#CoolingEnabled[*],~CoolingAllowed[*alse]],!MODULE[PlannerController]]:NEEDS[CryoTanks,ProfileDefault]:LAST[KerbalismBridge00Integration]
+{
+	MODULE
+	{
+		name = PlannerController
+		title = #KERBALISM_Brokers_Cryotank
+		considered = #$/MODULE[ModuleCryoTank]:HAS[@BOILOFFCONFIG:HAS[#CoolingCost[>0]],#CoolingEnabled[*],~CoolingAllowed[*alse],0/CoolingEnabled$
+	}
+}
+
+@PART[*]:HAS[@MODULE[ModuleCryoTank]:HAS[@BOILOFFCONFIG:HAS[#CoolingCost[>0]],~CoolingEnabled[],~CoolingAllowed[*alse]],!MODULE[PlannerController]]:NEEDS[CryoTanks,ProfileDefault]:LAST[KerbalismBridge00Integration]
 {
 	MODULE
 	{

--- a/src/Kerbalism/Background.cs
+++ b/src/Kerbalism/Background.cs
@@ -535,64 +535,62 @@ namespace KERBALISM
 			// Note. Currently background simulation of Cryotanks has an irregularity in that boiloff of a fuel type in a tank removes resources from all tanks
 			// but at least some simulation is better than none ;)
 
-			// get list of fuels, do nothing if no fuels
+			// Fallback when CryoTankKerbalismUpdater is absent.
+			// CoolingCost may be module-level and/or per BOILOFFCONFIG fuel entry.
 			IList fuels = Lib.ReflectionValue<IList>(cryotank, "fuels");
 			if (fuels == null) return;
 
-			// is cooling available, note: comparing against amount in previous simulation step
-			bool available = (Lib.Proto.GetBool(m, "CoolingEnabled") && ec.Amount > double.Epsilon);
-
-			// get cooling cost
-			double cooling_cost = Lib.ReflectionValue<float>(cryotank, "CoolingCost");
-
-			string fuel_name = "";
-			double amount = 0.0;
+			bool cooling_enabled = Lib.Proto.GetBool(m, "CoolingEnabled");
+			float module_cooling_cost = Lib.ReflectionValue<float>(cryotank, "CoolingCost");
+			float present_fuel_cooling_cost = 0f;
+			double total_amount = 0.0;
 			double total_cost = 0.0;
-			double boiloff_rate = 0.0;
 
 			foreach (var item in fuels)
 			{
-				fuel_name = Lib.ReflectionValue<string>(item, "fuelName");
-				// if fuel_name is null, don't do anything
+				string fuel_name = Lib.ReflectionValue<string>(item, "fuelName");
 				if (fuel_name == null)
 					continue;
 
-				//get fuel resource
 				ResourceInfo fuel = resources.GetResource(v, fuel_name);
+				if (fuel.Amount <= double.Epsilon)
+					continue;
 
-				// if there is some fuel
-				// note: comparing against amount in previous simulation step
-				if (fuel.Amount > double.Epsilon)
-				{
-					// Try to find resource "fuel_name" in PartResources
-					ProtoPartResourceSnapshot proto_fuel = p.resources.Find(k => k.resourceName == fuel_name);
+				ProtoPartResourceSnapshot proto_fuel = p.resources.Find(k => k.resourceName == fuel_name);
+				if (proto_fuel == null) continue;
 
-					// If part doesn't have the fuel, don't do anything.
-					if (proto_fuel == null) continue;
+				double amount = proto_fuel.amount;
+				if (amount <= double.Epsilon)
+					continue;
 
-					// get amount in the part
-					amount = proto_fuel.amount;
-
-					// if cooling is enabled and there is enough EC
-					if (available)
-					{
-						// calculate ec consumption
-						total_cost += cooling_cost * amount * 0.001;
-					}
-					// if cooling is disabled or there wasn't any EC
-					else
-					{
-						// get boiloff rate per-second
-						boiloff_rate = Lib.ReflectionValue<float>(item, "boiloffRate") / 360000.0f;
-
-						// let it boil off
-						fuel.Consume(amount * (1.0 - Math.Pow(1.0 - boiloff_rate, elapsed_s)), ResourceBroker.Boiloff);
-					}
-				}
+				present_fuel_cooling_cost += Lib.ReflectionValue<float>(item, "coolingCost");
+				total_amount += amount;
 			}
 
-			// apply EC consumption
-			ec.Consume(total_cost * elapsed_s, ResourceBroker.Cryotank);
+			bool available = cooling_enabled && ec.Amount > double.Epsilon;
+			if (available && total_amount > double.Epsilon)
+				total_cost = (module_cooling_cost + present_fuel_cooling_cost) * total_amount * 0.001;
+
+			if (available && total_cost > 0.0)
+			{
+				ec.Consume(total_cost * elapsed_s, ResourceBroker.Cryotank);
+				return;
+			}
+
+			foreach (var item in fuels)
+			{
+				string fuel_name = Lib.ReflectionValue<string>(item, "fuelName");
+				if (fuel_name == null)
+					continue;
+
+				ProtoPartResourceSnapshot proto_fuel = p.resources.Find(k => k.resourceName == fuel_name);
+				if (proto_fuel == null || proto_fuel.amount <= double.Epsilon)
+					continue;
+
+				double boiloff_rate = Lib.ReflectionValue<float>(item, "boiloffRate") / 360000.0f;
+				ResourceInfo fuel = resources.GetResource(v, fuel_name);
+				fuel.Consume(proto_fuel.amount * (1.0 - Math.Pow(1.0 - boiloff_rate, elapsed_s)), ResourceBroker.Boiloff);
+			}
 		}
 
 		// TODO : this is to migrate pre-3.1 saves using WarpFixer to the new SolarPanelFixer. At some point in the future we can remove this code.

--- a/src/Kerbalism/External/CryoTanks.cs
+++ b/src/Kerbalism/External/CryoTanks.cs
@@ -23,10 +23,14 @@ namespace KERBALISM
 
 		public static float GetBoiloffRate(object fuelEntry) => IntegrationReflection.GetFloat(fuelEntry, "boiloffRate");
 
+		/// <summary>Per-fuel CoolingCost from BOILOFFCONFIG (modern CryoTanks).</summary>
+		public static float GetFuelCoolingCost(object fuelEntry) => IntegrationReflection.GetFloat(fuelEntry, "coolingCost");
+
 		public static bool GetCoolingEnabled(PartModule tank) => Get(tank, "CoolingEnabled", false);
 
 		public static void SetCoolingEnabled(PartModule tank, bool value) => Set(tank, "CoolingEnabled", value);
 
+		/// <summary>Module-level CoolingCost. Often 0 when cost is defined per BOILOFFCONFIG.</summary>
 		public static float GetCoolingCost(PartModule tank) => Get(tank, "CoolingCost", 0f);
 
 		public static PartModule FindCryoTankModule(Part part)

--- a/src/Kerbalism/Integrations/CryoTanks/Automation/CryoTankComputerDevicesHarmony.cs
+++ b/src/Kerbalism/Integrations/CryoTanks/Automation/CryoTankComputerDevicesHarmony.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using HarmonyLib;
+
+namespace KERBALISM
+{
+	[HarmonyPatch(typeof(Computer), nameof(Computer.GetModuleDevices))]
+	internal static class CryoTankComputerDevicesHarmony
+	{
+		private static void Postfix(Vessel v, ref List<Device> __result)
+		{
+			if (__result == null || v == null || !Features.Automation)
+				return;
+			if (!CryoTanks.Installed || !CryoSettings.Enabled)
+				return;
+
+			CryoTankDeviceCollector.RemoveDevices(__result);
+
+			var moduleDevices = new List<Device>();
+			if (v.loaded)
+				CryoTankDeviceCollector.CollectLoaded(v, moduleDevices);
+			else
+				CryoTankDeviceCollector.CollectProto(v, moduleDevices);
+
+			if (moduleDevices.Count == 0)
+				return;
+
+			__result.InsertRange(FindFirstVesselDeviceIndex(__result), moduleDevices);
+		}
+
+		private static int FindFirstVesselDeviceIndex(List<Device> devices)
+		{
+			for (int i = 0; i < devices.Count; i++)
+			{
+				if (devices[i] is VesselDevice)
+					return i;
+			}
+
+			return devices.Count;
+		}
+	}
+}

--- a/src/Kerbalism/Integrations/CryoTanks/Automation/CryoTankDeviceCollector.cs
+++ b/src/Kerbalism/Integrations/CryoTanks/Automation/CryoTankDeviceCollector.cs
@@ -1,0 +1,153 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace KERBALISM
+{
+	internal static class CryoTankDeviceCollector
+	{
+		internal static void RemoveDevices(List<Device> devices)
+		{
+			for (int i = devices.Count - 1; i >= 0; i--)
+			{
+				Device device = devices[i];
+				if (device is CryoTankCoolingDevice || device is ProtoCryoTankCoolingDevice)
+					devices.RemoveAt(i);
+			}
+		}
+
+		internal static void CollectLoaded(Vessel v, List<Device> devices)
+		{
+			if (!CryoTanks.Installed || !CryoSettings.Enabled)
+				return;
+
+			foreach (Part part in v.parts)
+			{
+				if (part.FindModuleImplementing<CryoTankKerbalismUpdater>() == null)
+					continue;
+
+				PartModule cryo = CryoTanks.FindCryoTankModule(part);
+				if (cryo == null || !IsCoolable(cryo, part))
+					continue;
+
+				devices.Add(new CryoTankCoolingDevice(cryo));
+			}
+		}
+
+		internal static void CollectProto(Vessel v, List<Device> devices)
+		{
+			if (!CryoTanks.Installed || !CryoSettings.Enabled || v?.protoVessel == null)
+				return;
+
+			var prefabData = new Dictionary<string, Lib.Module_prefab_data>();
+
+			foreach (ProtoPartSnapshot partSnapshot in v.protoVessel.protoPartSnapshots)
+			{
+				if (IntegrationUtils.TryFindPartModuleSnapshot(partSnapshot, "CryoTankKerbalismUpdater") == null)
+					continue;
+
+				Part partPrefab = PartLoader.getPartInfoByName(partSnapshot.partName).partPrefab;
+				prefabData.Clear();
+
+				foreach (ProtoPartModuleSnapshot moduleSnapshot in partSnapshot.modules)
+				{
+					if (moduleSnapshot.moduleName != "ModuleCryoTank")
+						continue;
+
+					PartModule modulePrefab = Lib.ModulePrefab(partPrefab.Modules, moduleSnapshot.moduleName, prefabData);
+					if (modulePrefab == null || !IsCoolable(modulePrefab, partSnapshot))
+						continue;
+
+					devices.Add(new ProtoCryoTankCoolingDevice(modulePrefab, partSnapshot, moduleSnapshot));
+				}
+			}
+		}
+
+		internal static bool IsCoolable(PartModule cryoModule, Part part)
+		{
+			if (cryoModule == null || part == null)
+				return false;
+			if (!CryoTanks.Get(cryoModule, "CoolingAllowed", true))
+				return false;
+
+			if (CryoTanks.GetCoolingCost(cryoModule) > 0f)
+				return HasAnyBoiloffResource(cryoModule, part);
+
+			IList fuels = CryoTankAccess.GetFuels(cryoModule);
+			if (fuels == null)
+				return false;
+
+			foreach (object fuel in fuels)
+			{
+				string fuelName = CryoTankAccess.GetFuelName(fuel);
+				if (string.IsNullOrEmpty(fuelName))
+					continue;
+				if (part.Resources.Get(fuelName) == null)
+					continue;
+				if (CryoTankAccess.GetFuelCoolingCost(fuel) > 0f)
+					return true;
+			}
+
+			return false;
+		}
+
+		internal static bool IsCoolable(PartModule cryoPrefab, ProtoPartSnapshot part)
+		{
+			if (cryoPrefab == null || part == null)
+				return false;
+			if (!CryoTanks.Get(cryoPrefab, "CoolingAllowed", true))
+				return false;
+
+			if (CryoTanks.GetCoolingCost(cryoPrefab) > 0f)
+				return HasAnyBoiloffResource(cryoPrefab, part);
+
+			IList fuels = CryoTankAccess.GetFuels(cryoPrefab);
+			if (fuels == null)
+				return false;
+
+			foreach (object fuel in fuels)
+			{
+				string fuelName = CryoTankAccess.GetFuelName(fuel);
+				if (string.IsNullOrEmpty(fuelName))
+					continue;
+				if (CryoUtils.FindPartResource(part, fuelName) == null)
+					continue;
+				if (CryoTankAccess.GetFuelCoolingCost(fuel) > 0f)
+					return true;
+			}
+
+			return false;
+		}
+
+		static bool HasAnyBoiloffResource(PartModule cryoModule, Part part)
+		{
+			IList fuels = CryoTankAccess.GetFuels(cryoModule);
+			if (fuels == null)
+				return false;
+
+			foreach (object fuel in fuels)
+			{
+				string fuelName = CryoTankAccess.GetFuelName(fuel);
+				if (!string.IsNullOrEmpty(fuelName) && part.Resources.Get(fuelName) != null)
+					return true;
+			}
+
+			return false;
+		}
+
+		static bool HasAnyBoiloffResource(PartModule cryoPrefab, ProtoPartSnapshot part)
+		{
+			IList fuels = CryoTankAccess.GetFuels(cryoPrefab);
+			if (fuels == null)
+				return false;
+
+			foreach (object fuel in fuels)
+			{
+				string fuelName = CryoTankAccess.GetFuelName(fuel);
+				if (!string.IsNullOrEmpty(fuelName) && CryoUtils.FindPartResource(part, fuelName) != null)
+					return true;
+			}
+
+			return false;
+		}
+	}
+}

--- a/src/Kerbalism/Integrations/CryoTanks/Automation/CryoTankDevices.cs
+++ b/src/Kerbalism/Integrations/CryoTanks/Automation/CryoTankDevices.cs
@@ -1,0 +1,76 @@
+using KSP.Localization;
+
+namespace KERBALISM
+{
+	public sealed class CryoTankCoolingDevice : LoadedDevice<PartModule>
+	{
+		public CryoTankCoolingDevice(PartModule module) : base(module) { }
+
+		// Keep Name English for stable device Id hashing across languages.
+		public override string Name
+		{
+			get
+			{
+				string moduleId = CryoTanks.Get(module, "moduleID", string.Empty);
+				return string.IsNullOrEmpty(moduleId) ? "cryo tank cooling" : "cryo tank cooling " + moduleId;
+			}
+		}
+
+		public override string DisplayName => Localizer.Format("#KERBALISM_Device_CryoTankCooling");
+
+		public override string Status => Lib.Color(
+			CryoTanks.GetCoolingEnabled(module),
+			Local.Generic_ON, Lib.Kolor.Green,
+			Local.Generic_OFF, Lib.Kolor.Yellow);
+
+		public override bool IsVisible => CryoTankDeviceCollector.IsCoolable(module, module.part);
+
+		public override void Ctrl(bool value)
+		{
+			if (!IsVisible)
+				return;
+			CryoTanks.SetCoolingEnabled(module, value);
+		}
+
+		public override void Toggle()
+		{
+			Ctrl(!CryoTanks.GetCoolingEnabled(module));
+		}
+	}
+
+	public sealed class ProtoCryoTankCoolingDevice : ProtoDevice<PartModule>
+	{
+		public ProtoCryoTankCoolingDevice(PartModule prefab, ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot protoModule)
+			: base(prefab, protoPart, protoModule) { }
+
+		public override string Name
+		{
+			get
+			{
+				string moduleId = CryoTanks.Get(prefab, "moduleID", string.Empty);
+				return string.IsNullOrEmpty(moduleId) ? "cryo tank cooling" : "cryo tank cooling " + moduleId;
+			}
+		}
+
+		public override string DisplayName => Localizer.Format("#KERBALISM_Device_CryoTankCooling");
+
+		public override string Status => Lib.Color(
+			Lib.Proto.GetBool(protoModule, "CoolingEnabled"),
+			Local.Generic_ON, Lib.Kolor.Green,
+			Local.Generic_OFF, Lib.Kolor.Yellow);
+
+		public override bool IsVisible => CryoTankDeviceCollector.IsCoolable(prefab, protoPart);
+
+		public override void Ctrl(bool value)
+		{
+			if (!IsVisible)
+				return;
+			Lib.Proto.Set(protoModule, "CoolingEnabled", value);
+		}
+
+		public override void Toggle()
+		{
+			Ctrl(!Lib.Proto.GetBool(protoModule, "CoolingEnabled"));
+		}
+	}
+}

--- a/src/Kerbalism/Integrations/CryoTanks/CryoTankAccess.cs
+++ b/src/Kerbalism/Integrations/CryoTanks/CryoTankAccess.cs
@@ -12,5 +12,7 @@ namespace KERBALISM
 		internal static string GetFuelName(object fuelEntry) => CryoTanks.GetFuelName(fuelEntry);
 
 		internal static float GetBoiloffRate(object fuelEntry) => CryoTanks.GetBoiloffRate(fuelEntry);
+
+		internal static float GetFuelCoolingCost(object fuelEntry) => CryoTanks.GetFuelCoolingCost(fuelEntry);
 	}
 }

--- a/src/Kerbalism/Integrations/CryoTanks/CryoTankKerbalismUpdater.cs
+++ b/src/Kerbalism/Integrations/CryoTanks/CryoTankKerbalismUpdater.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 
 namespace KERBALISM
@@ -62,32 +61,15 @@ namespace KERBALISM
 			if (cryoSnapshot == null)
 				return CryoTankResourceSim.BrokerTitle;
 
-			double ecRate = 0.0;
 			string title = CryoTankResourceSim.BackgroundUpdate(v, part_snapshot, cryoSnapshot, cryoPrefab, elapsed_s);
 
 			bool coolingEnabled = Lib.Proto.GetBool(cryoSnapshot, "CoolingEnabled");
 			if (coolingEnabled)
 			{
-				IList fuels = CryoTankAccess.GetFuels(cryoPrefab);
-				float coolingCost = CryoTanks.GetCoolingCost(cryoPrefab);
-				if (fuels != null && coolingCost > 0f)
-				{
-					foreach (object fuel in fuels)
-					{
-						string fuelName = CryoTankAccess.GetFuelName(fuel);
-						if (string.IsNullOrEmpty(fuelName))
-							continue;
-
-						ProtoPartResourceSnapshot protoFuel = CryoUtils.FindPartResource(part_snapshot, fuelName);
-						if (protoFuel == null || protoFuel.amount <= double.Epsilon)
-							continue;
-						ecRate += coolingCost * protoFuel.amount * 0.001;
-					}
-				}
+				double ecRate = CryoTankResourceSim.EstimateCoolingEcRate(cryoPrefab, part_snapshot);
+				if (ecRate > 0.0)
+					resourceChangeRequest.Add(new KeyValuePair<string, double>("ElectricCharge", -ecRate));
 			}
-
-			if (ecRate > 0.0)
-				resourceChangeRequest.Add(new KeyValuePair<string, double>("ElectricCharge", -ecRate));
 
 			return title;
 		}

--- a/src/Kerbalism/Integrations/CryoTanks/CryoTankResourceSim.cs
+++ b/src/Kerbalism/Integrations/CryoTanks/CryoTankResourceSim.cs
@@ -9,17 +9,97 @@ namespace KERBALISM
 		internal const string BrokerName = "CryoTank";
 		internal static string BrokerTitle => Localizer.Format("#KERBALISM_Brokers_Cryotank");
 
+		/// <summary>
+		/// CryoTanks cooling is CoolingCost (module) + present fuels' BOILOFFCONFIG CoolingCost,
+		/// in EC/s per 1000 units. Matches SimpleBoiloff.ModuleCryoTank.GetTotalCoolingCost().
+		/// </summary>
+		internal static double EstimateCoolingEcRate(PartModule cryoModule, Part part)
+		{
+			if (cryoModule == null || part == null)
+				return 0.0;
+
+			IList fuels = CryoTankAccess.GetFuels(cryoModule);
+			if (fuels == null)
+				return 0.0;
+
+			float moduleCost = CryoTanks.GetCoolingCost(cryoModule);
+			float presentFuelCost = 0f;
+			double totalAmount = 0.0;
+
+			foreach (object fuel in fuels)
+			{
+				string fuelName = CryoTankAccess.GetFuelName(fuel);
+				if (string.IsNullOrEmpty(fuelName))
+					continue;
+
+				double amount = Lib.Amount(part, fuelName);
+				if (amount <= double.Epsilon)
+					continue;
+
+				presentFuelCost += CryoTankAccess.GetFuelCoolingCost(fuel);
+				totalAmount += amount;
+			}
+
+			float coolingCostPer1000 = moduleCost + presentFuelCost;
+			if (coolingCostPer1000 <= 0f || totalAmount <= double.Epsilon)
+				return 0.0;
+
+			return coolingCostPer1000 * totalAmount * 0.001;
+		}
+
+		internal static double EstimateCoolingEcRate(PartModule cryoPrefab, ProtoPartSnapshot part)
+		{
+			if (cryoPrefab == null || part == null)
+				return 0.0;
+
+			IList fuels = CryoTankAccess.GetFuels(cryoPrefab);
+			if (fuels == null)
+				return 0.0;
+
+			float moduleCost = CryoTanks.GetCoolingCost(cryoPrefab);
+			float presentFuelCost = 0f;
+			double totalAmount = 0.0;
+
+			foreach (object fuel in fuels)
+			{
+				string fuelName = CryoTankAccess.GetFuelName(fuel);
+				if (string.IsNullOrEmpty(fuelName))
+					continue;
+
+				ProtoPartResourceSnapshot protoFuel = CryoUtils.FindPartResource(part, fuelName);
+				if (protoFuel == null || protoFuel.amount <= double.Epsilon)
+					continue;
+
+				presentFuelCost += CryoTankAccess.GetFuelCoolingCost(fuel);
+				totalAmount += protoFuel.amount;
+			}
+
+			float coolingCostPer1000 = moduleCost + presentFuelCost;
+			if (coolingCostPer1000 <= 0f || totalAmount <= double.Epsilon)
+				return 0.0;
+
+			return coolingCostPer1000 * totalAmount * 0.001;
+		}
+
 		internal static void AddPlannerRates(PartModule cryoModule, List<KeyValuePair<string, double>> resourceChangeRequest)
 		{
-			if (cryoModule == null || !CryoTanks.GetCoolingEnabled(cryoModule))
+			if (cryoModule == null || cryoModule.part == null)
 				return;
 
 			IList fuels = CryoTankAccess.GetFuels(cryoModule);
-			float coolingCost = CryoTanks.GetCoolingCost(cryoModule);
-			if (fuels == null || coolingCost <= 0f)
+			if (fuels == null)
 				return;
 
-			double totalCost = 0.0;
+			bool coolingEnabled = CryoTanks.GetCoolingEnabled(cryoModule);
+			double ecRate = EstimateCoolingEcRate(cryoModule, cryoModule.part);
+
+			if (coolingEnabled && ecRate > 0.0)
+			{
+				resourceChangeRequest.Add(new KeyValuePair<string, double>("ElectricCharge", -ecRate));
+				return;
+			}
+
+			// Cooling off, or tank has no cooling cost: report boiloff in planner.
 			foreach (object fuel in fuels)
 			{
 				string fuelName = CryoTankAccess.GetFuelName(fuel);
@@ -27,12 +107,15 @@ namespace KERBALISM
 					continue;
 
 				double amount = Lib.Amount(cryoModule.part, fuelName);
-				if (amount > double.Epsilon)
-					totalCost += coolingCost * amount * 0.001;
-			}
+				if (amount <= double.Epsilon)
+					continue;
 
-			if (totalCost > 0.0)
-				resourceChangeRequest.Add(new KeyValuePair<string, double>("ElectricCharge", -totalCost));
+				double boiloffRate = CryoTankAccess.GetBoiloffRate(fuel) / 360000.0;
+				if (boiloffRate <= 0.0)
+					continue;
+
+				resourceChangeRequest.Add(new KeyValuePair<string, double>(fuelName, -amount * boiloffRate));
+			}
 		}
 
 		internal static string UpdateLoaded(PartModule cryoModule, Vessel v)
@@ -47,11 +130,26 @@ namespace KERBALISM
 			KERBALISM.ResourceBroker broker = KERBALISM.ResourceBroker.GetOrCreate(BrokerName, KERBALISM.ResourceBroker.BrokerCategory.VesselSystem, BrokerTitle);
 			ResourceInfo ec = KERBALISM.ResourceCache.GetResource(v, "ElectricCharge");
 			double dt = TimeWarp.fixedDeltaTime;
-			double totalEcRate = 0.0;
-			double totalCost = 0.0;
 			bool coolingEnabled = CryoTanks.GetCoolingEnabled(cryoModule);
-			float coolingCost = CryoTanks.GetCoolingCost(cryoModule);
+			double ecRate = EstimateCoolingEcRate(cryoModule, cryoModule.part);
 
+			if (coolingEnabled && ecRate > 0.0)
+			{
+				// Fail only when EC cannot pay ~1s of cooling, not the full physics step.
+				if (ec.Amount < ecRate)
+				{
+					CryoTanks.SetCoolingEnabled(cryoModule, false);
+					SyncCryoTankPaw(cryoModule, false, true, ecRate);
+				}
+				else
+				{
+					ec.Consume(ecRate * dt, broker);
+					SyncCryoTankPaw(cryoModule, true, false, ecRate);
+					return BrokerTitle;
+				}
+			}
+
+			double boiloffPerSecond = 0.0;
 			foreach (object fuel in fuels)
 			{
 				string fuelName = CryoTankAccess.GetFuelName(fuel);
@@ -62,30 +160,38 @@ namespace KERBALISM
 				if (resource == null || resource.amount <= double.Epsilon)
 					continue;
 
-				if (coolingEnabled && coolingCost > 0f)
+				double boiled = CryoUtils.ApplyBoiloffAmount(resource.amount, CryoTankAccess.GetBoiloffRate(fuel), dt);
+				if (boiled > double.Epsilon)
 				{
-					double fuelEcRate = coolingCost * resource.amount * 0.001;
-					totalEcRate += fuelEcRate;
-					totalCost += fuelEcRate * dt;
-				}
-				else
-				{
-					double boiled = CryoUtils.ApplyBoiloffAmount(resource.amount, CryoTankAccess.GetBoiloffRate(fuel), dt);
-					if (boiled > double.Epsilon)
-						resource.amount = (float)(resource.amount - boiled);
+					KERBALISM.ResourceCache.GetResource(v, fuelName).Consume(boiled, broker);
+					if (dt > double.Epsilon)
+						boiloffPerSecond += boiled / dt;
 				}
 			}
 
-			if (coolingEnabled && totalCost > double.Epsilon)
-			{
-				// Fail only when EC cannot pay ~1s of cooling, not the full physics step.
-				if (ec.Amount < totalEcRate)
-					CryoTanks.SetCoolingEnabled(cryoModule, false);
-				else
-					ec.Consume(totalCost, broker);
-			}
-
+			SyncCryoTankPaw(cryoModule, false, boiloffPerSecond > 0.0, ecRate, boiloffPerSecond);
 			return BrokerTitle;
+		}
+
+		static void SyncCryoTankPaw(PartModule cryoModule, bool cooling, bool boiling, double ecRate, double boiloffPerSecond = 0.0)
+		{
+			// Native ModuleCryoTank.FixedUpdate is skipped while the updater is present.
+			if (cooling)
+			{
+				CryoTanks.Set(cryoModule, "BoiloffOccuring", false);
+				CryoTanks.Set(cryoModule, "BoiloffStatus", Localizer.Format("#LOC_CryoTanks_ModuleCryoTank_Field_BoiloffStatus_Insulated"));
+				CryoTanks.Set(cryoModule, "CoolingStatus", Localizer.Format("#LOC_CryoTanks_ModuleCryoTank_Field_CoolingStatus_Cooling", ecRate.ToString("F2")));
+				CryoTanks.Set(cryoModule, "currentCoolingCost", ecRate);
+				return;
+			}
+
+			CryoTanks.Set(cryoModule, "BoiloffOccuring", boiling);
+			CryoTanks.Set(cryoModule, "currentCoolingCost", 0.0);
+			CryoTanks.Set(cryoModule, "CoolingStatus", Localizer.Format("#LOC_CryoTanks_ModuleCryoTank_Field_CoolingStatus_Disabled"));
+			if (boiling && boiloffPerSecond > 0.0)
+				CryoTanks.Set(cryoModule, "BoiloffStatus", string.Format("-{0:F3}/s", boiloffPerSecond));
+			else
+				CryoTanks.Set(cryoModule, "BoiloffStatus", Localizer.Format("#LOC_CryoTanks_ModuleCryoTank_Field_CoolingStatus_Disabled"));
 		}
 
 		internal static string BackgroundUpdate(
@@ -104,10 +210,15 @@ namespace KERBALISM
 				return BrokerTitle;
 
 			ResourceInfo ec = KERBALISM.ResourceCache.Get(v).GetResource(v, "ElectricCharge");
-			bool coolingAvailable = coolingEnabled && ec.Amount > double.Epsilon;
-			double totalEcCost = 0.0;
+			double ecRate = EstimateCoolingEcRate(cryoPrefab, part);
 			string brokerTitle = BrokerTitle;
-			float coolingCost = CryoTanks.GetCoolingCost(cryoPrefab);
+
+			// When cooling can run, EC is reported via resourceChangeRequest in CryoTankKerbalismUpdater.
+			if (coolingEnabled && ecRate > 0.0 && ec.Amount >= ecRate)
+				return brokerTitle;
+
+			if (coolingEnabled && ecRate > 0.0)
+				Lib.Proto.Set(cryoSnapshot, "CoolingEnabled", false);
 
 			foreach (object fuel in fuels)
 			{
@@ -119,21 +230,9 @@ namespace KERBALISM
 				if (protoFuel == null || protoFuel.amount <= double.Epsilon)
 					continue;
 
-				double amount = protoFuel.amount;
-
-				if (coolingAvailable && coolingCost > 0f)
-				{
-					totalEcCost += coolingCost * amount * 0.001;
-				}
-				else
-				{
-					double boiled = CryoUtils.ApplyBoiloffAmount(amount, CryoTankAccess.GetBoiloffRate(fuel), elapsed_s);
-					CryoUtils.ConsumePartResource(part, fuelName, boiled, v, brokerTitle);
-				}
+				double boiled = CryoUtils.ApplyBoiloffAmount(protoFuel.amount, CryoTankAccess.GetBoiloffRate(fuel), elapsed_s);
+				CryoUtils.ConsumePartResource(part, fuelName, boiled, v, brokerTitle);
 			}
-
-			if (totalEcCost > 0.0 && ec.Amount < totalEcCost)
-				Lib.Proto.Set(cryoSnapshot, "CoolingEnabled", false);
 
 			return brokerTitle;
 		}

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -193,7 +193,9 @@ namespace KERBALISM.Planner
 								Process_radioisotope_generator(p, m);
 								break;
 							case "ModuleCryoTank":
-								Process_cryotank(p, m);
+								// CryoTankKerbalismUpdater owns planner rates when present (per-fuel CoolingCost).
+								if (p.FindModuleImplementing<CryoTankKerbalismUpdater>() == null)
+									Process_cryotank(p, m);
 								break;
 							case "ModuleRTAntennaPassive":
 								Process_rtantenna(m);
@@ -686,56 +688,43 @@ namespace KERBALISM.Planner
 
 		void Process_cryotank(Part p, PartModule m)
 		{
-			// is cooling available
+			// Fallback when CryoTankKerbalismUpdater is absent.
+			// CoolingCost may be module-level and/or per BOILOFFCONFIG fuel entry.
 			bool available = Lib.ReflectionValue<bool>(m, "CoolingEnabled");
-
-			// get list of fuels, do nothing if no fuels
 			IList fuels = Lib.ReflectionValue<IList>(m, "fuels");
 			if (fuels == null)
 				return;
 
-			// get cooling cost
-			double cooling_cost = Lib.ReflectionValue<float>(m, "CoolingCost");
+			float module_cooling_cost = Lib.ReflectionValue<float>(m, "CoolingCost");
+			float present_fuel_cooling_cost = 0f;
+			double total_amount = 0.0;
 
-			string fuel_name = "";
-			double amount = 0.0;
-			double total_cost = 0.0;
-			double boiloff_rate = 0.0;
-
-			// calculate EC cost of cooling
 			foreach (object fuel in fuels)
 			{
-				fuel_name = Lib.ReflectionValue<string>(fuel, "fuelName");
-				// if fuel_name is null, don't do anything
+				string fuel_name = Lib.ReflectionValue<string>(fuel, "fuelName");
 				if (fuel_name == null)
 					continue;
 
-				// get amount in the part
-				amount = Lib.Amount(p, fuel_name);
+				double amount = Lib.Amount(p, fuel_name);
+				if (amount <= double.Epsilon)
+					continue;
 
-				// if there is some fuel
-				if (amount > double.Epsilon)
+				present_fuel_cooling_cost += Lib.ReflectionValue<float>(fuel, "coolingCost");
+				total_amount += amount;
+
+				if (!available)
 				{
-					// if cooling is enabled
-					if (available)
-					{
-						// calculate ec consumption
-						total_cost += cooling_cost * amount * 0.001;
-					}
-					// if cooling is disabled
-					else
-					{
-						// get boiloff rate per-second
-						boiloff_rate = Lib.ReflectionValue<float>(fuel, "boiloffRate") / 360000.0f;
-
-						// let it boil off
-						Resource(fuel_name).Consume(amount * boiloff_rate, Local.Planner_source_cryotank);
-					}
+					double boiloff_rate = Lib.ReflectionValue<float>(fuel, "boiloffRate") / 360000.0f;
+					Resource(fuel_name).Consume(amount * boiloff_rate, Local.Planner_source_cryotank);
 				}
 			}
 
-			// apply EC consumption
-			Resource("ElectricCharge").Consume(total_cost, Local.Planner_source_cryotank);
+			if (available && total_amount > double.Epsilon)
+			{
+				double total_cost = (module_cooling_cost + present_fuel_cooling_cost) * total_amount * 0.001;
+				if (total_cost > 0.0)
+					Resource("ElectricCharge").Consume(total_cost, Local.Planner_source_cryotank);
+			}
 		}
 
 		void Process_rtantenna(PartModule m)


### PR DESCRIPTION
1. Fix ModuleCryoTank planner/monitor accounting for modern CryoTanks configs where `CoolingCost` lives in `BOILOFFCONFIG` (per fuel), not only on the module (#534).
2. Simulate cooling EC and boiloff through Kerbalism resource brokers so Monitor no longer shows losses under "Other".
3. Expose cryo tank cooling (`CoolingEnabled`) as an Automation device for EC/sunlight scripts (#264 ).
