### PR TITLE
Remove obsolete pre-3.1 save migration code

### DIFF
--- a/src/Kerbalism/Background.cs
+++ b/src/Kerbalism/Background.cs
@@ -198,9 +198,6 @@ namespace KERBALISM
 				// for each module
 				foreach (ProtoPartModuleSnapshot m in p.modules)
 				{
-					// TODO : this is to migrate pre-3.1 saves using WarpFixer to the new SolarPanelFixer. At some point in the future we can remove this code.
-					if (m.moduleName == "WarpFixer") MigrateWarpFixer(v, part_prefab, p, m);
-
 					// get the module prefab
 					// if the prefab doesn't contain this module, skip it
 					PartModule module_prefab = Lib.ModulePrefab(part_prefab.Modules, m.moduleName, PD);
@@ -593,53 +590,6 @@ namespace KERBALISM
 
 			// apply EC consumption
 			ec.Consume(total_cost * elapsed_s, ResourceBroker.Cryotank);
-		}
-
-		// TODO : this is to migrate pre-3.1 saves using WarpFixer to the new SolarPanelFixer. At some point in the future we can remove this code.
-		static void MigrateWarpFixer(Vessel v, Part prefab, ProtoPartSnapshot p, ProtoPartModuleSnapshot m)
-		{
-			ModuleDeployableSolarPanel panelModule = prefab.FindModuleImplementing<ModuleDeployableSolarPanel>();
-			ProtoPartModuleSnapshot protoPanelModule = p.modules.Find(pm => pm.moduleName == "ModuleDeployableSolarPanel");
-
-			if (panelModule == null || protoPanelModule == null)
-			{
-				Lib.Log("Vessel " + v.name + " has solar panels that can't be converted automatically following Kerbalism 3.1 update. Load it to fix the issue.");
-				return;
-			}
-
-			SolarPanelFixer.PanelState state = SolarPanelFixer.PanelState.Unknown;
-			string panelStateStr = Lib.Proto.GetString(protoPanelModule, "deployState");
-
-			if (!Enum.IsDefined(typeof(ModuleDeployablePart.DeployState), panelStateStr)) return;
-			ModuleDeployablePart.DeployState panelState = (ModuleDeployablePart.DeployState)Enum.Parse(typeof(ModuleDeployablePart.DeployState), panelStateStr);
-
-			if (panelState == ModuleDeployablePart.DeployState.BROKEN)
-				state = SolarPanelFixer.PanelState.Broken;
-			else if (!panelModule.isTracking)
-			{
-				state = SolarPanelFixer.PanelState.Static;
-			}
-			else
-			{
-				switch (panelState)
-				{
-					case ModuleDeployablePart.DeployState.EXTENDED:
-						if (!panelModule.retractable)
-							state = SolarPanelFixer.PanelState.ExtendedFixed;
-						else
-							state = SolarPanelFixer.PanelState.Extended;
-						break;
-					case ModuleDeployablePart.DeployState.RETRACTED: state = SolarPanelFixer.PanelState.Retracted; break;
-					case ModuleDeployablePart.DeployState.RETRACTING: state = SolarPanelFixer.PanelState.Retracting; break;
-					case ModuleDeployablePart.DeployState.EXTENDING: state = SolarPanelFixer.PanelState.Extending; break;
-					default: state = SolarPanelFixer.PanelState.Unknown; break;
-				}
-			}
-
-			m.moduleName = "SolarPanelFixer";
-			Lib.Proto.Set(m, "state", state);
-			Lib.Proto.Set(m, "launchUT", Planetarium.GetUniversalTime());
-			Lib.Proto.Set(m, "nominalRate", panelModule.chargeRate);
 		}
 	}
 } // KERBALISM

--- a/src/Kerbalism/Database/DB.cs
+++ b/src/Kerbalism/Database/DB.cs
@@ -11,12 +11,7 @@ namespace KERBALISM
         {
             // get version (or use current one for new savegames)
             string versionStr = Lib.ConfigValue(node, "version", Lib.KerbalismVersion.ToString());
-            // sanitize old saves (pre 3.1) format (X.X.X.X) to new format (X.X)
-            if (versionStr.Split('.').Length > 2) versionStr = versionStr.Split('.')[0] + "." + versionStr.Split('.')[1];
             version = new Version(versionStr);
-
-            // if this is an unsupported version, print warning
-            if (version <= new Version(1, 2)) Lib.Log("loading save from unsupported version " + version);
 
             // get unique id (or generate one for new savegames)
             uid = Lib.ConfigValue(node, "uid", Lib.RandomInt(int.MaxValue));
@@ -59,33 +54,6 @@ namespace KERBALISM
 				}
 			}
 			Profiler.EndSample();
-
-			// for compatibility with old saves, convert drives data (it's now saved in PartData)
-			if (node.HasNode("drives"))
-			{
-				Dictionary<uint, PartData> allParts = new Dictionary<uint, PartData>();
-				foreach (VesselData vesselData in vessels.Values)
-				{
-					foreach (PartData partData in vesselData.PartDatas)
-					{
-						// we had a case of someone having a save with multiple parts having the same flightID
-						// 5 duplicates, all were asteroids.
-						if (!allParts.ContainsKey(partData.FlightId))
-						{
-							allParts.Add(partData.FlightId, partData);
-						}
-					}
-				}
-
-				foreach (var drive_node in node.GetNode("drives").GetNodes())
-				{
-					uint driveId = Lib.Parse.ToUInt(drive_node.name);
-					if (allParts.ContainsKey(driveId))
-					{
-						allParts[driveId].Drive = new Drive(drive_node);
-					}
-				}
-			}
 
 			// load bodies data
 			storms = new Dictionary<string, StormData>();

--- a/src/Kerbalism/Modules/Habitat.cs
+++ b/src/Kerbalism/Modules/Habitat.cs
@@ -37,11 +37,7 @@ namespace KERBALISM
 			/// <summary> deployable is being pressurized by equalizing its pressure with all enabled habitats</summary>
 			waitingForPressureAndEqualizing,
 			/// <summary> special unescapable state for EVA kerbals</summary>
-			evaKerbal,
-			/// <summary> depreciated, kept around for backward compat</summary>
-			pressurizing = 2,
-			/// <summary> depreciated, kept around for backward compat</summary>
-			depressurizing = 0
+			evaKerbal
 		}
 
 		// volume / surface cache

--- a/src/Kerbalism/Radiation/StormData.cs
+++ b/src/Kerbalism/Radiation/StormData.cs
@@ -34,15 +34,6 @@ namespace KERBALISM
 			msg_storm = Lib.ConfigValue(node, "msg_storm", 0u);
 			displayed_duration = Lib.ConfigValue(node, "displayed_duration", storm_duration);
 			display_warning = Lib.ConfigValue(node, "display_warning", true);
-
-			if(storm_time > 0 && storm_duration <= 0) // legacy save games did storms differently.
-			{
-				// storm_time used to be the point of time of the next storm, there was no storm_duration
-				// as storms all had a fixed duration depending on the distance to the sun.
-				// setting this to 0 will trigger a reroll of storm generation based on the new implementation.
-				storm_time = 0;
-				storm_generation = 0;
-			}
 		}
 
 		public void Save(ConfigNode node)

--- a/src/Kerbalism/Science/Drive.cs
+++ b/src/Kerbalism/Science/Drive.cs
@@ -41,23 +41,6 @@ namespace KERBALISM
 							file.subjectData.AddDataCollectedInFlight(file.size);
 						}
 					}
-					else
-					{
-						file = File.LoadOldFormat(subject_id, file_node);
-						if (file != null)
-						{
-							Lib.Log("Drive file load : converted '" + subject_id + "' to new format");
-							if(files.ContainsKey(file.subjectData))
-							{
-								Lib.Log("discarding duplicate converted subject " + file.subjectData, Lib.LogLevel.Warning);
-							}
-							else
-							{
-								files.Add(file.subjectData, file);
-								file.subjectData.AddDataCollectedInFlight(file.size);
-							}
-						}
-					}
 				}
 			}
 
@@ -74,17 +57,6 @@ namespace KERBALISM
 						samples.Add(sample.subjectData, sample);
 						sample.subjectData.AddDataCollectedInFlight(sample.size);
 					}
-					else
-					{
-						sample = Sample.LoadOldFormat(subject_id, sample_node);
-						if (sample != null)
-						{
-							Lib.Log("Drive sample load : converted '" + subject_id + "' to new format");
-							samples.Add(sample.subjectData, sample);
-							sample.subjectData.AddDataCollectedInFlight(sample.size);
-						}
-					}
-
 				}
 			}
 

--- a/src/Kerbalism/Science/File.cs
+++ b/src/Kerbalism/Science/File.cs
@@ -64,27 +64,6 @@ namespace KERBALISM
 			return new File(subjectData, size, useStockCrediting, resultText);
 		}
 
-		// this is a fallback loading method for pre 3.1 / pre build 7212 files saved used the stock subject id
-		public static File LoadOldFormat(string stockSubjectId, ConfigNode node)
-		{
-			SubjectData subjectData = ScienceDB.GetSubjectDataFromStockId(stockSubjectId);
-
-			if (subjectData == null)
-				return null;
-
-			double size = Lib.ConfigValue(node, "size", 0.0);
-			if (double.IsNaN(size))
-			{
-				Lib.LogStack($"File has a NaN size on load : {subjectData.DebugStateInfo}", Lib.LogLevel.Error);
-				return null;
-			}
-
-			string resultText = Lib.ConfigValue(node, "resultText", "");
-			bool useStockCrediting = Lib.ConfigValue(node, "useStockCrediting", false);
-
-			return new File(subjectData, size, useStockCrediting, resultText);
-		}
-
 		public void Save(ConfigNode node)
 		{
 			node.AddValue("size", size);

--- a/src/Kerbalism/Science/Sample.cs
+++ b/src/Kerbalism/Science/Sample.cs
@@ -79,32 +79,6 @@ namespace KERBALISM
 			return sample;
 		}
 
-		// this is a fallback loading method for pre 3.1 / pre build 7212 files saved used the stock subject id
-		public static Sample LoadOldFormat(string stockSubjectId, ConfigNode node)
-		{
-			SubjectData subjectData = ScienceDB.GetSubjectDataFromStockId(stockSubjectId);
-
-			if (subjectData == null)
-				return null;
-
-			double size = Lib.ConfigValue(node, "size", 0.0);
-			if (double.IsNaN(size))
-			{
-				Lib.LogStack($"Sample has a NaN size on load : {subjectData.DebugStateInfo}", Lib.LogLevel.Error);
-				return null;
-			}
-
-			string resultText = Lib.ConfigValue(node, "resultText", "");
-			bool useStockCrediting = Lib.ConfigValue(node, "useStockCrediting", false);
-
-			Sample sample = new Sample(subjectData, size, useStockCrediting, resultText);
-
-			sample.analyze = Lib.ConfigValue(node, "analyze", false);
-			sample.mass = Lib.ConfigValue(node, "mass", 0.0);
-
-			return sample;
-		}
-
 		/// <summary>
 		/// Stores a science sample into the specified config node
 		/// </summary>


### PR DESCRIPTION
Drop WarpFixer→SolarPanelFixer migration and other pre-3.1 save compatibility shims. Modern saves are unaffected.