### PR TITLE
Fix CactEye infinite science exploit

### DIFF
--- a/src/Kerbalism/Science/ScienceDB.cs
+++ b/src/Kerbalism/Science/ScienceDB.cs
@@ -455,8 +455,36 @@ namespace KERBALISM
 					GetSubjectDataFromStockId(stockSubject.id, stockSubject);
 		}
 
+		/// <summary>
+		/// UnknownSubjectData may mirror in-flight science onto the stock subject at runtime (#880).
+		/// Strip that before the game persists RnD subjects so only recovered/transmitted science is saved.
+		/// </summary>
+		public static void PrepareUnknownSubjectsForSave()
+		{
+			foreach (SubjectData subjectData in unknownSubjectDatas.Values)
+			{
+				if (subjectData is UnknownSubjectData unknown)
+					unknown.PrepareStockSubjectForSave();
+			}
+		}
+
+		/// <summary>
+		/// Re-apply retrieved + in-flight science onto stock subjects after a save.
+		/// </summary>
+		public static void SyncUnknownSubjectsCommittedScience()
+		{
+			foreach (SubjectData subjectData in unknownSubjectDatas.Values)
+			{
+				if (subjectData is UnknownSubjectData unknown)
+					unknown.SyncStockSubjectCommittedScience();
+			}
+		}
+
 		public static void Save(ConfigNode node)
 		{
+			// Belt-and-suspenders with onGameStateSave: never persist in-flight commit as retrieved.
+			PrepareUnknownSubjectsForSave();
+
 			// RnD subjects don't exists in sandbox, so we have our own subject persistence
 			if (!Science.GameHasRnD)
 			{
@@ -770,6 +798,13 @@ namespace KERBALISM
 			// if the subject is a "doable" subject, we should have it in the DB.
 			if (extraSituationInfo == null)
 				subjectData = GetSubjectData(expInfo, vesselSituation);
+
+			// Never credit a different stock subject than the one carried by the ScienceData.
+			// Some mods build subjects whose id is not Kerbalism's canonical body+situation id
+			// (CactEye #880: ...InSpaceHighVisualObservation<body>). Collapsing those onto the
+			// generic subject leaves the mod's own RnD entry at science=0 forever.
+			if (subjectData != null && subjectData.StockSubjectId != stockSubjectId)
+				subjectData = null;
 
 			// else create the subjectdata. this can happen either because :
 			// - it's a subject using the stock "extra id" system (asteroid samples)

--- a/src/Kerbalism/Science/SubjectData.cs
+++ b/src/Kerbalism/Science/SubjectData.cs
@@ -50,7 +50,7 @@ namespace KERBALISM
 
 		/// <summary> science points recovered or transmitted </summary>
 		// Note : this code is a bit convoluted to avoid "never completed" issues due to float <> double conversions
-		public double ScienceRetrievedInKSC => ExistsInRnD ? (RnDSubject.scienceCap - RnDSubject.science <= 0f) ? ScienceMaxValue : RnDSubject.science : 0.0;
+		public virtual double ScienceRetrievedInKSC => ExistsInRnD ? (RnDSubject.scienceCap - RnDSubject.science <= 0f) ? ScienceMaxValue : RnDSubject.science : 0.0;
 
 		/// <summary> all science points recovered, transmitted or collected in flight </summary>
 		public double ScienceCollectedTotal => ScienceCollectedInFlight + ScienceRetrievedInKSC;
@@ -188,26 +188,26 @@ namespace KERBALISM
 		}
 
 		/// <summary> add data to the in-flight collected science </summary>
-		public void AddDataCollectedInFlight(double dataAmount)
+		public virtual void AddDataCollectedInFlight(double dataAmount)
 		{
 			ScienceCollectedInFlight += dataAmount * SciencePerMB;
 		}
 
 		/// <summary> remove data from the in-flight collected science </summary>
-		public void RemoveDataCollectedInFlight(double dataAmount)
+		public virtual void RemoveDataCollectedInFlight(double dataAmount)
 		{
 			ScienceCollectedInFlight -= dataAmount * SciencePerMB;
 			if (ScienceCollectedInFlight < 0.0) ScienceCollectedInFlight = 0.0;
 		}
 
 		/// <summary> remove science points from the in-flight collected science </summary>
-		public void RemoveScienceCollectedInFlight(double credits)
+		public virtual void RemoveScienceCollectedInFlight(double credits)
 		{
 			ScienceCollectedInFlight -= credits;
 			if (ScienceCollectedInFlight < 0.0) ScienceCollectedInFlight = 0.0;
 		}
 
-		public void ClearDataCollectedInFlight() => ScienceCollectedInFlight = 0.0;
+		public virtual void ClearDataCollectedInFlight() => ScienceCollectedInFlight = 0.0;
 
 		/// <summary>
 		/// update our subject completion database.
@@ -239,7 +239,7 @@ namespace KERBALISM
 		/// <param name="fromVessel">passed to the OnScienceRecieved gameevent on subject completion. Can be null if not available</param>
 		/// <param name="file">if not null, the "subject completed" completed message will use the result text stored in the file. If null, it will be a generic message</param>
 		/// <returns>The amount of science credited, accounting for the subject + included subjects remaining science value</returns>
-		public double RetrieveScience(double scienceValue, bool showMessage = false, ProtoVessel fromVessel = null, File file = null)
+		public virtual double RetrieveScience(double scienceValue, bool showMessage = false, ProtoVessel fromVessel = null, File file = null)
 		{
 			if (!ExistsInRnD)
 				CreateSubjectInRnD();
@@ -348,11 +348,34 @@ namespace KERBALISM
 			RnDSubject = stockSubject;
 			ScienceCollectedInFlight = 0.0;
 
+			// Mods such as CactEye create the stock ScienceSubject before Kerbalism sees the
+			// ScienceData; link to that existing RnD entry instead of waiting for CreateSubjectInRnD.
+			if (RnDSubject == null)
+				CheckRnD();
+
 			TimesCompleted = ExistsInRnD ? (int)(RnDSubject.science / (RnDSubject.scienceCap - Science.scienceLeftForSubjectCompleted)) : 0;
 			PercentRetrieved = ExistsInRnD ? RnDSubject.science / ScienceMaxValue : 0.0;
 		}
 
 		public override string Id => StockSubjectId;
+
+		/// <summary>
+		/// Kerbalism truth for recovered/transmitted science. Do not read RnDSubject.science here:
+		/// that field may temporarily include in-flight data so external mods cannot re-farm (#880).
+		/// </summary>
+		public override double ScienceRetrievedInKSC
+		{
+			get
+			{
+				if (!ExistsInRnD)
+					return 0.0;
+
+				double retrieved = PercentRetrieved * ScienceMaxValue;
+				if (ScienceMaxValue - retrieved <= Science.scienceLeftForSubjectCompleted)
+					return ScienceMaxValue;
+				return retrieved;
+			}
+		}
 
 		public override string FullTitle =>
 			ExistsInRnD
@@ -370,5 +393,63 @@ namespace KERBALISM
 			: string.IsNullOrEmpty(extraSituationInfo)
 			? Situation.BiomeTitle
 			: Lib.BuildString(Situation.BiomeTitle, " - ", extraSituationInfo);
+
+		public override void AddDataCollectedInFlight(double dataAmount)
+		{
+			base.AddDataCollectedInFlight(dataAmount);
+			SyncStockSubjectCommittedScience();
+		}
+
+		public override void RemoveDataCollectedInFlight(double dataAmount)
+		{
+			base.RemoveDataCollectedInFlight(dataAmount);
+			SyncStockSubjectCommittedScience();
+		}
+
+		public override void RemoveScienceCollectedInFlight(double credits)
+		{
+			base.RemoveScienceCollectedInFlight(credits);
+			SyncStockSubjectCommittedScience();
+		}
+
+		public override void ClearDataCollectedInFlight()
+		{
+			base.ClearDataCollectedInFlight();
+			SyncStockSubjectCommittedScience();
+		}
+
+		public override double RetrieveScience(double scienceValue, bool showMessage = false, ProtoVessel fromVessel = null, File file = null)
+		{
+			double scienceRetrieved = base.RetrieveScience(scienceValue, showMessage, fromVessel, file);
+			SyncStockSubjectCommittedScience();
+			return scienceRetrieved;
+		}
+
+		/// <summary>
+		/// Expose retrieved + in-flight science on the stock subject so mods that gate repeats on
+		/// <see cref="ScienceSubject.science"/> (e.g. CactEye) cannot re-run while data is still aboard.
+		/// </summary>
+		public void SyncStockSubjectCommittedScience()
+		{
+			if (!ExistsInRnD)
+				CreateSubjectInRnD();
+			if (!ExistsInRnD)
+				return;
+
+			RnDSubject.science = (float)Math.Min(ScienceCollectedTotal, RnDSubject.scienceCap);
+			RnDSubject.scientificValue = ResearchAndDevelopment.GetSubjectValue(RnDSubject.science, RnDSubject);
+		}
+
+		/// <summary>
+		/// Persist only recovered/transmitted science on the stock subject; in-flight data lives on drives.
+		/// </summary>
+		public void PrepareStockSubjectForSave()
+		{
+			if (!ExistsInRnD)
+				return;
+
+			RnDSubject.science = (float)Math.Min(ScienceRetrievedInKSC, RnDSubject.scienceCap);
+			RnDSubject.scientificValue = ResearchAndDevelopment.GetSubjectValue(RnDSubject.science, RnDSubject);
+		}
 	}
 }

--- a/src/Kerbalism/System/Callbacks.cs
+++ b/src/Kerbalism/System/Callbacks.cs
@@ -128,8 +128,25 @@ namespace KERBALISM
 			GameEvents.onGamePause.Add(this.OnGamePauseCapture);
 			GameEvents.onGUIApplicationLauncherReady.Add(() => visible = true);
 
+			// UnknownSubjectData may put in-flight science on the stock subject for mod gating (#880).
+			// Persist retrieved-only values, then restore the runtime committed total after save.
+			// Must be instance callbacks: KSP EventData NRE's on static method groups.
+			GameEvents.onGameStateSave.Add(this.OnGameStateSave);
+			GameEvents.onGameStateSaved.Add(this.OnGameStateSaved);
+
 			// add editor events
 			GameEvents.onEditorShipModified.Add((sc) => Planner.Planner.EditorShipModifiedEvent(sc));
+		}
+
+		void OnGameStateSave(ConfigNode node)
+		{
+			ScienceDB.PrepareUnknownSubjectsForSave();
+		}
+
+		void OnGameStateSaved(Game game)
+		{
+			if (HighLogic.CurrentGame == game)
+				ScienceDB.SyncUnknownSubjectsCommittedScience();
 		}
 
         // this require special handling as EVA construction doesn't trigger the other events


### PR DESCRIPTION
1. Fixes Kerbalism/CactEye infinite science: hijacked results were credited to the wrong stock subject, so CactEye never saw the experiment as done.
2. Also reserves in-flight/transmitting science on that subject, so Process Data cannot be re-farmed before transmission finishes.
3. Closes #880
