### PR TITLE
Add Reliability to SSTU Custom Probe Core

### DIFF
--- a/GameData/KerbalismConfig/Support/SSTU.cfg
+++ b/GameData/KerbalismConfig/Support/SSTU.cfg
@@ -469,6 +469,28 @@
 }
 
 //=======================================================================================================
+// Custom Probe Core reliability (#676)
+// Stock SSTU PPC has SAS + INTERNAL antenna but no ModuleReactionWheel, so the
+// default Reliability patches never match. Attach Attitude Control to SAS.
+//=======================================================================================================
+@PART[SSTU-SC-GEN-PPC]:HAS[@MODULE[ModuleSAS],!MODULE[Reliability]]:NEEDS[SSTU,FeatureReliability]:AFTER[zzzKerbalismDefault]
+{
+	MODULE
+	{
+		name = Reliability
+		type = ModuleSAS
+		title = #KERBALISM_Reliability_title_ReactionWheel
+		redundancy = Attitude Control
+		repair = true
+		mtbf = 36288000
+		extra_cost = 0.25
+		extra_mass = 0.15
+		rated_radiation = 0.16
+		radiation_decay_rate = 1.7
+	}
+}
+
+//=======================================================================================================
 // Other habitat / comfort patches
 //=======================================================================================================
 @PART[SSTU-ST-DOS-FEM]:NEEDS[SSTU]:AFTER[KerbalismDefault]


### PR DESCRIPTION
#676 Stock SSTU-SC-GEN-PPC has SAS and an INTERNAL antenna but no reaction wheel, so default Reliability patches never match. Attach Attitude Control reliability to ModuleSAS