### PR TITLE
Warn before boarding when vessel cannot store EVA science (#673)

### DIFF
--- a/GameData/Kerbalism/Localization/de.cfg
+++ b/GameData/Kerbalism/Localization/de.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = Es gibt kein <<1>> im EVA-Anzug // "There isn't any <<1>> in the EVA suit"
     #KERBALISM_CallBackMsg_EvaNoMP2 = Lass die Leiter nicht los! // "Don't let the ladder go!"
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = Das Schiff <<1>> hat nicht genug Speicherplatz für alle Experimente von <<2>> // "The vessel <<1>> doesn't have enough space to store all the experiments carried by <<2>>"
+    #KERBALISM_CallBackMsg_EvaBoardFiles = Dateien auf EVA // "Files on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardSamples = Proben auf EVA // "Samples on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = Speicherkapazität // "Storage capacity"
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = Wenn Sie fortfahren, gehen einige Experimentergebnisse verloren // "If you proceed, some experiment results will be lost"
     #KERBALISM_CallBackMsg_PROGRESS = FORTSCHRITT // "PROGRESS"
     #KERBALISM_CallBackMsg_PROGRESS2 = Unsere Wissenschaftler haben gerade einen Durchbruch geschafft // "Our scientists just made a breakthrough"
     #KERBALISM_CallBackMsg_configureUnlock = Wir haben jetzt Zugriff auf\n<<1>> // "We now have access to \n<<1>>"

--- a/GameData/Kerbalism/Localization/en-us.cfg
+++ b/GameData/Kerbalism/Localization/en-us.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = There isn't any <<1>> in the EVA suit
     #KERBALISM_CallBackMsg_EvaNoMP2 = Don't let the ladder go!
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = The vessel <<1>> doesn't have enough space to store all the experiments carried by <<2>>
+    #KERBALISM_CallBackMsg_EvaBoardFiles = Files on EVA
+    #KERBALISM_CallBackMsg_EvaBoardSamples = Samples on EVA
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = Storage capacity
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = If you proceed, some experiment results will be lost
     #KERBALISM_CallBackMsg_PROGRESS = PROGRESS
     #KERBALISM_CallBackMsg_PROGRESS2 = Our scientists just made a breakthrough
     #KERBALISM_CallBackMsg_configureUnlock = We now have access to \n<<1>>

--- a/GameData/Kerbalism/Localization/es-es.cfg
+++ b/GameData/Kerbalism/Localization/es-es.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = No hay <<1>> en el traje EVA
     #KERBALISM_CallBackMsg_EvaNoMP2 = ¡No sueltes la escalera!
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = La nave <<1>> no tiene suficiente espacio para almacenar todos los experimentos que lleva <<2>>
+    #KERBALISM_CallBackMsg_EvaBoardFiles = Archivos en EVA
+    #KERBALISM_CallBackMsg_EvaBoardSamples = Muestras en EVA
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = Capacidad de almacenamiento
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = Si continúas, se perderán algunos resultados de experimentos
     #KERBALISM_CallBackMsg_PROGRESS = PROGRESO
     #KERBALISM_CallBackMsg_PROGRESS2 = Nuestros científicos acaban de lograr un avance
     #KERBALISM_CallBackMsg_configureUnlock = Ahora tenemos acceso a\n<<1>> // "We now have access to \n<<1>>"

--- a/GameData/Kerbalism/Localization/fr-fr.cfg
+++ b/GameData/Kerbalism/Localization/fr-fr.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = Il n'y a pas de <<1>> dans la combinaison d'AEV // "There isn't any <<1>> in the EVA suit"
     #KERBALISM_CallBackMsg_EvaNoMP2 = Ne lâchez pas l'échelle ! // "Don't let the ladder go!"
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = Le vaisseau <<1>> n'a pas assez d'espace pour stocker toutes les expériences transportées par <<2>> // "The vessel <<1>> doesn't have enough space to store all the experiments carried by <<2>>"
+    #KERBALISM_CallBackMsg_EvaBoardFiles = Fichiers en EVA // "Files on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardSamples = Échantillons en EVA // "Samples on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = Capacité de stockage // "Storage capacity"
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = Si vous continuez, certains résultats d'expériences seront perdus // "If you proceed, some experiment results will be lost"
     #KERBALISM_CallBackMsg_PROGRESS = PROGRÈS // "PROGRESS"
     #KERBALISM_CallBackMsg_PROGRESS2 = Nos scientifiques viennent de faire une avancé // "Our scientists just made a breakthrough"
     #KERBALISM_CallBackMsg_configureUnlock = Nous avons maintenant acc猫s 脿\n<<1>> // "We now have access to \n<<1>>"

--- a/GameData/Kerbalism/Localization/it-it.cfg
+++ b/GameData/Kerbalism/Localization/it-it.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = Non c'è <<1>> nella tuta EVA // "There isn't any <<1>> in the EVA suit"
     #KERBALISM_CallBackMsg_EvaNoMP2 = Non lasciare andare la scala! // "Don't let the ladder go!"
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = Il veicolo <<1>> non ha abbastanza spazio per memorizzare tutti gli esperimenti trasportati da <<2>> // "The vessel <<1>> doesn't have enough space to store all the experiments carried by <<2>>"
+    #KERBALISM_CallBackMsg_EvaBoardFiles = File in EVA // "Files on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardSamples = Campioni in EVA // "Samples on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = Capacità di archiviazione // "Storage capacity"
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = Se procedi, alcuni risultati degli esperimenti andranno persi // "If you proceed, some experiment results will be lost"
     #KERBALISM_CallBackMsg_PROGRESS = PROGRESSO // "PROGRESS"
     #KERBALISM_CallBackMsg_PROGRESS2 = I nostri scienziati hanno appena fatto una scoperta // "Our scientists just made a breakthrough"
     #KERBALISM_CallBackMsg_configureUnlock = Ora abbiamo accesso a\n<<1>> // "We now have access to \n<<1>>"

--- a/GameData/Kerbalism/Localization/ko-kr.cfg
+++ b/GameData/Kerbalism/Localization/ko-kr.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = EVA 슈트에 << 1 >>이 없습니다
     #KERBALISM_CallBackMsg_EvaNoMP2 = 사다리를 놓지 마십시오!
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = 선박 <<1>>에는 <<2>>가 가진 모든 실험 데이터를 저장할 공간이 부족합니다
+    #KERBALISM_CallBackMsg_EvaBoardFiles = EVA의 파일
+    #KERBALISM_CallBackMsg_EvaBoardSamples = EVA의 샘플
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = 저장 용량
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = 계속하면 일부 실험 결과가 손실됩니다
     #KERBALISM_CallBackMsg_PROGRESS = 진행
     #KERBALISM_CallBackMsg_PROGRESS2 = 우리 과학자들은 방금 돌파구를 만들었습니다
     #KERBALISM_CallBackMsg_configureUnlock = 이제 다음에 접근할 수 있습니다\n<<1>>

--- a/GameData/Kerbalism/Localization/pt-br.cfg
+++ b/GameData/Kerbalism/Localization/pt-br.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = Não há <<1>> no traje EVA
     #KERBALISM_CallBackMsg_EvaNoMP2 = Não solte a escada!
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = A nave <<1>> não tem espaço suficiente para armazenar todos os experimentos carregados por <<2>>
+    #KERBALISM_CallBackMsg_EvaBoardFiles = Arquivos no EVA
+    #KERBALISM_CallBackMsg_EvaBoardSamples = Amostras no EVA
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = Capacidade de armazenamento
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = Se continuar, alguns resultados de experimentos serão perdidos
     #KERBALISM_CallBackMsg_PROGRESS = Progresso
     #KERBALISM_CallBackMsg_PROGRESS2 = Nossos cientistas acabaram de fazer uma descoberta
     #KERBALISM_CallBackMsg_configureUnlock = Agora temos acesso a\n<<1>> // "We now have access to \n<<1>>"

--- a/GameData/Kerbalism/Localization/ru.cfg
+++ b/GameData/Kerbalism/Localization/ru.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = В скафандре ВКД нет <<1>>
     #KERBALISM_CallBackMsg_EvaNoMP2 = Не отпускайте лестницу!
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = На корабле <<1>> недостаточно места для хранения всех экспериментов, которые несёт <<2>>
+    #KERBALISM_CallBackMsg_EvaBoardFiles = Файлы на EVA
+    #KERBALISM_CallBackMsg_EvaBoardSamples = Образцы на EVA
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = Ёмкость хранилища
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = Если продолжить, некоторые результаты экспериментов будут потеряны
     #KERBALISM_CallBackMsg_PROGRESS = ПРОГРЕСС
     #KERBALISM_CallBackMsg_PROGRESS2 = Наши ученые только что совершили прорыв // "Our scientists just made a breakthrough"
     #KERBALISM_CallBackMsg_configureUnlock = 孝械锌械褉褜 褍 薪邪褋 械褋褌褜 写芯褋褌褍锌 泻\n<<1>> // "We now have access to \n<<1>>"

--- a/GameData/Kerbalism/Localization/zh-cn.cfg
+++ b/GameData/Kerbalism/Localization/zh-cn.cfg
@@ -870,6 +870,11 @@ Localization
     //
     #KERBALISM_CallBackMsg_EvaNoMP = 宇航服内已没有任何<<1>> // "There isn't any <<1>> in the EVA suit"
     #KERBALISM_CallBackMsg_EvaNoMP2 = 抓稳梯子千万别放手! // "Don't let the ladder go!"
+    #KERBALISM_CallBackMsg_EvaBoardNoSpace = 飞船 <<1>> 没有足够空间存放 <<2>> 携带的全部实验数据 // "The vessel <<1>> doesn't have enough space to store all the experiments carried by <<2>>"
+    #KERBALISM_CallBackMsg_EvaBoardFiles = EVA 上的数据文件 // "Files on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardSamples = EVA 上的样本 // "Samples on EVA"
+    #KERBALISM_CallBackMsg_EvaBoardStorageCapacity = 存储容量 // "Storage capacity"
+    #KERBALISM_CallBackMsg_EvaBoardDataLoss = 若继续登船，部分实验结果将会丢失 // "If you proceed, some experiment results will be lost"
     #KERBALISM_CallBackMsg_PROGRESS = 进展 // "PROGRESS"
     #KERBALISM_CallBackMsg_PROGRESS2 = 我们的科学家刚刚取得了突破 // "Our scientists just made a breakthrough"
     #KERBALISM_CallBackMsg_configureUnlock = 我们现在可以使用\n<<1>> // "We now have access to \n<<1>>"

--- a/src/Kerbalism/LocalizationCache.cs
+++ b/src/Kerbalism/LocalizationCache.cs
@@ -1160,6 +1160,11 @@ namespace KERBALISM
 		////////////////////////////////////////////////////////////////////
 		public static ParamString CallBackMsg_EvaNoMP = new ParamString("CallBackMsg_EvaNoMP"); // "There isn't any <<1>> in the EVA suit"
 		public static string CallBackMsg_EvaNoMP2 = GetLoc("CallBackMsg_EvaNoMP2"); // "Don't let the ladder go!"
+		public static ParamString CallBackMsg_EvaBoardNoSpace = new ParamString("CallBackMsg_EvaBoardNoSpace"); // "The vessel <<1>> doesn't have enough space to store all the experiments carried by <<2>>"
+		public static string CallBackMsg_EvaBoardFiles = GetLoc("CallBackMsg_EvaBoardFiles"); // "Files on EVA"
+		public static string CallBackMsg_EvaBoardSamples = GetLoc("CallBackMsg_EvaBoardSamples"); // "Samples on EVA"
+		public static string CallBackMsg_EvaBoardStorageCapacity = GetLoc("CallBackMsg_EvaBoardStorageCapacity"); // "Storage capacity"
+		public static string CallBackMsg_EvaBoardDataLoss = GetLoc("CallBackMsg_EvaBoardDataLoss"); // "If you proceed, some experiment results will be lost"
 		public static string CallBackMsg_PROGRESS = GetLoc("CallBackMsg_PROGRESS"); // "PROGRESS"
 		public static string CallBackMsg_PROGRESS2 = GetLoc("CallBackMsg_PROGRESS2"); // "Our scientists just made a breakthrough"
 		public static ParamString CallBackMsg_configureUnlock = new ParamString("CallBackMsg_configureUnlock"); // "We now have access to \n<<1>>"

--- a/src/Kerbalism/System/Callbacks.cs
+++ b/src/Kerbalism/System/Callbacks.cs
@@ -73,9 +73,24 @@ namespace KERBALISM
 		}
 	}
 
+	// Create an OnAttemptBoard event that allows preventing boarding a vessel from EVA
+	// Called before anything (experiments/inventory...) has been transferred to the boarded vessel
+	[HarmonyPatch(typeof(KerbalEVA))]
+	[HarmonyPatch("BoardPart")]
+	class KerbalEVA_BoardPart
+	{
+		static bool Prefix(KerbalEVA __instance, Part p)
+		{
+			// continue to BoardPart() if AttemptBoard returns true
+			return Kerbalism.Callbacks.AttemptBoard(__instance, p);
+		}
+	}
+
 	public sealed class Callbacks
 	{
 		public static EventData<Part, Configure> onConfigure = new EventData<Part, Configure>("onConfigure");
+
+		private static bool ignoreNextBoardAttemptDriveCheck = false;
 
 		public Callbacks()
 		{
@@ -417,6 +432,86 @@ namespace KERBALISM
             }
         }
 
+
+		/// <summary>
+		/// Stock-alike confirmation before boarding when the target vessel cannot store all EVA science.
+		/// Backported from Kerbalism 4 (#673).
+		/// </summary>
+		public bool AttemptBoard(KerbalEVA instance, Part targetPart)
+		{
+			if (!Features.Science || instance == null || targetPart == null || instance.vessel == null || targetPart.vessel == null)
+			{
+				ignoreNextBoardAttemptDriveCheck = false;
+				return true;
+			}
+
+			if (!ignoreNextBoardAttemptDriveCheck)
+			{
+				double filesSize = 0.0;
+				double fileCapacity = 0.0;
+				int samplesSize = 0;
+				int samplesCapacity = 0;
+				bool unlimitedFileCapacity = false;
+				bool unlimitedSampleCapacity = false;
+
+				foreach (Drive drive in Drive.GetDrives(instance.vessel, true))
+				{
+					filesSize += drive.FilesSize();
+					samplesSize += drive.SamplesSize();
+				}
+
+				if (filesSize <= double.Epsilon && samplesSize <= 0)
+				{
+					ignoreNextBoardAttemptDriveCheck = false;
+					return true;
+				}
+
+				foreach (Drive drive in Drive.GetDrives(targetPart.vessel))
+				{
+					double availableFiles = drive.FileCapacityAvailable();
+					if (availableFiles >= double.MaxValue / 2.0)
+						unlimitedFileCapacity = true;
+					else
+						fileCapacity += availableFiles;
+
+					double availableSamples = drive.SampleCapacityAvailable();
+					if (availableSamples >= double.MaxValue / 2.0)
+						unlimitedSampleCapacity = true;
+					else
+						samplesCapacity += Lib.SampleSizeToSlots(availableSamples);
+				}
+
+				bool filesDontFit = !unlimitedFileCapacity && filesSize > fileCapacity;
+				bool samplesDontFit = !unlimitedSampleCapacity && samplesSize > samplesCapacity;
+
+				if (filesDontFit || samplesDontFit)
+				{
+					string message = Lib.BuildString(
+						Local.CallBackMsg_EvaBoardNoSpace.Format(targetPart.vessel.vesselName, instance.vessel.vesselName),
+						"\n\n",
+						Local.CallBackMsg_EvaBoardFiles, " : ", Lib.HumanReadableDataSize(filesSize),
+						" - ", Local.CallBackMsg_EvaBoardStorageCapacity, " : ", Lib.HumanReadableDataSize(fileCapacity), "\n",
+						Local.CallBackMsg_EvaBoardSamples, " : ", Lib.HumanReadableSampleSize(samplesSize),
+						" - ", Local.CallBackMsg_EvaBoardStorageCapacity, " : ", Lib.HumanReadableSampleSize(samplesCapacity), "\n\n",
+						Local.CallBackMsg_EvaBoardDataLoss);
+
+					Lib.Popup(
+						Localizer.Format("#autoLOC_116007"), // Cannot store Experiments
+						message,
+						new DialogGUIButton(Localizer.Format("#autoLOC_116008"), () => // Board Anyway\n(Dump Experiments)
+						{
+							ignoreNextBoardAttemptDriveCheck = true;
+							instance.BoardPart(targetPart);
+						}),
+						new DialogGUIButton(Localizer.Format("#autoLOC_116009"), () => { })); // Cancel
+
+					return false;
+				}
+			}
+
+			ignoreNextBoardAttemptDriveCheck = false;
+			return true;
+		}
 
 		void FromEVA(GameEvents.FromToAction<Part, Part> data)
 		{


### PR DESCRIPTION
Backport Got's Kerbalism 4 stock-alike boarding dialog: when the target vessel cannot store all EVA science, show Cancel / Board Anyway (Dump Experiments) before boarding.
Ref: https://github.com/Kerbalism/Kerbalism/blob/b55459a96c95ac7d51b0058b279e32f688e22baa/src/Kerbalism/System/Callbacks.cs#L335-L379
Fixes #673


## Before / After
| Before | After |
| --- | --- |
| <img width="450" alt="Before" src="https://github.com/user-attachments/assets/6f5cbce4-97ec-4336-bc85-c1199a0c6cca" /> | <img width="450" alt="After 1" src="https://github.com/user-attachments/assets/64d89d7a-14cb-4cb3-88f9-e3a9c524d900" /> |
| | <img width="450" alt="After 2" src="https://github.com/user-attachments/assets/09d2472c-46b4-4d2f-ac99-8dfd1c09d901" /> |