### PR TITLE
Use the SpaceHigh modifier for Space/Global for stars (#1089)

### DIFF
--- a/src/Kerbalism/Science/ScienceSituation.cs
+++ b/src/Kerbalism/Science/ScienceSituation.cs
@@ -130,6 +130,7 @@ namespace KERBALISM
 					result = body.scienceValues.FlyingHighDataValue; break;
 				case ScienceSituation.BodyGlobal:
 				case ScienceSituation.Space:
+					result = Lib.IsSun(body) ? body.scienceValues.InSpaceHighDataValue : body.scienceValues.InSpaceLowDataValue; break;
 				case ScienceSituation.InSpaceLow:
 					result = body.scienceValues.InSpaceLowDataValue; break;
 				case ScienceSituation.InSpaceHigh:


### PR DESCRIPTION
For https://github.com/Kerbalism/Kerbalism/issues/1089
The InSpaceLow modifier for Sun in stock solar system is 11x. Since this is a difficult situation to get to it is not reasonable to use it for the Space and Global situations.
Retain existing modifier for all other bodies.
This affects Kerbalism's GeigerCounter experiment. This is a reduction of 36 science for each of the virtual biomes that apply to suns (NoBiome, Storm, Interstellar)