### PR TITLE
Add support for Planetside Exploration Technologies (#1092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  - 2026-07-13
 
  ### Changes since the last release
+ * Added: Planetside Exploration Technologies (Benjee10_MMSEV) support — habitat volumes, comfort, greenhouse, logistics supply containers, and expandable HDU attic inflate Habitat (@Aebestach)
  * Added: SystemHeat native integration with automation devices, background thermal simulation, DynamicRadiation support for Sterling Systems power-dependent emitters, and expanded optional-mod configs for CryoTanks, Far Future Technologies, Near Future Electrical, Sterling Systems, KPBS, Buffalo SAFER, and SpaceDust harvesters (#1052, @Aebestach)
  * Added: VABOrganizer part categories (#983, @LouisB3)
  * Added: HabTech2 part upgrade dependency (#979, @LouisB3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
  - 2026-07-13
 
  ### Changes since the last release
- * Added: Planetside Exploration Technologies (Benjee10_MMSEV) support — habitat volumes, comfort, greenhouse, logistics supply containers, and expandable HDU attic inflate Habitat (@Aebestach)
  * Added: SystemHeat native integration with automation devices, background thermal simulation, DynamicRadiation support for Sterling Systems power-dependent emitters, and expanded optional-mod configs for CryoTanks, Far Future Technologies, Near Future Electrical, Sterling Systems, KPBS, Buffalo SAFER, and SpaceDust harvesters (#1052, @Aebestach)
  * Added: VABOrganizer part categories (#983, @LouisB3)
  * Added: HabTech2 part upgrade dependency (#979, @LouisB3)

--- a/GameData/Kerbalism/Localization/de.cfg
+++ b/GameData/Kerbalism/Localization/de.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = andere // "others"
     #KERBALISM_Brokers_SolarPanel = Solarmodul // "solar panel"
+    #KERBALISM_Brokers_WindTurbine = Windturbine // "wind turbine"
     #KERBALISM_Brokers_KSPIEGenerator = KSPIE Generator // "KSPIE generator"
     #KERBALISM_Brokers_FissionReactor = Fission Generator // "fission generator"
     #KERBALISM_Brokers_RTG = Radioisotopen-Generator // "radioisotope generator"

--- a/GameData/Kerbalism/Localization/en-us.cfg
+++ b/GameData/Kerbalism/Localization/en-us.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = others
     #KERBALISM_Brokers_SolarPanel = solar panel
+    #KERBALISM_Brokers_WindTurbine = wind turbine
     #KERBALISM_Brokers_KSPIEGenerator = KSPIE generator
     #KERBALISM_Brokers_FissionReactor = fission reactor
     #KERBALISM_Brokers_RTG = radioisotope generator

--- a/GameData/Kerbalism/Localization/es-es.cfg
+++ b/GameData/Kerbalism/Localization/es-es.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = otros
     #KERBALISM_Brokers_SolarPanel = panel solar
+    #KERBALISM_Brokers_WindTurbine = turbina eólica
     #KERBALISM_Brokers_KSPIEGenerator = generador KSPIE
     #KERBALISM_Brokers_FissionReactor = fission generator // "fission generator"
     #KERBALISM_Brokers_RTG = generador de radioisótopos

--- a/GameData/Kerbalism/Localization/fr-fr.cfg
+++ b/GameData/Kerbalism/Localization/fr-fr.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = Autres // "others"
     #KERBALISM_Brokers_SolarPanel = Panneau solaire // "solar panel"
+    #KERBALISM_Brokers_WindTurbine = Éolienne // "wind turbine"
     #KERBALISM_Brokers_KSPIEGenerator = générateur KSPIE // "KSPIE generator"
     #KERBALISM_Brokers_FissionReactor = réacteur à fission // "fission generator"
     #KERBALISM_Brokers_RTG = générateur à radio-isotope // "radioisotope generator"

--- a/GameData/Kerbalism/Localization/it-it.cfg
+++ b/GameData/Kerbalism/Localization/it-it.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = altri // "others"
     #KERBALISM_Brokers_SolarPanel = Pannello fotovoltaico // "solar panel"
+    #KERBALISM_Brokers_WindTurbine = Turbina eolica // "wind turbine"
     #KERBALISM_Brokers_KSPIEGenerator = Generatore KSPIE // "KSPIE generator"
     #KERBALISM_Brokers_FissionReactor = generatore di fissione // "fission generator"
     #KERBALISM_Brokers_RTG = generatore di radioisotopi // "radioisotope generator"

--- a/GameData/Kerbalism/Localization/ko-kr.cfg
+++ b/GameData/Kerbalism/Localization/ko-kr.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = 기타
     #KERBALISM_Brokers_SolarPanel = 태양 전지판
+    #KERBALISM_Brokers_WindTurbine = 풍력 발전기
     #KERBALISM_Brokers_KSPIEGenerator = KSPIE 발전기
     #KERBALISM_Brokers_FissionReactor = 분열 발전기
     #KERBALISM_Brokers_RTG = 방사성 동위원소 발전기

--- a/GameData/Kerbalism/Localization/pt-br.cfg
+++ b/GameData/Kerbalism/Localization/pt-br.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = outros
     #KERBALISM_Brokers_SolarPanel = painel solar
+    #KERBALISM_Brokers_WindTurbine = turbina eólica
     #KERBALISM_Brokers_KSPIEGenerator = gerador KSPIE
     #KERBALISM_Brokers_FissionReactor = fission generator // "fission generator"
     #KERBALISM_Brokers_RTG = gerador de radioisótopos

--- a/GameData/Kerbalism/Localization/ru.cfg
+++ b/GameData/Kerbalism/Localization/ru.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = другие // "others"
     #KERBALISM_Brokers_SolarPanel = панель солнечных батарей // "solar panel"
+    #KERBALISM_Brokers_WindTurbine = ветрогенератор // "wind turbine"
     #KERBALISM_Brokers_KSPIEGenerator = KSPIE генератор // "KSPIE generator"
     #KERBALISM_Brokers_FissionReactor = генератор деления // "fission generator"
     #KERBALISM_Brokers_RTG = радиоизотопный генератор // "radioisotope generator"

--- a/GameData/Kerbalism/Localization/zh-cn.cfg
+++ b/GameData/Kerbalism/Localization/zh-cn.cfg
@@ -76,6 +76,7 @@ Localization
     //
     #KERBALISM_Brokers_Others = 其他 // "others"
     #KERBALISM_Brokers_SolarPanel = 太阳能电池板 // "solar panel"
+    #KERBALISM_Brokers_WindTurbine = 风力发电机 // "wind turbine"
     #KERBALISM_Brokers_KSPIEGenerator = KSPIE发电机 // "KSPIE generator"
     #KERBALISM_Brokers_FissionReactor = 裂变反应堆 // "fission reactor"
     #KERBALISM_Brokers_RTG = 放射性同位素发生器 // "radioisotope generator"

--- a/GameData/KerbalismConfig/Localization/de.cfg
+++ b/GameData/KerbalismConfig/Localization/de.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = Wascheinheit zum Kibo-Modul hinzufügen
 		#KERBALISM_Upgrade_KiboLaundry_desc = Fügt dem Kibo-Laboratoriumsmodul eine ausgeklügelte Wascheinheit hinzu.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = Upgrade für unbemannte Experiment-Slots
+		#KERBALISM_Upgrade_UnmannedSlot_desc = Fügt Sonden einen zusätzlichen Experiment-Slot hinzu.
+		#KERBALISM_Upgrade_OrbitalSlot_title = Upgrade für Orbitalscanner-Slots
+		#KERBALISM_Upgrade_OrbitalSlot_desc = Fügt dem Orbitalscanner einen zusätzlichen Experiment-Slot hinzu.
+		#KERBALISM_Upgrade_LabSlot_title = Upgrade für Labor-Experiment-Slots
+		#KERBALISM_Upgrade_LabSlot_desc = Fügt allen Laboren einen zusätzlichen Experiment-Slot hinzu.
+		#KERBALISM_Upgrade_LabReconfigure_title = Upgrade zur Labor-Rekonfiguration
+		#KERBALISM_Upgrade_LabReconfigure_desc = Ermöglicht erfahrenen Wissenschaftlern, Laborexperimente im Flug oder am Boden neu zu konfigurieren.
+		#KERBALISM_Upgrade_SurfaceSlot_title = Upgrade für Oberflächenproben-Kit-Slots
+		#KERBALISM_Upgrade_SurfaceSlot_desc = Fügt allen Oberflächenproben-Kits einen zusätzlichen Experiment-Slot hinzu.
+		#KERBALISM_Upgrade_AtmoSlot_title = Upgrade für Atmosphärenwissenschaft-Slots
+		#KERBALISM_Upgrade_AtmoSlot_desc = Fügt allen Atmosphärenwissenschaft-Gruppen einen zusätzlichen Experiment-Slot hinzu.
+		#KERBALISM_Upgrade_CrewedSlot_title = Upgrade für bemannte Experiment-Slots
+		#KERBALISM_Upgrade_CrewedSlot_desc = Fügt allen Teilen, die bemannte Experimente aufnehmen können, einen zusätzlichen Experiment-Slot hinzu.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = Upgrade für Unterwasserwissenschaft-Slots
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = Fügt allen Unterwasserwissenschaft-Gruppen einen zusätzlichen Experiment-Slot hinzu.
+		#KERBALISM_Upgrade_HDDCapacity_title = HDD-Kapazitätsupgrade
+		#KERBALISM_Upgrade_HDDCapacity1_desc = Ingenieure fanden heraus, dass eine weitere Platte die Kapazität verdoppelt!
+		#KERBALISM_Upgrade_HDDCapacity2_desc = Höhere Plattendichte bedeutet mehr Kapazität!
+		#KERBALISM_Upgrade_HDDCapacity3_desc = Wandelt alle alten staubigen Festplatten in glänzende neue SSDs um!
+		#KERBALISM_Upgrade_HDDCapacity4_desc = Quantenphysikalischer Hokuspokus! Es funktioniert einfach. Nicht fragen, wie.
+		#KERBALISM_Upgrade_SampleCapacity_title = Probenlager-Kapazitätsupgrade
+		#KERBALISM_Upgrade_SampleCapacity_desc = Erhöht die gesamte Probenlagerkapazität
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Mystery-Goo-Probenkapazitätsupgrade
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Erhöht die Probenlagerkapazität für das Goo-Experiment
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Materialbay-Probenkapazitätsupgrade
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Erhöht die Probenlagerkapazität für die Materials Bay
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = Gasfilter

--- a/GameData/KerbalismConfig/Localization/en-us.cfg
+++ b/GameData/KerbalismConfig/Localization/en-us.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = Add laundry unit to the Kibo module
 		#KERBALISM_Upgrade_KiboLaundry_desc = Adds a sophisticated laundry unit to the Kibo laboratory module.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = Unmanned Experiments Slot Upgrade
+		#KERBALISM_Upgrade_UnmannedSlot_desc = Adds an additional experiment slot to Probes.
+		#KERBALISM_Upgrade_OrbitalSlot_title = Orbital Scanner Slot Upgrade
+		#KERBALISM_Upgrade_OrbitalSlot_desc = Adds an additional experiment slot to the Orbital Scanner.
+		#KERBALISM_Upgrade_LabSlot_title = Laboratory Experiments Slot Upgrade
+		#KERBALISM_Upgrade_LabSlot_desc = Adds an additional experiment slot to all Laboratories.
+		#KERBALISM_Upgrade_LabReconfigure_title = Laboratory Reconfiguration Upgrade
+		#KERBALISM_Upgrade_LabReconfigure_desc = Allows Laboratory Experiments to be reconfigured in flight or on the ground by experienced scientists.
+		#KERBALISM_Upgrade_SurfaceSlot_title = Surface Sampling Kit Slot Upgrade
+		#KERBALISM_Upgrade_SurfaceSlot_desc = Adds an additional experiment slot to all Surface Sampling Kits.
+		#KERBALISM_Upgrade_AtmoSlot_title = Atmospheric Science Slot Upgrade
+		#KERBALISM_Upgrade_AtmoSlot_desc = Adds an additional experiment slot to all Atmospheric Science groups.
+		#KERBALISM_Upgrade_CrewedSlot_title = Crewed Experiments Slot Upgrade
+		#KERBALISM_Upgrade_CrewedSlot_desc = Adds an additional experiment slot to all parts capable of hosting crewed experiments.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = Underwater Science Slot Upgrade
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = Adds an additional experiment slot to all Underwater Science groups.
+		#KERBALISM_Upgrade_HDDCapacity_title = HDD Capacity Upgrade
+		#KERBALISM_Upgrade_HDDCapacity1_desc = Engineers figured that if they add another platter to the drive, they can double the capacity!
+		#KERBALISM_Upgrade_HDDCapacity2_desc = An increase in platter density equals an increase in capacity!
+		#KERBALISM_Upgrade_HDDCapacity3_desc = Converts all the old dusty Hard Drives to all new and shiny Solid State Drives!
+		#KERBALISM_Upgrade_HDDCapacity4_desc = Quantum physics shenenigans! It just works. Don't ask how.
+		#KERBALISM_Upgrade_SampleCapacity_title = Sample Storage Capacity Upgrade
+		#KERBALISM_Upgrade_SampleCapacity_desc = Increase the total amount of sample storage
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Mystery Goo Sample Capacity Upgrade
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Increase the total amount of sample storage for the Goo Experiment
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Materials Bay Sample Capacity Upgrade
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Increase the total amount of sample storage for the Materials Bay
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = Scrubber

--- a/GameData/KerbalismConfig/Localization/es-es.cfg
+++ b/GameData/KerbalismConfig/Localization/es-es.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = Añadir unidad de lavandería al módulo Kibo
 		#KERBALISM_Upgrade_KiboLaundry_desc = Añade una sofisticada unidad de lavandería al módulo de laboratorio Kibo.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = Mejora de ranura de experimentos no tripulados
+		#KERBALISM_Upgrade_UnmannedSlot_desc = Añade una ranura de experimento adicional a las sondas.
+		#KERBALISM_Upgrade_OrbitalSlot_title = Mejora de ranura del escáner orbital
+		#KERBALISM_Upgrade_OrbitalSlot_desc = Añade una ranura de experimento adicional al escáner orbital.
+		#KERBALISM_Upgrade_LabSlot_title = Mejora de ranura de experimentos de laboratorio
+		#KERBALISM_Upgrade_LabSlot_desc = Añade una ranura de experimento adicional a todos los laboratorios.
+		#KERBALISM_Upgrade_LabReconfigure_title = Mejora de reconfiguración de laboratorio
+		#KERBALISM_Upgrade_LabReconfigure_desc = Permite a científicos experimentados reconfigurar los experimentos de laboratorio en vuelo o en tierra.
+		#KERBALISM_Upgrade_SurfaceSlot_title = Mejora de ranura del kit de muestreo superficial
+		#KERBALISM_Upgrade_SurfaceSlot_desc = Añade una ranura de experimento adicional a todos los kits de muestreo superficial.
+		#KERBALISM_Upgrade_AtmoSlot_title = Mejora de ranura de ciencia atmosférica
+		#KERBALISM_Upgrade_AtmoSlot_desc = Añade una ranura de experimento adicional a todos los grupos de ciencia atmosférica.
+		#KERBALISM_Upgrade_CrewedSlot_title = Mejora de ranura de experimentos tripulados
+		#KERBALISM_Upgrade_CrewedSlot_desc = Añade una ranura de experimento adicional a todas las piezas capaces de alojar experimentos tripulados.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = Mejora de ranura de ciencia submarina
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = Añade una ranura de experimento adicional a todos los grupos de ciencia submarina.
+		#KERBALISM_Upgrade_HDDCapacity_title = Mejora de capacidad del HDD
+		#KERBALISM_Upgrade_HDDCapacity1_desc = ¡Los ingenieros descubrieron que añadiendo otro plato al disco pueden duplicar la capacidad!
+		#KERBALISM_Upgrade_HDDCapacity2_desc = ¡Más densidad de platos equivale a más capacidad!
+		#KERBALISM_Upgrade_HDDCapacity3_desc = ¡Convierte todos los viejos discos duros polvorientos en flamantes SSD!
+		#KERBALISM_Upgrade_HDDCapacity4_desc = ¡Trucos de física cuántica! Simplemente funciona. No preguntes cómo.
+		#KERBALISM_Upgrade_SampleCapacity_title = Mejora de capacidad de almacenamiento de muestras
+		#KERBALISM_Upgrade_SampleCapacity_desc = Aumenta la cantidad total de almacenamiento de muestras
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Mejora de capacidad de muestras de Mystery Goo
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Aumenta el almacenamiento de muestras del experimento Goo
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Mejora de capacidad de muestras de Materials Bay
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Aumenta el almacenamiento de muestras de la Materials Bay
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = Depurador

--- a/GameData/KerbalismConfig/Localization/fr-fr.cfg
+++ b/GameData/KerbalismConfig/Localization/fr-fr.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = Ajouter une unité de lessive au module Kibo
 		#KERBALISM_Upgrade_KiboLaundry_desc = Ajoute une unité de lessive sophistiquée au module de laboratoire Kibo.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = Amélioration d'emplacement d'expériences sans équipage
+		#KERBALISM_Upgrade_UnmannedSlot_desc = Ajoute un emplacement d'expérience supplémentaire aux sondes.
+		#KERBALISM_Upgrade_OrbitalSlot_title = Amélioration d'emplacement du scanneur orbital
+		#KERBALISM_Upgrade_OrbitalSlot_desc = Ajoute un emplacement d'expérience supplémentaire au scanneur orbital.
+		#KERBALISM_Upgrade_LabSlot_title = Amélioration d'emplacement d'expériences de laboratoire
+		#KERBALISM_Upgrade_LabSlot_desc = Ajoute un emplacement d'expérience supplémentaire à tous les laboratoires.
+		#KERBALISM_Upgrade_LabReconfigure_title = Amélioration de reconfiguration de laboratoire
+		#KERBALISM_Upgrade_LabReconfigure_desc = Permet à des scientifiques expérimentés de reconfigurer les expériences de laboratoire en vol ou au sol.
+		#KERBALISM_Upgrade_SurfaceSlot_title = Amélioration d'emplacement du kit d'échantillonnage de surface
+		#KERBALISM_Upgrade_SurfaceSlot_desc = Ajoute un emplacement d'expérience supplémentaire à tous les kits d'échantillonnage de surface.
+		#KERBALISM_Upgrade_AtmoSlot_title = Amélioration d'emplacement de science atmosphérique
+		#KERBALISM_Upgrade_AtmoSlot_desc = Ajoute un emplacement d'expérience supplémentaire à tous les groupes de science atmosphérique.
+		#KERBALISM_Upgrade_CrewedSlot_title = Amélioration d'emplacement d'expériences habitées
+		#KERBALISM_Upgrade_CrewedSlot_desc = Ajoute un emplacement d'expérience supplémentaire à toutes les pièces capables d'accueillir des expériences habitées.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = Amélioration d'emplacement de science sous-marine
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = Ajoute un emplacement d'expérience supplémentaire à tous les groupes de science sous-marine.
+		#KERBALISM_Upgrade_HDDCapacity_title = Amélioration de capacité du HDD
+		#KERBALISM_Upgrade_HDDCapacity1_desc = Les ingénieurs ont compris qu'ajouter un autre plateau double la capacité !
+		#KERBALISM_Upgrade_HDDCapacity2_desc = Une densité de plateaux plus élevée égale une capacité plus élevée !
+		#KERBALISM_Upgrade_HDDCapacity3_desc = Convertit tous les vieux disques durs poussiéreux en SSD tout neufs et brillants !
+		#KERBALISM_Upgrade_HDDCapacity4_desc = Magie de la physique quantique ! Ça marche, ne demandez pas comment.
+		#KERBALISM_Upgrade_SampleCapacity_title = Amélioration de capacité de stockage d'échantillons
+		#KERBALISM_Upgrade_SampleCapacity_desc = Augmente la quantité totale de stockage d'échantillons
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Amélioration de capacité d'échantillons Mystery Goo
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Augmente le stockage d'échantillons de l'expérience Goo
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Amélioration de capacité d'échantillons Materials Bay
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Augmente le stockage d'échantillons de la Materials Bay
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = Absorbeur

--- a/GameData/KerbalismConfig/Localization/it-it.cfg
+++ b/GameData/KerbalismConfig/Localization/it-it.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = Aggiungi unità lavanderia al modulo Kibo
 		#KERBALISM_Upgrade_KiboLaundry_desc = Aggiunge una sofisticata unità lavanderia al modulo laboratorio Kibo.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = Potenziamento slot esperimenti senza equipaggio
+		#KERBALISM_Upgrade_UnmannedSlot_desc = Aggiunge uno slot esperimento aggiuntivo alle sonde.
+		#KERBALISM_Upgrade_OrbitalSlot_title = Potenziamento slot scanner orbitale
+		#KERBALISM_Upgrade_OrbitalSlot_desc = Aggiunge uno slot esperimento aggiuntivo allo scanner orbitale.
+		#KERBALISM_Upgrade_LabSlot_title = Potenziamento slot esperimenti di laboratorio
+		#KERBALISM_Upgrade_LabSlot_desc = Aggiunge uno slot esperimento aggiuntivo a tutti i laboratori.
+		#KERBALISM_Upgrade_LabReconfigure_title = Potenziamento riconfigurazione laboratorio
+		#KERBALISM_Upgrade_LabReconfigure_desc = Consente a scienziati esperti di riconfigurare gli esperimenti di laboratorio in volo o a terra.
+		#KERBALISM_Upgrade_SurfaceSlot_title = Potenziamento slot kit campionamento superficiale
+		#KERBALISM_Upgrade_SurfaceSlot_desc = Aggiunge uno slot esperimento aggiuntivo a tutti i kit di campionamento superficiale.
+		#KERBALISM_Upgrade_AtmoSlot_title = Potenziamento slot scienza atmosferica
+		#KERBALISM_Upgrade_AtmoSlot_desc = Aggiunge uno slot esperimento aggiuntivo a tutti i gruppi di scienza atmosferica.
+		#KERBALISM_Upgrade_CrewedSlot_title = Potenziamento slot esperimenti con equipaggio
+		#KERBALISM_Upgrade_CrewedSlot_desc = Aggiunge uno slot esperimento aggiuntivo a tutte le parti in grado di ospitare esperimenti con equipaggio.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = Potenziamento slot scienza subacquea
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = Aggiunge uno slot esperimento aggiuntivo a tutti i gruppi di scienza subacquea.
+		#KERBALISM_Upgrade_HDDCapacity_title = Potenziamento capacità HDD
+		#KERBALISM_Upgrade_HDDCapacity1_desc = Gli ingegneri hanno scoperto che aggiungendo un altro piatto al disco possono raddoppiare la capacità!
+		#KERBALISM_Upgrade_HDDCapacity2_desc = Maggiore densità dei piatti equivale a maggiore capacità!
+		#KERBALISM_Upgrade_HDDCapacity3_desc = Converte tutti i vecchi hard disk polverosi in SSD nuovi e lucenti!
+		#KERBALISM_Upgrade_HDDCapacity4_desc = Trucchetti di fisica quantistica! Funziona e basta. Non chiedere come.
+		#KERBALISM_Upgrade_SampleCapacity_title = Potenziamento capacità stoccaggio campioni
+		#KERBALISM_Upgrade_SampleCapacity_desc = Aumenta la quantità totale di stoccaggio campioni
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Potenziamento capacità campioni Mystery Goo
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Aumenta lo stoccaggio campioni dell'esperimento Goo
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Potenziamento capacità campioni Materials Bay
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Aumenta lo stoccaggio campioni della Materials Bay
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = Depuratore

--- a/GameData/KerbalismConfig/Localization/ko-kr.cfg
+++ b/GameData/KerbalismConfig/Localization/ko-kr.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = 키보 모듈에 세탁 장치 추가
 		#KERBALISM_Upgrade_KiboLaundry_desc = 키보 실험실 모듈에 정교한 세탁 장치를 추가합니다.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = 무인 실험 슬롯 업그레이드
+		#KERBALISM_Upgrade_UnmannedSlot_desc = 탐사선에 추가 실험 슬롯을 제공합니다.
+		#KERBALISM_Upgrade_OrbitalSlot_title = 궤도 스캐너 슬롯 업그레이드
+		#KERBALISM_Upgrade_OrbitalSlot_desc = 궤도 스캐너에 추가 실험 슬롯을 제공합니다.
+		#KERBALISM_Upgrade_LabSlot_title = 실험실 실험 슬롯 업그레이드
+		#KERBALISM_Upgrade_LabSlot_desc = 모든 실험실에 추가 실험 슬롯을 제공합니다.
+		#KERBALISM_Upgrade_LabReconfigure_title = 실험실 재구성 업그레이드
+		#KERBALISM_Upgrade_LabReconfigure_desc = 숙련된 과학자가 비행 중이거나 지상에서 실험실 실험을 재구성할 수 있게 합니다.
+		#KERBALISM_Upgrade_SurfaceSlot_title = 표면 샘플링 키트 슬롯 업그레이드
+		#KERBALISM_Upgrade_SurfaceSlot_desc = 모든 표면 샘플링 키트에 추가 실험 슬롯을 제공합니다.
+		#KERBALISM_Upgrade_AtmoSlot_title = 대기 과학 슬롯 업그레이드
+		#KERBALISM_Upgrade_AtmoSlot_desc = 모든 대기 과학 그룹에 추가 실험 슬롯을 제공합니다.
+		#KERBALISM_Upgrade_CrewedSlot_title = 유인 실험 슬롯 업그레이드
+		#KERBALISM_Upgrade_CrewedSlot_desc = 유인 실험을 수용할 수 있는 모든 부품에 추가 실험 슬롯을 제공합니다.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = 수중 과학 슬롯 업그레이드
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = 모든 수중 과학 그룹에 추가 실험 슬롯을 제공합니다.
+		#KERBALISM_Upgrade_HDDCapacity_title = HDD 용량 업그레이드
+		#KERBALISM_Upgrade_HDDCapacity1_desc = 엔지니어들은 플래터를 하나 더 넣으면 용량이 두 배가 된다는 걸 알아냈습니다!
+		#KERBALISM_Upgrade_HDDCapacity2_desc = 플래터 밀도를 높이면 용량도 늘어납니다!
+		#KERBALISM_Upgrade_HDDCapacity3_desc = 먼지투성이 구형 하드 드라이브를 반짝이는 새 SSD로 바꿉니다!
+		#KERBALISM_Upgrade_HDDCapacity4_desc = 양자물리학 장난! 그냥 됩니다. 어떻게인지는 묻지 마세요.
+		#KERBALISM_Upgrade_SampleCapacity_title = 샘플 저장 용량 업그레이드
+		#KERBALISM_Upgrade_SampleCapacity_desc = 샘플 저장 총량을 늘립니다
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Mystery Goo 샘플 용량 업그레이드
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Goo 실험의 샘플 저장량을 늘립니다
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Materials Bay 샘플 용량 업그레이드
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Materials Bay의 샘플 저장량을 늘립니다
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = 스크러버

--- a/GameData/KerbalismConfig/Localization/pt-br.cfg
+++ b/GameData/KerbalismConfig/Localization/pt-br.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = Adicionar unidade de lavanderia ao módulo Kibo
 		#KERBALISM_Upgrade_KiboLaundry_desc = Adiciona uma sofisticada unidade de lavanderia ao módulo laboratorial Kibo.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = Melhoria de slot de experimentos não tripulados
+		#KERBALISM_Upgrade_UnmannedSlot_desc = Adiciona um slot de experimento extra às sondas.
+		#KERBALISM_Upgrade_OrbitalSlot_title = Melhoria de slot do scanner orbital
+		#KERBALISM_Upgrade_OrbitalSlot_desc = Adiciona um slot de experimento extra ao scanner orbital.
+		#KERBALISM_Upgrade_LabSlot_title = Melhoria de slot de experimentos de laboratório
+		#KERBALISM_Upgrade_LabSlot_desc = Adiciona um slot de experimento extra a todos os laboratórios.
+		#KERBALISM_Upgrade_LabReconfigure_title = Melhoria de reconfiguração de laboratório
+		#KERBALISM_Upgrade_LabReconfigure_desc = Permite que cientistas experientes reconfigurem experimentos de laboratório em voo ou no solo.
+		#KERBALISM_Upgrade_SurfaceSlot_title = Melhoria de slot do kit de amostragem de superfície
+		#KERBALISM_Upgrade_SurfaceSlot_desc = Adiciona um slot de experimento extra a todos os kits de amostragem de superfície.
+		#KERBALISM_Upgrade_AtmoSlot_title = Melhoria de slot de ciência atmosférica
+		#KERBALISM_Upgrade_AtmoSlot_desc = Adiciona um slot de experimento extra a todos os grupos de ciência atmosférica.
+		#KERBALISM_Upgrade_CrewedSlot_title = Melhoria de slot de experimentos tripulados
+		#KERBALISM_Upgrade_CrewedSlot_desc = Adiciona um slot de experimento extra a todas as peças capazes de hospedar experimentos tripulados.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = Melhoria de slot de ciência subaquática
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = Adiciona um slot de experimento extra a todos os grupos de ciência subaquática.
+		#KERBALISM_Upgrade_HDDCapacity_title = Melhoria de capacidade do HDD
+		#KERBALISM_Upgrade_HDDCapacity1_desc = Os engenheiros descobriram que adicionar outro prato ao disco dobra a capacidade!
+		#KERBALISM_Upgrade_HDDCapacity2_desc = Mais densidade de pratos equivale a mais capacidade!
+		#KERBALISM_Upgrade_HDDCapacity3_desc = Converte todos os HDs velhos e empoeirados em SSDs novos e brilhantes!
+		#KERBALISM_Upgrade_HDDCapacity4_desc = Truques de física quântica! Simplesmente funciona. Não pergunte como.
+		#KERBALISM_Upgrade_SampleCapacity_title = Melhoria de capacidade de armazenamento de amostras
+		#KERBALISM_Upgrade_SampleCapacity_desc = Aumenta a quantidade total de armazenamento de amostras
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Melhoria de capacidade de amostras Mystery Goo
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Aumenta o armazenamento de amostras do experimento Goo
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Melhoria de capacidade de amostras Materials Bay
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Aumenta o armazenamento de amostras da Materials Bay
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = Purificador

--- a/GameData/KerbalismConfig/Localization/ru.cfg
+++ b/GameData/KerbalismConfig/Localization/ru.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = Добавить стиральную установку в модуль Kibo
 		#KERBALISM_Upgrade_KiboLaundry_desc = Добавляет сложную стиральную установку в лабораторный модуль Kibo.
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = Улучшение слота беспилотных экспериментов
+		#KERBALISM_Upgrade_UnmannedSlot_desc = Добавляет дополнительный слот эксперимента для зондов.
+		#KERBALISM_Upgrade_OrbitalSlot_title = Улучшение слота орбитального сканера
+		#KERBALISM_Upgrade_OrbitalSlot_desc = Добавляет дополнительный слот эксперимента для орбитального сканера.
+		#KERBALISM_Upgrade_LabSlot_title = Улучшение слота лабораторных экспериментов
+		#KERBALISM_Upgrade_LabSlot_desc = Добавляет дополнительный слот эксперимента всем лабораториям.
+		#KERBALISM_Upgrade_LabReconfigure_title = Улучшение реконфигурации лаборатории
+		#KERBALISM_Upgrade_LabReconfigure_desc = Позволяет опытным учёным реконфигурировать лабораторные эксперименты в полёте или на земле.
+		#KERBALISM_Upgrade_SurfaceSlot_title = Улучшение слота комплекта поверхностных проб
+		#KERBALISM_Upgrade_SurfaceSlot_desc = Добавляет дополнительный слот эксперимента всем комплектам поверхностных проб.
+		#KERBALISM_Upgrade_AtmoSlot_title = Улучшение слота атмосферной науки
+		#KERBALISM_Upgrade_AtmoSlot_desc = Добавляет дополнительный слот эксперимента всем группам атмосферной науки.
+		#KERBALISM_Upgrade_CrewedSlot_title = Улучшение слота пилотируемых экспериментов
+		#KERBALISM_Upgrade_CrewedSlot_desc = Добавляет дополнительный слот эксперимента всем деталям, способным размещать пилотируемые эксперименты.
+		#KERBALISM_Upgrade_UnderwaterSlot_title = Улучшение слота подводной науки
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = Добавляет дополнительный слот эксперимента всем группам подводной науки.
+		#KERBALISM_Upgrade_HDDCapacity_title = Улучшение ёмкости HDD
+		#KERBALISM_Upgrade_HDDCapacity1_desc = Инженеры поняли: ещё одна пластина — и ёмкость удваивается!
+		#KERBALISM_Upgrade_HDDCapacity2_desc = Больше плотность пластин — больше ёмкость!
+		#KERBALISM_Upgrade_HDDCapacity3_desc = Превращает все старые пыльные жёсткие диски в новенькие блестящие SSD!
+		#KERBALISM_Upgrade_HDDCapacity4_desc = Квантовая физика творит чудеса! Просто работает. Не спрашивайте как.
+		#KERBALISM_Upgrade_SampleCapacity_title = Улучшение ёмкости хранения образцов
+		#KERBALISM_Upgrade_SampleCapacity_desc = Увеличивает общий объём хранения образцов
+		#KERBALISM_Upgrade_GooSampleCapacity_title = Улучшение ёмкости образцов Mystery Goo
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = Увеличивает объём хранения образцов для эксперимента Goo
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = Улучшение ёмкости образцов Materials Bay
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = Увеличивает объём хранения образцов для Materials Bay
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = Газоочиститель

--- a/GameData/KerbalismConfig/Localization/zh-cn.cfg
+++ b/GameData/KerbalismConfig/Localization/zh-cn.cfg
@@ -224,6 +224,35 @@ Localization
 		#KERBALISM_Upgrade_KiboLaundry_title = 为希望号模块添加洗衣装置
 		#KERBALISM_Upgrade_KiboLaundry_desc = 为希望号实验舱添加一套精巧的洗衣装置。
 
+		// Science PARTUPGRADE titles/descriptions
+		#KERBALISM_Upgrade_UnmannedSlot_title = 无人实验插槽升级
+		#KERBALISM_Upgrade_UnmannedSlot_desc = 为探测器增加一个额外的实验插槽。
+		#KERBALISM_Upgrade_OrbitalSlot_title = 轨道扫描仪插槽升级
+		#KERBALISM_Upgrade_OrbitalSlot_desc = 为轨道扫描仪增加一个额外的实验插槽。
+		#KERBALISM_Upgrade_LabSlot_title = 实验室实验插槽升级
+		#KERBALISM_Upgrade_LabSlot_desc = 为所有实验室增加一个额外的实验插槽。
+		#KERBALISM_Upgrade_LabReconfigure_title = 实验室重配置升级
+		#KERBALISM_Upgrade_LabReconfigure_desc = 允许经验丰富的科学家在飞行中或地面上重新配置实验室实验。
+		#KERBALISM_Upgrade_SurfaceSlot_title = 表面采样套件插槽升级
+		#KERBALISM_Upgrade_SurfaceSlot_desc = 为所有表面采样套件增加一个额外的实验插槽。
+		#KERBALISM_Upgrade_AtmoSlot_title = 大气科学插槽升级
+		#KERBALISM_Upgrade_AtmoSlot_desc = 为所有大气科学组增加一个额外的实验插槽。
+		#KERBALISM_Upgrade_CrewedSlot_title = 载人实验插槽升级
+		#KERBALISM_Upgrade_CrewedSlot_desc = 为所有可承载载人实验的部件增加一个额外的实验插槽。
+		#KERBALISM_Upgrade_UnderwaterSlot_title = 水下科学插槽升级
+		#KERBALISM_Upgrade_UnderwaterSlot_desc = 为所有水下科学组增加一个额外的实验插槽。
+		#KERBALISM_Upgrade_HDDCapacity_title = 硬盘容量升级
+		#KERBALISM_Upgrade_HDDCapacity1_desc = 工程师发现再加一块盘片就能把容量翻倍！
+		#KERBALISM_Upgrade_HDDCapacity2_desc = 提高盘片密度就等于提高容量！
+		#KERBALISM_Upgrade_HDDCapacity3_desc = 把那些落满灰的老硬盘全换成崭新锃亮的固态硬盘！
+		#KERBALISM_Upgrade_HDDCapacity4_desc = 量子物理的花活！反正能用，别问怎么做到的。
+		#KERBALISM_Upgrade_SampleCapacity_title = 样本存储容量升级
+		#KERBALISM_Upgrade_SampleCapacity_desc = 增加样本存储总量
+		#KERBALISM_Upgrade_GooSampleCapacity_title = 神秘黏液样本容量升级
+		#KERBALISM_Upgrade_GooSampleCapacity_desc = 增加神秘黏液实验的样本存储总量
+		#KERBALISM_Upgrade_MatBaySampleCapacity_title = 材料舱样本容量升级
+		#KERBALISM_Upgrade_MatBaySampleCapacity_desc = 增加材料舱的样本存储总量
+
 		//Configurable Life Support System title
 
 		#KERBALISM_Scrubber_title = 废气处理装置

--- a/GameData/KerbalismConfig/Support/Benjee10_MMSEV.cfg
+++ b/GameData/KerbalismConfig/Support/Benjee10_MMSEV.cfg
@@ -1,0 +1,521 @@
+// ============================================================================
+// Planetside Exploration Technologies (Benjee10_MMSEV)
+// Targeted Kerbalism support — generic CrewCapacity patches cover the rest.
+// Wind turbines (ModulePETTurbine) intentionally left alone for now.
+// ============================================================================
+
+// ============================================================================
+// Expandable attic: CrewCapacity lives on ModuleAnimateGeneric, so the generic
+// Habitat / ProfileDefault wildcards never see it. Promote capacity first.
+// ============================================================================
+@PART[Benjee10_base_HDU_attic]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:BEFORE[KerbalismDefault]
+{
+	%CrewCapacity = 6
+}
+
+// ============================================================================
+// Habitable volume / surface (hand-tuned from size, mass, crew and descriptions)
+// ============================================================================
+
+// PT-M50H — "cozy" half-length 1.875 m hab (crew 3, 1.4 t)
+@PART[Benjee10_MMSEV_baseHabShort]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 7.5
+		surface = 14.0
+	}
+}
+
+// PT-M100H — "positively roomy" double-length 1.875 m hab (crew 5, 2.8 t)
+@PART[Benjee10_MMSEV_baseHabLong]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 14.0
+		surface = 24.0
+	}
+}
+
+// PT-M100L — same shell as M100H, but lab gear eats living space (crew 2, 2.8 t)
+@PART[Benjee10_MMSEV_baseLab]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 11.0
+		surface = 24.0
+	}
+}
+
+// PT-M100G — hydroponics shares the M100 shell with the crop (crew 2, 2.8 t)
+@PART[Benjee10_MMSEV_baseGreenhouse]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 10.0
+		surface = 24.0
+	}
+}
+
+// PT-3A Command Node — 3.75 m core / outpost (crew 6, 5 t); vertical interior, command-biased
+@PART[Benjee10_MMSEV_baseHDU]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 34.0
+		surface = 50.0
+	}
+}
+
+// PT-3B Habitation — "spacious… live, work and sleep" + large window clusters (crew 6, 5 t)
+@PART[Benjee10_MMSEV_baseHDU_hab]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 38.0
+		surface = 52.0
+	}
+}
+
+// PT-3H Expandable Habitat — inflatable dome attic (crew 6 when deployed, 2.5 t fabric)
+@PART[Benjee10_base_HDU_attic]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		%inflate = atticDeploy
+		%state = disabled
+		%animBackwards = False
+		%canRetract = True
+		volume = 40.0
+		surface = 90.0
+	}
+
+	// Habitat drives the inflate animation; drop the stock animate module that owned CrewCapacity
+	!MODULE[ModuleAnimateGeneric]:HAS[#animationName[atticDeploy]] {}
+}
+
+// ============================================================================
+// Comfort
+// ============================================================================
+
+// Roomy surface hab — exercise gear fits the description
+@PART[Benjee10_MMSEV_baseHabLong]:NEEDS[Benjee10_MMSEV,FeatureComfort]:AFTER[KerbalismDefault]
+{
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		bonus = exercise
+		desc = #KERBALISM_Comfort_exercise_desc
+	}
+
+	@tags ^= :$: comfort:
+}
+
+// Spacious HDU hab with large window clusters
+@PART[Benjee10_MMSEV_baseHDU_hab]:NEEDS[Benjee10_MMSEV,FeatureComfort]:AFTER[KerbalismDefault]
+{
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		bonus = exercise
+		desc = #KERBALISM_Comfort_exercise_desc
+	}
+
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		bonus = panorama
+		desc = #KERBALISM_Comfort_panorama_desc
+	}
+
+	@tags ^= :$: comfort:
+}
+
+// Inflatable dome attic — views once deployed
+@PART[Benjee10_base_HDU_attic]:NEEDS[Benjee10_MMSEV,FeatureComfort]:AFTER[KerbalismDefault]
+{
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		bonus = panorama
+		desc = #KERBALISM_Comfort_panorama_desc
+	}
+
+	@tags ^= :$: comfort:
+}
+
+// Hydroponics — plants comfort (Greenhouse module alone does not grant this)
+@PART[Benjee10_MMSEV_baseGreenhouse]:NEEDS[Benjee10_MMSEV,FeatureComfort]:AFTER[KerbalismDefault]
+{
+	MODULE:NEEDS[FeatureComfort]
+	{
+		name = Comfort
+		bonus = plants
+		desc = #KERBALISM_Comfort_plants_desc
+	}
+
+	@tags ^= :$: comfort:
+}
+
+// ============================================================================
+// Greenhouse (PT-M100G Hydroponics Module)
+// Same outer shell as M100H; ~1× stock kerbalism-greenhouse crop throughput.
+// ============================================================================
+@PART[Benjee10_MMSEV_baseGreenhouse]:NEEDS[Benjee10_MMSEV,ProfileDefault]:AFTER[KerbalismDefault]
+{
+	MODULE
+	{
+		name = Greenhouse
+		crop_resource = Food
+		crop_size = 496.125
+		crop_rate = 0.00000023148
+		ec_rate = 2.5
+		light_tolerance = 400.0
+		pressure_tolerance = 0.1
+		radiation_tolerance = 0.000008333
+
+		INPUT_RESOURCE
+		{
+			name = Ammonia
+			rate = 0.00172265625
+		}
+
+		INPUT_RESOURCE
+		{
+			name = Water
+			rate = 0.0000574218
+		}
+
+		INPUT_RESOURCE
+		{
+			name = WasteAtmosphere
+			rate = 0.0224243955
+		}
+
+		INPUT_RESOURCE
+		{
+			name = CarbonDioxide
+			rate = 0.00747479835
+		}
+
+		OUTPUT_RESOURCE
+		{
+			name = Oxygen
+			rate = 0.0310283685
+		}
+	}
+
+	RESOURCE
+	{
+		name = Ammonia
+		amount = 4896
+		maxAmount = 4896
+	}
+
+	RESOURCE
+	{
+		name = CarbonDioxide
+		amount = 81000
+		maxAmount = 81000
+	}
+
+	RESOURCE
+	{
+		name = Water
+		amount = 198
+		maxAmount = 198
+	}
+
+	// Dedicated N2 buffer for pressure control (same pattern as stock / SSPX greenhouses)
+	@MODULE[Configure]
+	{
+		@SETUP[Pressure?Control]
+		{
+			!RESOURCE[Nitrogen] {}
+		}
+	}
+
+	RESOURCE
+	{
+		name = Nitrogen
+		amount = 10000
+		maxAmount = 10000
+	}
+
+	@tags ^= :$: greenhouse:
+}
+
+// ============================================================================
+// Logistics — described as storage / snacks, not living quarters.
+// Keep a minimal Habitat for the access tunnel; add a real supply bay.
+// ============================================================================
+
+// PT-M100S — full-length logistics module (~1.875 m × 3.1 m cargo shell)
+@PART[Benjee10_MMSEV_logisticslong]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 4.0
+		surface = 24.0
+	}
+}
+
+@PART[Benjee10_MMSEV_logisticsShort]:NEEDS[Benjee10_MMSEV,FeatureHabitat]:AFTER[KerbalismDefault]
+{
+	@MODULE[Habitat]
+	{
+		volume = 2.0
+		surface = 10.0
+	}
+}
+
+@PART[Benjee10_MMSEV_logisticslong]:NEEDS[Benjee10_MMSEV,ProfileDefault]:AFTER[zzzKerbalismDefault]
+{
+	@tags ^= :$: container food water waste sewage:
+	%ContainerVolume = 3000
+
+	MODULE
+	{
+		name = Configure
+		configureId = SupplyContainer
+		title = #KERBALISM_Configure_SupplyContainer_title
+		slots = 1
+		symmetric = true
+
+		SETUP
+		{
+			name = Supplies
+			title = #KERBALISM_Setup_Supplies_title
+			desc = #KERBALISM_SupplyContainer_desc
+
+			RESOURCE
+			{
+				name = Food
+				amount = 0.7221584
+				maxAmount = 0.7221584
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+
+			RESOURCE
+			{
+				name = Water
+				amount = 0.2778416
+				maxAmount = 0.2778416
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Food
+			title = #KERBALISM_Setup_Food_title
+
+			RESOURCE
+			{
+				name = Food
+				amount = 1
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Water
+			title = #KERBALISM_Setup_Water_title
+
+			RESOURCE
+			{
+				name = Water
+				amount = 1
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Sewage
+			title = #KERBALISM_Setup_Sewage_title
+			desc = #KERBALISM_SupplyContainer_desc2
+
+			RESOURCE
+			{
+				name = Waste
+				amount = 0
+				maxAmount = 0.4946378
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+
+			RESOURCE
+			{
+				name = WasteWater
+				amount = 0
+				maxAmount = 0.5053622
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Waste
+			title = #KERBALISM_Setup_Waste_title
+
+			RESOURCE
+			{
+				name = Waste
+				amount = 0
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = WasteWater
+			title = #KERBALISM_Setup_WasteWater_title
+
+			RESOURCE
+			{
+				name = WasteWater
+				amount = 0
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+	}
+}
+
+// PT-M025S — short logistics / "snacks and board games" bay
+@PART[Benjee10_MMSEV_logisticsShort]:NEEDS[Benjee10_MMSEV,ProfileDefault]:AFTER[zzzKerbalismDefault]
+{
+	@tags ^= :$: container food water waste sewage:
+	%ContainerVolume = 750
+
+	MODULE
+	{
+		name = Configure
+		configureId = SupplyContainer
+		title = #KERBALISM_Configure_SupplyContainer_title
+		slots = 1
+		symmetric = true
+
+		SETUP
+		{
+			name = Supplies
+			title = #KERBALISM_Setup_Supplies_title
+			desc = #KERBALISM_SupplyContainer_desc
+
+			RESOURCE
+			{
+				name = Food
+				amount = 0.7221584
+				maxAmount = 0.7221584
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+
+			RESOURCE
+			{
+				name = Water
+				amount = 0.2778416
+				maxAmount = 0.2778416
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Food
+			title = #KERBALISM_Setup_Food_title
+
+			RESOURCE
+			{
+				name = Food
+				amount = 1
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Water
+			title = #KERBALISM_Setup_Water_title
+
+			RESOURCE
+			{
+				name = Water
+				amount = 1
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Sewage
+			title = #KERBALISM_Setup_Sewage_title
+			desc = #KERBALISM_SupplyContainer_desc2
+
+			RESOURCE
+			{
+				name = Waste
+				amount = 0
+				maxAmount = 0.4946378
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+
+			RESOURCE
+			{
+				name = WasteWater
+				amount = 0
+				maxAmount = 0.5053622
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = Waste
+			title = #KERBALISM_Setup_Waste_title
+
+			RESOURCE
+			{
+				name = Waste
+				amount = 0
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+
+		SETUP
+		{
+			name = WasteWater
+			title = #KERBALISM_Setup_WasteWater_title
+
+			RESOURCE
+			{
+				name = WasteWater
+				amount = 0
+				maxAmount = 1
+				@amount *= #$/ContainerVolume$
+				@maxAmount *= #$/ContainerVolume$
+			}
+		}
+	}
+}

--- a/GameData/KerbalismConfig/Support/Benjee10_MMSEV.cfg
+++ b/GameData/KerbalismConfig/Support/Benjee10_MMSEV.cfg
@@ -166,6 +166,15 @@
 }
 
 // ============================================================================
+// Sickbay — RDU on the large HDU hab (TV already comes from CrewCapacity > 3)
+// ============================================================================
+@PART[Benjee10_MMSEV_baseHDU_hab]:NEEDS[Benjee10_MMSEV,FeatureHabitat,FeatureRadiation]:FOR[zzzKerbalismDefault]
+{
+	%AddConfigurableSickbay = true
+	%AddSickbayRDU = true
+}
+
+// ============================================================================
 // Greenhouse (PT-M100G Hydroponics Module)
 // Same outer shell as M100H; 0.5× stock kerbalism-greenhouse crop throughput
 // (habitat volume ~10 m³ vs stock ~24 m³ crop reference).

--- a/GameData/KerbalismConfig/Support/Benjee10_MMSEV.cfg
+++ b/GameData/KerbalismConfig/Support/Benjee10_MMSEV.cfg
@@ -1,8 +1,16 @@
 // ============================================================================
 // Planetside Exploration Technologies (Benjee10_MMSEV)
 // Targeted Kerbalism support — generic CrewCapacity patches cover the rest.
-// Wind turbines (ModulePETTurbine) intentionally left alone for now.
+// Wind turbines: PETTurbineFixer + Harmony take over EC for Telemetry/Auto.
 // ============================================================================
+
+@PART[*]:HAS[@MODULE[ModulePETTurbine]]:NEEDS[Benjee10_MMSEV]:FOR[KerbalismDefault]
+{
+	MODULE
+	{
+		name = PETTurbineFixer
+	}
+}
 
 // ============================================================================
 // Expandable attic: CrewCapacity lives on ModuleAnimateGeneric, so the generic
@@ -159,7 +167,8 @@
 
 // ============================================================================
 // Greenhouse (PT-M100G Hydroponics Module)
-// Same outer shell as M100H; ~1× stock kerbalism-greenhouse crop throughput.
+// Same outer shell as M100H; 0.5× stock kerbalism-greenhouse crop throughput
+// (habitat volume ~10 m³ vs stock ~24 m³ crop reference).
 // ============================================================================
 @PART[Benjee10_MMSEV_baseGreenhouse]:NEEDS[Benjee10_MMSEV,ProfileDefault]:AFTER[KerbalismDefault]
 {
@@ -167,9 +176,9 @@
 	{
 		name = Greenhouse
 		crop_resource = Food
-		crop_size = 496.125
+		crop_size = 248.0625					// 0.5× kerbalism-greenhouse
 		crop_rate = 0.00000023148
-		ec_rate = 2.5
+		ec_rate = 1.25							// 0.5× kerbalism-greenhouse
 		light_tolerance = 400.0
 		pressure_tolerance = 0.1
 		radiation_tolerance = 0.000008333
@@ -177,53 +186,53 @@
 		INPUT_RESOURCE
 		{
 			name = Ammonia
-			rate = 0.00172265625
+			rate = 0.000861328125				// 0.5× kerbalism-greenhouse
 		}
 
 		INPUT_RESOURCE
 		{
 			name = Water
-			rate = 0.0000574218
+			rate = 0.0000287109					// 0.5× kerbalism-greenhouse
 		}
 
 		INPUT_RESOURCE
 		{
 			name = WasteAtmosphere
-			rate = 0.0224243955
+			rate = 0.01121219775				// 0.5× kerbalism-greenhouse
 		}
 
 		INPUT_RESOURCE
 		{
 			name = CarbonDioxide
-			rate = 0.00747479835
+			rate = 0.003737399175				// 0.5× kerbalism-greenhouse
 		}
 
 		OUTPUT_RESOURCE
 		{
 			name = Oxygen
-			rate = 0.0310283685
+			rate = 0.01551418425				// 0.5× kerbalism-greenhouse
 		}
 	}
 
 	RESOURCE
 	{
 		name = Ammonia
-		amount = 4896
-		maxAmount = 4896
+		amount = 2448							// 0.5× kerbalism-greenhouse
+		maxAmount = 2448
 	}
 
 	RESOURCE
 	{
 		name = CarbonDioxide
-		amount = 81000
-		maxAmount = 81000
+		amount = 40500							// 0.5× kerbalism-greenhouse
+		maxAmount = 40500
 	}
 
 	RESOURCE
 	{
 		name = Water
-		amount = 198
-		maxAmount = 198
+		amount = 99								// 0.5× kerbalism-greenhouse
+		maxAmount = 99
 	}
 
 	// Dedicated N2 buffer for pressure control (same pattern as stock / SSPX greenhouses)
@@ -238,7 +247,7 @@
 	RESOURCE
 	{
 		name = Nitrogen
-		amount = 10000
+		amount = 10000							// pressure-control buffer; not scaled with crop throughput
 		maxAmount = 10000
 	}
 

--- a/GameData/KerbalismConfig/System/ScienceRework/Groups/Upgrades.cfg
+++ b/GameData/KerbalismConfig/System/ScienceRework/Groups/Upgrades.cfg
@@ -7,9 +7,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Unmanned-Upgrade1
   partIcon = kerbalism-geigercounter
-  title = Unmanned Experiments Slot Upgrade
+  title = #KERBALISM_Upgrade_UnmannedSlot_title//Unmanned Experiments Slot Upgrade
   manufacturer = A&D Aerospace
-  description = Adds an additional experiment slot to Probes.
+  description = #KERBALISM_Upgrade_UnmannedSlot_desc//Adds an additional experiment slot to Probes.
 }
 @PARTUPGRADE[Unmanned-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -22,9 +22,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Orbital-Upgrade1
   partIcon = SurveyScanner
-  title = Orbital Scanner Slot Upgrade
+  title = #KERBALISM_Upgrade_OrbitalSlot_title//Orbital Scanner Slot Upgrade
   manufacturer = A&D Aerospace
-  description = Adds an additional experiment slot to the Orbital Scanner.
+  description = #KERBALISM_Upgrade_OrbitalSlot_desc//Adds an additional experiment slot to the Orbital Scanner.
 }
 @PARTUPGRADE[Orbital-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -37,9 +37,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Lab-Upgrade1
   partIcon = Large_Crewed_Lab
-  title = Laboratory Experiments Slot Upgrade
+  title = #KERBALISM_Upgrade_LabSlot_title//Laboratory Experiments Slot Upgrade
   manufacturer = A&D Aerospace
-  description = Adds an additional experiment slot to all Laboratories.
+  description = #KERBALISM_Upgrade_LabSlot_desc//Adds an additional experiment slot to all Laboratories.
 }
 @PARTUPGRADE[Lab-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -51,9 +51,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Lab-Upgrade2
   partIcon = Large_Crewed_Lab
-  title = Laboratory Reconfiguration Upgrade
+  title = #KERBALISM_Upgrade_LabReconfigure_title//Laboratory Reconfiguration Upgrade
   manufacturer = A&D Aerospace
-  description = Allows Laboratory Experiments to be reconfigured in flight or on the ground by experienced scientists.
+  description = #KERBALISM_Upgrade_LabReconfigure_desc//Allows Laboratory Experiments to be reconfigured in flight or on the ground by experienced scientists.
 }
 @PARTUPGRADE[Lab-Upgrade2]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -68,9 +68,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
   // partIcon = RadialDrill
   // techRequired = advScienceTech
   // entryCost = 15000
-  // title = Surface Sampling Kit Slot Upgrade
+  // title = #KERBALISM_Upgrade_SurfaceSlot_title//Surface Sampling Kit Slot Upgrade
   // manufacturer = A&D Aerospace
-  // description = Adds an additional experiment slot to all Surface Sampling Kits.
+  // description = #KERBALISM_Upgrade_SurfaceSlot_desc//Adds an additional experiment slot to all Surface Sampling Kits.
 // }
 
 // @PARTUPGRADE[Surface-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
@@ -84,9 +84,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Atmo-Upgrade1
   partIcon = sensorAtmosphere
-  title = Atmospheric Science Slot Upgrade
+  title = #KERBALISM_Upgrade_AtmoSlot_title//Atmospheric Science Slot Upgrade
   manufacturer = A&D Aerospace
-  description = Adds an additional experiment slot to all Atmospheric Science groups.
+  description = #KERBALISM_Upgrade_AtmoSlot_desc//Adds an additional experiment slot to all Atmospheric Science groups.
 }
 @PARTUPGRADE[Atmo-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -99,9 +99,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Crew-Upgrade1
   partIcon = crewCabin
-  title = Crewed Experiments Slot Upgrade
+  title = #KERBALISM_Upgrade_CrewedSlot_title//Crewed Experiments Slot Upgrade
   manufacturer = A&D Aerospace
-  description = Adds an additional experiment slot to all parts capable of hosting crewed experiments.
+  description = #KERBALISM_Upgrade_CrewedSlot_desc//Adds an additional experiment slot to all parts capable of hosting crewed experiments.
 }
 @PARTUPGRADE[Crew-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -114,9 +114,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Underwater-Upgrade1
   partIcon = sensorAtmosphere
-  title = Underwater Science Slot Upgrade
+  title = #KERBALISM_Upgrade_UnderwaterSlot_title//Underwater Science Slot Upgrade
   manufacturer = A&D Aerospace
-  description = Adds an additional experiment slot to all Underwater Science groups.
+  description = #KERBALISM_Upgrade_UnderwaterSlot_desc//Adds an additional experiment slot to all Underwater Science groups.
 }
 @PARTUPGRADE[Underwater-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -133,9 +133,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = HDD-Upgrade1
   partIcon = ScienceBox
-  title = HDD Capacity Upgrade
+  title = #KERBALISM_Upgrade_HDDCapacity_title//HDD Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Engineers figured that if they add another platter to the drive, they can double the capacity!
+  description = #KERBALISM_Upgrade_HDDCapacity1_desc//Engineers figured that if they add another platter to the drive, they can double the capacity!
 }
 @PARTUPGRADE[HDD-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -146,9 +146,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = HDD-Upgrade2
   partIcon = ScienceBox
-  title = HDD Capacity Upgrade
+  title = #KERBALISM_Upgrade_HDDCapacity_title//HDD Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = An increase in platter density equals an increase in capacity!
+  description = #KERBALISM_Upgrade_HDDCapacity2_desc//An increase in platter density equals an increase in capacity!
 }
 @PARTUPGRADE[HDD-Upgrade2]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -159,9 +159,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = HDD-Upgrade3
   partIcon = ScienceBox
-  title = HDD Capacity Upgrade
+  title = #KERBALISM_Upgrade_HDDCapacity_title//HDD Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Converts all the old dusty Hard Drives to all new and shiny Solid State Drives!
+  description = #KERBALISM_Upgrade_HDDCapacity3_desc//Converts all the old dusty Hard Drives to all new and shiny Solid State Drives!
 }
 @PARTUPGRADE[HDD-Upgrade3]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -172,9 +172,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = HDD-Upgrade4
   partIcon = ScienceBox
-  title = HDD Capacity Upgrade
+  title = #KERBALISM_Upgrade_HDDCapacity_title//HDD Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Quantum physics shenenigans! It just works. Don't ask how.
+  description = #KERBALISM_Upgrade_HDDCapacity4_desc//Quantum physics shenenigans! It just works. Don't ask how.
 }
 @PARTUPGRADE[HDD-Upgrade4]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -187,9 +187,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = SampleCapacity-Upgrade1
   partIcon = ScienceBox
-  title = Sample Storage Capacity Upgrade
+  title = #KERBALISM_Upgrade_SampleCapacity_title//Sample Storage Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Increase the total amount of sample storage
+  description = #KERBALISM_Upgrade_SampleCapacity_desc//Increase the total amount of sample storage
 }
 @PARTUPGRADE[SampleCapacity-Upgrade1]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -200,9 +200,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = SampleCapacity-Upgrade2
   partIcon = ScienceBox
-  title = Sample Storage Capacity Upgrade
+  title = #KERBALISM_Upgrade_SampleCapacity_title//Sample Storage Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Increase the total amount of sample storage
+  description = #KERBALISM_Upgrade_SampleCapacity_desc//Increase the total amount of sample storage
 }
 @PARTUPGRADE[SampleCapacity-Upgrade2]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -213,9 +213,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = SampleCapacity-Upgrade3
   partIcon = ScienceBox
-  title = Sample Storage Capacity Upgrade
+  title = #KERBALISM_Upgrade_SampleCapacity_title//Sample Storage Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Increase the total amount of sample storage
+  description = #KERBALISM_Upgrade_SampleCapacity_desc//Increase the total amount of sample storage
 }
 @PARTUPGRADE[SampleCapacity-Upgrade3]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -232,9 +232,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = Goo-Storage-Upgrade
   partIcon = GooExperiment
-  title =  Mystery Goo Sample Capacity Upgrade
+  title = #KERBALISM_Upgrade_GooSampleCapacity_title//Mystery Goo Sample Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Increase the total amount of sample storage for the Goo Experiment
+  description = #KERBALISM_Upgrade_GooSampleCapacity_desc//Increase the total amount of sample storage for the Goo Experiment
 }
 @PARTUPGRADE[Goo-Storage-Upgrade]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {
@@ -247,9 +247,9 @@ PARTUPGRADE:NEEDS[FeatureScience]
 {
   name = MatBay-Storage-Upgrade
   partIcon = science_module
-  title = Materials Bay Sample Capacity Upgrade
+  title = #KERBALISM_Upgrade_MatBaySampleCapacity_title//Materials Bay Sample Capacity Upgrade
   manufacturer = Spacegate Technology
-  description = Increase the total amount of sample storage for the Materials Bay
+  description = #KERBALISM_Upgrade_MatBaySampleCapacity_desc//Increase the total amount of sample storage for the Materials Bay
 }
 @PARTUPGRADE[MatBay-Storage-Upgrade]:NEEDS[FeatureScience]:FOR[KerbalismDefault]
 {

--- a/src/Kerbalism/Automation/Computer.cs
+++ b/src/Kerbalism/Automation/Computer.cs
@@ -277,6 +277,7 @@ namespace KERBALISM
 						case "Laboratory":                   device = new LaboratoryDevice(m as Laboratory);                     break;
 						case "Experiment":                   device = new ExperimentDevice(m as Experiment);                     break;
 						case "SolarPanelFixer":				 device = new PanelDevice(m as SolarPanelFixer);					  break;
+						case "PETTurbineFixer":               device = new WindTurbineDevice(m as PETTurbineFixer);               break;
 						case "ModuleGenerator":              device = new GeneratorDevice(m as ModuleGenerator);                 break;
 						case "ModuleResourceConverter":      device = new ConverterDevice(m as ModuleResourceConverter);         break;
 						case "ModuleKPBSConverter":          device = new ConverterDevice(m as ModuleResourceConverter);         break;
@@ -353,6 +354,7 @@ namespace KERBALISM
 							case "Laboratory":                   device = new ProtoLaboratoryDevice(module_prefab as Laboratory, p, m);            break;
 							case "Experiment":					 device = new ProtoExperimentDevice(module_prefab as Experiment, p, m, v);         break;
 							case "SolarPanelFixer":              device = new ProtoPanelDevice(module_prefab as SolarPanelFixer, p, m);            break;
+							case "PETTurbineFixer":              device = new ProtoWindTurbineDevice(module_prefab as PETTurbineFixer, p, m);     break;
 							case "ModuleGenerator":              device = new ProtoGeneratorDevice(module_prefab as ModuleGenerator, p, m);        break;
 							case "ModuleResourceConverter":
 							case "ModuleKPBSConverter":

--- a/src/Kerbalism/Automation/Devices/WindTurbine.cs
+++ b/src/Kerbalism/Automation/Devices/WindTurbine.cs
@@ -1,0 +1,142 @@
+using System;
+
+namespace KERBALISM
+{
+	public sealed class WindTurbineDevice : LoadedDevice<PETTurbineFixer>
+	{
+		public WindTurbineDevice(PETTurbineFixer module) : base(module) { }
+
+		public override string Name => "wind turbine";
+
+		public override string DisplayName => Local.Brokers_WindTurbine;
+
+		public override string Status
+		{
+			get
+			{
+				if (module.IsBroken)
+					return Lib.Color(Local.Generic_BROKEN, Lib.Kolor.Red);
+
+				if (!module.IsDeployable)
+					return Lib.Color(module.IsActive, Local.Generic_ON, Lib.Kolor.Green, Local.Generic_OFF, Lib.Kolor.Yellow);
+
+				switch (module.DeployState)
+				{
+					case "RETRACTED":
+						return Lib.Color(Local.Generic_RETRACTED, Lib.Kolor.Yellow);
+					case "EXTENDING":
+						return Local.Generic_EXTENDING;
+					case "RETRACTING":
+						return Local.Generic_RETRACTING;
+					case "EXTENDED":
+						return Lib.Color(Local.Generic_EXTENDED, Lib.Kolor.Green);
+					default:
+						return Local.Statu_unknown;
+				}
+			}
+		}
+
+		public override bool IsVisible => module.TurbineModule != null && !module.IsBroken;
+
+		public override void Ctrl(bool value) => module.Ctrl(value);
+
+		public override void Toggle() => module.Toggle();
+	}
+
+	public sealed class ProtoWindTurbineDevice : ProtoDevice<PETTurbineFixer>
+	{
+		private readonly ProtoPartModuleSnapshot turbineProto;
+		private readonly PartModule turbinePrefab;
+
+		public ProtoWindTurbineDevice(PETTurbineFixer prefab, ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot protoModule)
+			: base(prefab, protoPart, protoModule)
+		{
+			turbineProto = PETTurbineResourceSim.FindTurbineProto(protoPart);
+			turbinePrefab = null;
+			if (protoPart != null)
+			{
+				AvailablePart ap = PartLoader.getPartInfoByName(protoPart.partName);
+				if (ap != null)
+					turbinePrefab = PETTurbineResourceSim.FindTurbinePrefab(ap.partPrefab);
+			}
+		}
+
+		public override string Name => "wind turbine";
+
+		public override string DisplayName => Local.Brokers_WindTurbine;
+
+		public override string Status
+		{
+			get
+			{
+				if (turbineProto == null)
+					return Local.Statu_unknown;
+
+				if (PETTurbineResourceSim.IsBroken(turbineProto))
+					return Lib.Color(Local.Generic_BROKEN, Lib.Kolor.Red);
+
+				bool deployable = PETTurbineResourceSim.IsDeployable(turbinePrefab);
+				if (!deployable)
+				{
+					bool active = Lib.Proto.GetBool(turbineProto, "isActive");
+					return Lib.Color(active, Local.Generic_ON, Lib.Kolor.Green, Local.Generic_OFF, Lib.Kolor.Yellow);
+				}
+
+				switch (PETTurbineResourceSim.GetDeployState(turbineProto))
+				{
+					case "RETRACTED":
+						return Lib.Color(Local.Generic_RETRACTED, Lib.Kolor.Yellow);
+					case "EXTENDING":
+						return Local.Generic_EXTENDING;
+					case "RETRACTING":
+						return Local.Generic_RETRACTING;
+					case "EXTENDED":
+						return Lib.Color(Local.Generic_EXTENDED, Lib.Kolor.Green);
+					default:
+						return Local.Statu_unknown;
+				}
+			}
+		}
+
+		public override bool IsVisible => turbineProto != null && !PETTurbineResourceSim.IsBroken(turbineProto);
+
+		public override void Ctrl(bool value)
+		{
+			if (turbineProto == null || PETTurbineResourceSim.IsBroken(turbineProto))
+				return;
+
+			bool deployable = PETTurbineResourceSim.IsDeployable(turbinePrefab);
+			if (deployable)
+			{
+				string state = PETTurbineResourceSim.GetDeployState(turbineProto);
+				if (value && state == "RETRACTED")
+					PETTurbineResourceSim.ProtoSetDeployed(turbineProto, true);
+				else if (!value && state == "EXTENDED")
+					PETTurbineResourceSim.ProtoSetDeployed(turbineProto, false);
+				return;
+			}
+
+			PETTurbineResourceSim.ProtoSetActive(turbineProto, value);
+		}
+
+		public override void Toggle()
+		{
+			if (turbineProto == null || PETTurbineResourceSim.IsBroken(turbineProto))
+				return;
+
+			bool deployable = PETTurbineResourceSim.IsDeployable(turbinePrefab);
+			if (deployable)
+			{
+				string state = PETTurbineResourceSim.GetDeployState(turbineProto);
+				if (state == "RETRACTED")
+					PETTurbineResourceSim.ProtoSetDeployed(turbineProto, true);
+				else if (state == "EXTENDED")
+					PETTurbineResourceSim.ProtoSetDeployed(turbineProto, false);
+				return;
+			}
+
+			bool active = Lib.Proto.GetBool(turbineProto, "isActive");
+			PETTurbineResourceSim.ProtoSetActive(turbineProto, !active);
+		}
+	}
+}

--- a/src/Kerbalism/External/OptionalAssembly.cs
+++ b/src/Kerbalism/External/OptionalAssembly.cs
@@ -7,7 +7,8 @@ namespace KERBALISM
 {
 	internal sealed class OptionalAssembly
 	{
-		private const BindingFlags Flags = BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+		private const BindingFlags DeclaredFlags =
+			BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
 
 		private readonly Dictionary<string, Type> typeCache = new Dictionary<string, Type>();
 		private readonly Dictionary<string, FieldInfo> fieldCache = new Dictionary<string, FieldInfo>();
@@ -52,7 +53,14 @@ namespace KERBALISM
 			FieldInfo field;
 			if (!fieldCache.TryGetValue(key, out field))
 			{
-				field = type.GetField(name, Flags);
+				// Walk inheritance: private fields on base types (e.g. ModulePETAnimation.deployState)
+				// are invisible to Type.GetField on the derived type.
+				for (Type current = type; current != null; current = current.BaseType)
+				{
+					field = current.GetField(name, DeclaredFlags);
+					if (field != null)
+						break;
+				}
 				fieldCache[key] = field;
 			}
 			return field;
@@ -67,7 +75,12 @@ namespace KERBALISM
 			PropertyInfo property;
 			if (!propertyCache.TryGetValue(key, out property))
 			{
-				property = type.GetProperty(name, Flags);
+				for (Type current = type; current != null; current = current.BaseType)
+				{
+					property = current.GetProperty(name, DeclaredFlags);
+					if (property != null)
+						break;
+				}
 				propertyCache[key] = property;
 			}
 			return property;
@@ -82,7 +95,14 @@ namespace KERBALISM
 			MethodInfo method;
 			if (!methodCache.TryGetValue(key, out method))
 			{
-				method = parameters == null ? type.GetMethod(name, Flags) : type.GetMethod(name, Flags, null, parameters, null);
+				for (Type current = type; current != null; current = current.BaseType)
+				{
+					method = parameters == null
+						? current.GetMethod(name, DeclaredFlags)
+						: current.GetMethod(name, DeclaredFlags, null, parameters, null);
+					if (method != null)
+						break;
+				}
 				methodCache[key] = method;
 			}
 			return method;

--- a/src/Kerbalism/External/PlanetsideExplorationTechnologies.cs
+++ b/src/Kerbalism/External/PlanetsideExplorationTechnologies.cs
@@ -1,0 +1,39 @@
+namespace KERBALISM
+{
+	internal static class PlanetsideExplorationTechnologies
+	{
+		private static readonly OptionalAssembly assembly = new OptionalAssembly("PlanetsideExplorationTechnologies");
+
+		public const string TurbineModuleName = "ModulePETTurbine";
+		public const string TurbineTypeName = "PlanetsideExplorationTechnologies.Modules.ModulePETTurbine";
+
+		public static bool Installed => assembly.Installed;
+
+		public static bool IsTurbine(PartModule module)
+		{
+			return assembly.IsModule(module, TurbineTypeName) || (module != null && module.moduleName == TurbineModuleName);
+		}
+
+		public static T Get<T>(object instance, string name, T fallback = default(T)) => assembly.Get(instance, name, fallback);
+
+		public static void Set<T>(object instance, string name, T value) => assembly.Set(instance, name, value);
+
+		public static object Call(object instance, string name, System.Type[] parameters = null, object[] args = null)
+			=> assembly.Call(instance, name, parameters, args);
+
+		public static PartModule FindTurbineModule(Part part)
+		{
+			if (part == null)
+				return null;
+
+			for (int i = 0; i < part.Modules.Count; i++)
+			{
+				PartModule module = part.Modules[i];
+				if (IsTurbine(module))
+					return module;
+			}
+
+			return null;
+		}
+	}
+}

--- a/src/Kerbalism/Integrations/IntegrationBootstrap.cs
+++ b/src/Kerbalism/Integrations/IntegrationBootstrap.cs
@@ -18,6 +18,7 @@ namespace KERBALISM
 			Apply("NearFutureElectrical", NearFutureElectrical.Installed, () => NearFutureElectricalIntegration.ApplyHarmonyPatches(harmony));
 			Apply("FarFutureTechnologies", FarFutureTechnologies.Installed, () => FarFutureTechnologiesIntegration.ApplyHarmonyPatches(harmony));
 			Apply("SpaceDust", SpaceDust.Installed, () => SpaceDustIntegration.ApplyHarmonyPatches(harmony));
+			Apply("PlanetsideExplorationTechnologies", PlanetsideExplorationTechnologies.Installed, () => PlanetsideExplorationTechnologiesIntegration.ApplyHarmonyPatches(harmony));
 			Apply("DynamicRadiation", true, () => DynamicRadiationIntegration.ApplyHarmonyPatches(harmony));
 
 			TryApplySystemHeatHarmony(harmony);

--- a/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineFixer.cs
+++ b/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineFixer.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+
+namespace KERBALISM
+{
+	/// <summary>
+	/// Kerbalism bridge for Planetside Exploration Technologies wind turbines.
+	/// Stock EC output is suppressed via Harmony; this module feeds Kerbalism's resource system
+	/// (loaded ResourceUpdate + unloaded BackgroundUpdate) and exposes Auto controls.
+	/// </summary>
+	public class PETTurbineFixer : PartModule, IKerbalismModule
+	{
+		private PartModule turbineModule;
+
+		internal PartModule TurbineModule
+		{
+			get
+			{
+				if (turbineModule == null)
+					turbineModule = PlanetsideExplorationTechnologies.FindTurbineModule(part);
+				return turbineModule;
+			}
+		}
+
+		public override void OnStart(StartState state)
+		{
+			base.OnStart(state);
+			turbineModule = PlanetsideExplorationTechnologies.FindTurbineModule(part);
+		}
+
+		public string ResourceUpdate(Dictionary<string, double> availableResources, List<KeyValuePair<string, double>> resourceChangeRequest)
+		{
+			// Loaded production is injected at PET's UpdateResourceHandler Harmony hook,
+			// after PET has calculated the wind efficiency used by its PAW.
+			return PETTurbineResourceSim.BrokerId;
+		}
+
+		public string PlannerUpdate(List<KeyValuePair<string, double>> resourceChangeRequest, CelestialBody body, Dictionary<string, double> environment)
+		{
+			// Planner wind estimation is out of scope for this pass.
+			return PETTurbineResourceSim.BrokerId;
+		}
+
+		public static string BackgroundUpdate(
+			Vessel v,
+			ProtoPartSnapshot part_snapshot,
+			ProtoPartModuleSnapshot module_snapshot,
+			PartModule proto_part_module,
+			Part proto_part,
+			Dictionary<string, double> availableResources,
+			List<KeyValuePair<string, double>> resourceChangeRequest,
+			double elapsed_s)
+		{
+			ProtoPartModuleSnapshot turbineProto = PETTurbineResourceSim.FindTurbineProto(part_snapshot);
+			PartModule turbinePrefab = PETTurbineResourceSim.FindTurbinePrefab(proto_part);
+			if (turbineProto == null || turbinePrefab == null)
+				return PETTurbineResourceSim.BrokerId;
+
+			double rate = PETTurbineResourceSim.GetBackgroundRate(v, turbineProto, turbinePrefab);
+			PETTurbineResourceSim.AddRate(resourceChangeRequest, rate);
+			return PETTurbineResourceSim.BrokerId;
+		}
+
+		internal bool IsDeployable => PETTurbineResourceSim.IsDeployable(TurbineModule);
+
+		internal bool IsBroken => PETTurbineResourceSim.IsBroken(TurbineModule);
+
+		internal string DeployState => PETTurbineResourceSim.GetDeployState(TurbineModule);
+
+		internal bool IsActive => PlanetsideExplorationTechnologies.Get(TurbineModule, "isActive", false);
+
+		internal void Toggle()
+		{
+			PartModule turbine = TurbineModule;
+			if (turbine == null || IsBroken)
+				return;
+
+			if (IsDeployable)
+			{
+				string state = DeployState;
+				if (state == "RETRACTED")
+					PETTurbineResourceSim.Extend(turbine);
+				else if (state == "EXTENDED")
+					PETTurbineResourceSim.Retract(turbine);
+				return;
+			}
+
+			PETTurbineResourceSim.SetActive(turbine, !IsActive);
+		}
+
+		internal void Ctrl(bool value)
+		{
+			PartModule turbine = TurbineModule;
+			if (turbine == null || IsBroken)
+				return;
+
+			if (IsDeployable)
+			{
+				string state = DeployState;
+				if (value && state == "RETRACTED")
+					PETTurbineResourceSim.Extend(turbine);
+				else if (!value && state == "EXTENDED")
+					PETTurbineResourceSim.Retract(turbine);
+				return;
+			}
+
+			PETTurbineResourceSim.SetActive(turbine, value);
+		}
+	}
+}

--- a/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineHarmony.cs
+++ b/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineHarmony.cs
@@ -1,0 +1,136 @@
+using HarmonyLib;
+using System.Reflection;
+
+namespace KERBALISM
+{
+	internal static class PETTurbineHarmony
+	{
+		private static bool productionFailureLogged;
+		private static long hookCallCount;
+		private static float nextHookTraceTime;
+		private static float nextSyncTraceTime;
+
+		public static void Apply(Harmony harmony)
+		{
+			System.Type turbineType = AccessTools.TypeByName(PlanetsideExplorationTechnologies.TurbineTypeName);
+			if (turbineType == null)
+			{
+				Lib.Log("PET turbine Harmony: type not found: " + PlanetsideExplorationTechnologies.TurbineTypeName, Lib.LogLevel.Warning);
+				return;
+			}
+
+			MethodInfo target = AccessTools.Method(turbineType, "UpdateResourceHandler");
+			MethodInfo prefix = AccessTools.Method(typeof(PETTurbineHarmony), nameof(ProduceEcThroughKerbalism));
+			if (target == null || prefix == null)
+			{
+				Lib.Log("PET turbine Harmony: UpdateResourceHandler patch target/prefix missing", Lib.LogLevel.Warning);
+				return;
+			}
+
+			harmony.Patch(target, new HarmonyMethod(prefix));
+			Lib.Log("PET turbine Harmony: patched ModulePETTurbine.UpdateResourceHandler");
+		}
+
+		/// <summary>
+		/// Replace PET stock EC output with Kerbalism deferred production. This runs after PET
+		/// has updated its wind efficiency, so the PAW and Kerbalism use the same rate.
+		/// </summary>
+		private static bool ProduceEcThroughKerbalism(object __instance)
+		{
+			PartModule module = __instance as PartModule;
+			if (module == null || module.part == null)
+				return true;
+
+			if (module.part.FindModuleImplementing<PETTurbineFixer>() == null)
+				return true;
+
+			try
+			{
+				++hookCallCount;
+				double rate = PETTurbineResourceSim.GetLoadedRate(module, module.vessel);
+				ResourceInfo ec = ResourceCache.GetResource(module.vessel, "ElectricCharge");
+				double deferredBefore = ec.Deferred;
+				double quantity = 0.0;
+				if (rate > 0.0)
+				{
+					quantity = rate * Kerbalism.elapsed_s;
+					ec.Produce(quantity, ResourceBroker.WindTurbine);
+				}
+
+				if (UnityEngine.Time.realtimeSinceStartup >= nextHookTraceTime)
+				{
+					nextHookTraceTime = UnityEngine.Time.realtimeSinceStartup + 2.0f;
+					object deployState = PlanetsideExplorationTechnologies.Get<object>(module, "deployState", null);
+					bool isActive = PlanetsideExplorationTechnologies.Get(module, "isActive", false);
+					float chargeRate = PlanetsideExplorationTechnologies.Get(module, "chargeRate", float.NaN);
+					float efficiencyCurve = PlanetsideExplorationTechnologies.Get(module, "efficiencyCurve", float.NaN);
+					float efficiencyAngle = PlanetsideExplorationTechnologies.Get(module, "efficiencyAngle", float.NaN);
+					float angleFactor = PETTurbineResourceSim.GetAngleEfficiency(module);
+					string pawRate = PlanetsideExplorationTechnologies.Get(module, "flowRateDisplay", "<missing>");
+
+					Lib.Log(string.Format(
+						"PET_TRACE HOOK calls={0} vessel={1} part={2} landed={3} splashed={4} atm={5:R} water={6} deploy={7} active={8} charge={9:R} efficiency={10:R} efficiencyAngle={11:R} angleFactor={12:R} PAW={13} calculatedRate={14:R} elapsed={15:R} queued={16:R} EC(amount={17:R},capacity={18:R},deferred={19:R}->{20:R})",
+						hookCallCount,
+						module.vessel != null ? module.vessel.vesselName : "<null>",
+						module.part.partInfo != null ? module.part.partInfo.name : module.part.name,
+						module.vessel != null && module.vessel.Landed,
+						module.vessel != null && module.vessel.Splashed,
+						module.vessel != null ? module.vessel.atmDensity : double.NaN,
+						module.part.WaterContact,
+						deployState != null ? deployState.ToString() : "<null>",
+						isActive,
+						chargeRate,
+						efficiencyCurve,
+						efficiencyAngle,
+						angleFactor,
+						pawRate,
+						rate,
+						Kerbalism.elapsed_s,
+						quantity,
+						ec.Amount,
+						ec.Capacity,
+						deferredBefore,
+						ec.Deferred));
+				}
+				return false;
+			}
+			catch (System.Exception ex)
+			{
+				if (!productionFailureLogged)
+				{
+					productionFailureLogged = true;
+					Lib.Log("PET turbine Kerbalism production failed; falling back to PET: " + ex, Lib.LogLevel.Error);
+				}
+				return true;
+			}
+		}
+
+		internal static void TraceResourceSync(
+			Vessel vessel,
+			double windQuantity,
+			double deferredBeforeClamp,
+			double deferredAfterClamp,
+			double amountBefore,
+			double physicalAmountBefore,
+			double amountAfter,
+			double capacity,
+			double elapsed)
+		{
+			if (UnityEngine.Time.realtimeSinceStartup < nextSyncTraceTime)
+				return;
+
+			nextSyncTraceTime = UnityEngine.Time.realtimeSinceStartup + 2.0f;
+			Lib.Log(string.Format(
+				"PET_TRACE SYNC vessel={0} windBrokerQuantity={1:R} deferredBeforeClamp={2:R} deferredApplied={3:R} cachedAmountBefore={4:R} physicalAmountBefore={5:R} amountAfter={6:R} capacity={7:R} elapsed={8:R}",
+				vessel != null ? vessel.vesselName : "<null>",
+				windQuantity,
+				deferredBeforeClamp,
+				deferredAfterClamp,
+				amountBefore,
+				physicalAmountBefore,
+				amountAfter,
+				capacity,
+				elapsed));
+		}
+	}
+}

--- a/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineHarmony.cs
+++ b/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineHarmony.cs
@@ -6,9 +6,6 @@ namespace KERBALISM
 	internal static class PETTurbineHarmony
 	{
 		private static bool productionFailureLogged;
-		private static long hookCallCount;
-		private static float nextHookTraceTime;
-		private static float nextSyncTraceTime;
 
 		public static void Apply(Harmony harmony)
 		{
@@ -28,7 +25,6 @@ namespace KERBALISM
 			}
 
 			harmony.Patch(target, new HarmonyMethod(prefix));
-			Lib.Log("PET turbine Harmony: patched ModulePETTurbine.UpdateResourceHandler");
 		}
 
 		/// <summary>
@@ -46,52 +42,9 @@ namespace KERBALISM
 
 			try
 			{
-				++hookCallCount;
 				double rate = PETTurbineResourceSim.GetLoadedRate(module, module.vessel);
-				ResourceInfo ec = ResourceCache.GetResource(module.vessel, "ElectricCharge");
-				double deferredBefore = ec.Deferred;
-				double quantity = 0.0;
 				if (rate > 0.0)
-				{
-					quantity = rate * Kerbalism.elapsed_s;
-					ec.Produce(quantity, ResourceBroker.WindTurbine);
-				}
-
-				if (UnityEngine.Time.realtimeSinceStartup >= nextHookTraceTime)
-				{
-					nextHookTraceTime = UnityEngine.Time.realtimeSinceStartup + 2.0f;
-					object deployState = PlanetsideExplorationTechnologies.Get<object>(module, "deployState", null);
-					bool isActive = PlanetsideExplorationTechnologies.Get(module, "isActive", false);
-					float chargeRate = PlanetsideExplorationTechnologies.Get(module, "chargeRate", float.NaN);
-					float efficiencyCurve = PlanetsideExplorationTechnologies.Get(module, "efficiencyCurve", float.NaN);
-					float efficiencyAngle = PlanetsideExplorationTechnologies.Get(module, "efficiencyAngle", float.NaN);
-					float angleFactor = PETTurbineResourceSim.GetAngleEfficiency(module);
-					string pawRate = PlanetsideExplorationTechnologies.Get(module, "flowRateDisplay", "<missing>");
-
-					Lib.Log(string.Format(
-						"PET_TRACE HOOK calls={0} vessel={1} part={2} landed={3} splashed={4} atm={5:R} water={6} deploy={7} active={8} charge={9:R} efficiency={10:R} efficiencyAngle={11:R} angleFactor={12:R} PAW={13} calculatedRate={14:R} elapsed={15:R} queued={16:R} EC(amount={17:R},capacity={18:R},deferred={19:R}->{20:R})",
-						hookCallCount,
-						module.vessel != null ? module.vessel.vesselName : "<null>",
-						module.part.partInfo != null ? module.part.partInfo.name : module.part.name,
-						module.vessel != null && module.vessel.Landed,
-						module.vessel != null && module.vessel.Splashed,
-						module.vessel != null ? module.vessel.atmDensity : double.NaN,
-						module.part.WaterContact,
-						deployState != null ? deployState.ToString() : "<null>",
-						isActive,
-						chargeRate,
-						efficiencyCurve,
-						efficiencyAngle,
-						angleFactor,
-						pawRate,
-						rate,
-						Kerbalism.elapsed_s,
-						quantity,
-						ec.Amount,
-						ec.Capacity,
-						deferredBefore,
-						ec.Deferred));
-				}
+					ResourceCache.GetResource(module.vessel, "ElectricCharge").Produce(rate * Kerbalism.elapsed_s, ResourceBroker.WindTurbine);
 				return false;
 			}
 			catch (System.Exception ex)
@@ -103,34 +56,6 @@ namespace KERBALISM
 				}
 				return true;
 			}
-		}
-
-		internal static void TraceResourceSync(
-			Vessel vessel,
-			double windQuantity,
-			double deferredBeforeClamp,
-			double deferredAfterClamp,
-			double amountBefore,
-			double physicalAmountBefore,
-			double amountAfter,
-			double capacity,
-			double elapsed)
-		{
-			if (UnityEngine.Time.realtimeSinceStartup < nextSyncTraceTime)
-				return;
-
-			nextSyncTraceTime = UnityEngine.Time.realtimeSinceStartup + 2.0f;
-			Lib.Log(string.Format(
-				"PET_TRACE SYNC vessel={0} windBrokerQuantity={1:R} deferredBeforeClamp={2:R} deferredApplied={3:R} cachedAmountBefore={4:R} physicalAmountBefore={5:R} amountAfter={6:R} capacity={7:R} elapsed={8:R}",
-				vessel != null ? vessel.vesselName : "<null>",
-				windQuantity,
-				deferredBeforeClamp,
-				deferredAfterClamp,
-				amountBefore,
-				physicalAmountBefore,
-				amountAfter,
-				capacity,
-				elapsed));
 		}
 	}
 }

--- a/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineResourceSim.cs
+++ b/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineResourceSim.cs
@@ -16,9 +16,6 @@ namespace KERBALISM
 
 		private static bool expectedWindCached;
 		private static double expectedWind = 0.8;
-		private static bool loadedRateDiagLogged;
-		private static bool loadedPositiveRateLogged;
-		private static float nextBackgroundTraceTime;
 
 		/// <summary>Broker id for ResourceUpdate / Background (must match ResourceBroker.WindTurbine.Id).</summary>
 		public static string BrokerId => ResourceBroker.WindTurbine.Id;
@@ -30,49 +27,13 @@ namespace KERBALISM
 			if (turbine == null || vessel == null)
 				return 0.0;
 
-			bool envOk = CanProduceEnvironment(vessel, turbine.part);
-			bool genOk = IsGeneratingState(turbine);
+			if (!CanProduceEnvironment(vessel, turbine.part) || !IsGeneratingState(turbine))
+				return 0.0;
+
 			float chargeRate = PlanetsideExplorationTechnologies.Get(turbine, "chargeRate", 0f);
 			float efficiencyCurve = PlanetsideExplorationTechnologies.Get(turbine, "efficiencyCurve", 0f);
-			float trueEfficiencyAngle = GetAngleEfficiency(turbine);
-			object deployState = PlanetsideExplorationTechnologies.Get<object>(turbine, "deployState", null);
-			bool isActive = PlanetsideExplorationTechnologies.Get(turbine, "isActive", false);
-			double rate = (envOk && genOk) ? chargeRate * efficiencyCurve * trueEfficiencyAngle : 0.0;
-			if (rate < 0.0)
-				rate = 0.0;
-
-			// One-shot Release log so StockChinese KSP.log shows why Monitor gets (or misses) EC.
-			if (!loadedRateDiagLogged)
-			{
-				loadedRateDiagLogged = true;
-				Lib.Log(string.Format(
-					"PET turbine ResourceUpdate: vessel={0} landed={1} splashed={2} atm={3:F4} waterContact={4} deployState={5} isActive={6} envOk={7} genOk={8} chargeRate={9:F3} efficiencyCurve={10:F4} trueEfficiencyAngle={11:F4} rate={12:F3} EC/s",
-					vessel.vesselName,
-					vessel.Landed,
-					vessel.Splashed,
-					vessel.atmDensity,
-					turbine.part != null && turbine.part.WaterContact,
-					deployState != null ? deployState.ToString() : "null",
-					isActive,
-					envOk,
-					genOk,
-					chargeRate,
-					efficiencyCurve,
-					trueEfficiencyAngle,
-					rate));
-			}
-
-			if (rate > 0.0 && !loadedPositiveRateLogged)
-			{
-				loadedPositiveRateLogged = true;
-				Lib.Log(string.Format(
-					"PET turbine production active: vessel={0} rate={1:F3} EC/s broker={2}",
-					vessel.vesselName,
-					rate,
-					BrokerId));
-			}
-
-			return rate;
+			double rate = chargeRate * efficiencyCurve * GetAngleEfficiency(turbine);
+			return rate > 0.0 ? rate : 0.0;
 		}
 
 		public static float GetAngleEfficiency(PartModule turbine)
@@ -109,26 +70,6 @@ namespace KERBALISM
 				rate = chargeRate * wind * atmFactor * alignment;
 				if (rate < 0.0)
 					rate = 0.0;
-			}
-
-			if (Time.realtimeSinceStartup >= nextBackgroundTraceTime)
-			{
-				nextBackgroundTraceTime = Time.realtimeSinceStartup + 2.0f;
-				Lib.Log(string.Format(
-					"PET_TRACE BACKGROUND vessel={0} altitude={1:R} vesselAtmDensity={2:R} calculatedAtmDensity={3:R} deploy={4} active={5} envOk={6} genOk={7} expectedWind={8:R} alignment={9:R} localWind={10:R} minWind={11:R} rate={12:R}",
-					v.vesselName,
-					v.altitude,
-					v.atmDensity,
-					atmDensity,
-					GetDeployState(turbineProto),
-					Lib.Proto.GetBool(turbineProto, "isActive"),
-					envOk,
-					genOk,
-					wind,
-					alignment,
-					localWindSpeed,
-					minWindSpeed,
-					rate));
 			}
 
 			return rate;

--- a/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineResourceSim.cs
+++ b/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineResourceSim.cs
@@ -14,8 +14,11 @@ namespace KERBALISM
 	{
 		private const string ResourceEc = "ElectricCharge";
 
-		private static bool expectedWindCached;
-		private static double expectedWind = 0.8;
+		private static bool windProbabilitiesCached;
+		private static double probabilityHighWinds = 0.10;
+		private static double probabilityMidWinds = 0.55;
+		private static double probabilityLowWinds = 0.25;
+		private static double probabilityNoWinds = 0.15;
 
 		/// <summary>Broker id for ResourceUpdate / Background (must match ResourceBroker.WindTurbine.Id).</summary>
 		public static string BrokerId => ResourceBroker.WindTurbine.Id;
@@ -57,17 +60,16 @@ namespace KERBALISM
 			float chargeRate = PlanetsideExplorationTechnologies.Get(turbinePrefab, "chargeRate", 0f);
 			float minWindSpeed = PlanetsideExplorationTechnologies.Get(turbinePrefab, "minWindSpeed", 0.25f);
 			FloatCurve atmCurve = PlanetsideExplorationTechnologies.Get<FloatCurve>(turbinePrefab, "atmEfficiencyCurve", null);
-			double alignment = GetAlignmentFactor(turbinePrefab);
-			double wind = GetExpectedWindMultiplier();
 			double atmDensity = GetAtmosphericDensity(v);
-			double localWindSpeed = atmDensity * wind * alignment;
 			double rate = 0.0;
 
-			if (envOk && genOk && localWindSpeed >= minWindSpeed && atmDensity > double.Epsilon)
+			if (envOk && genOk && atmDensity > double.Epsilon)
 			{
 				double atmFactor = atmCurve != null ? atmCurve.Evaluate((float)atmDensity) : 1.0;
-				// Steady-state tracking approximation of PET's loaded formula
-				rate = chargeRate * wind * atmFactor * alignment;
+				bool tracking = IsTracking(turbinePrefab);
+				double effectiveWind = GetExpectedEffectiveWind(atmDensity, minWindSpeed, tracking);
+				// PET's steady-state output is chargeRate * wind * atmFactor * angleEfficiency².
+				rate = chargeRate * atmFactor * effectiveWind;
 				if (rate < 0.0)
 					rate = 0.0;
 			}
@@ -235,32 +237,60 @@ namespace KERBALISM
 			return PlanetsideExplorationTechnologies.FindTurbineModule(partPrefab);
 		}
 
-		private static double GetAlignmentFactor(PartModule turbinePrefab)
+		private static bool IsTracking(PartModule turbinePrefab)
 		{
 			string turbineType = PlanetsideExplorationTechnologies.Get(turbinePrefab, "turbineType", string.Empty);
 			string rotationPivotName = PlanetsideExplorationTechnologies.Get(turbinePrefab, "rotationPivotName", string.Empty);
-			bool tracking = string.Equals(turbineType, "Tracking", StringComparison.OrdinalIgnoreCase)
+			return string.Equals(turbineType, "Tracking", StringComparison.OrdinalIgnoreCase)
 				|| !string.IsNullOrEmpty(rotationPivotName);
-			return tracking ? 1.0 : 0.75;
 		}
 
-		private static double GetExpectedWindMultiplier()
+		private static double GetExpectedEffectiveWind(double atmDensity, double minWindSpeed, bool tracking)
 		{
-			if (expectedWindCached)
-				return expectedWind;
+			CacheWindProbabilities();
 
-			expectedWindCached = true;
-			expectedWind = ComputeExpectedWindFromDifficulty();
-			return expectedWind;
+			double totalProbability = probabilityHighWinds + probabilityMidWinds + probabilityLowWinds + probabilityNoWinds;
+			if (totalProbability <= double.Epsilon)
+				return 0.0;
+
+			// PET samples uniformly inside each non-zero wind band. Midpoints preserve the
+			// existing approximation while evaluating the non-linear minimum-wind threshold
+			// separately for each band.
+			double weightedWind =
+				probabilityHighWinds * GetWindContribution(1.45, atmDensity, minWindSpeed, tracking)
+				+ probabilityMidWinds * GetWindContribution(0.975, atmDensity, minWindSpeed, tracking)
+				+ probabilityLowWinds * GetWindContribution(0.65, atmDensity, minWindSpeed, tracking);
+
+			return weightedWind / totalProbability;
 		}
 
-		private static double ComputeExpectedWindFromDifficulty()
+		private static double GetWindContribution(double wind, double atmDensity, double minWindSpeed, bool tracking)
 		{
-			// Defaults match PET DifficultyWindProbability field initializers
-			double pHigh = 0.10;
-			double pMid = 0.55;
-			double pLow = 0.25;
-			double pNone = 0.15;
+			if (wind <= double.Epsilon || atmDensity <= double.Epsilon)
+				return 0.0;
+
+			double minimumAlignment = minWindSpeed / (atmDensity * wind);
+			if (tracking)
+				return minimumAlignment <= 1.0 ? wind : 0.0;
+
+			if (minimumAlignment >= 1.0)
+				return 0.0;
+
+			minimumAlignment = Math.Max(0.0, minimumAlignment);
+
+			// For a fixed turbine and a uniformly random heading, angle efficiency is uniform
+			// on [0, 1]. PET applies it twice, so E[a² * I(a >= minimumAlignment)] is
+			// integral(a², minimumAlignment..1).
+			double expectedSquaredAlignment = (1.0 - minimumAlignment * minimumAlignment * minimumAlignment) / 3.0;
+			return wind * expectedSquaredAlignment;
+		}
+
+		private static void CacheWindProbabilities()
+		{
+			if (windProbabilitiesCached)
+				return;
+
+			windProbabilitiesCached = true;
 
 			try
 			{
@@ -276,10 +306,10 @@ namespace KERBALISM
 							object node = generic.MakeGenericMethod(difficultyType).Invoke(HighLogic.CurrentGame.Parameters, null);
 							if (node != null)
 							{
-								pHigh = IntegrationReflection.GetFloat(node, "probabilityHighWinds", (float)pHigh);
-								pMid = IntegrationReflection.GetFloat(node, "probabilityMidWinds", (float)pMid);
-								pLow = IntegrationReflection.GetFloat(node, "probabilityLowWinds", (float)pLow);
-								pNone = IntegrationReflection.GetFloat(node, "probabilityNoWinds", (float)pNone);
+								probabilityHighWinds = IntegrationReflection.GetFloat(node, "probabilityHighWinds", (float)probabilityHighWinds);
+								probabilityMidWinds = IntegrationReflection.GetFloat(node, "probabilityMidWinds", (float)probabilityMidWinds);
+								probabilityLowWinds = IntegrationReflection.GetFloat(node, "probabilityLowWinds", (float)probabilityLowWinds);
+								probabilityNoWinds = IntegrationReflection.GetFloat(node, "probabilityNoWinds", (float)probabilityNoWinds);
 							}
 						}
 					}
@@ -289,16 +319,6 @@ namespace KERBALISM
 			{
 				Lib.LogDebug("PET wind difficulty read failed: " + e.Message);
 			}
-
-			double total = pHigh + pMid + pLow + pNone;
-			if (total <= double.Epsilon)
-				return 0.8;
-
-			// Midpoints of PET GenerateWindSpeed ranges
-			double highMid = (1.1 + 1.8) * 0.5;
-			double midMid = (0.9 + 1.05) * 0.5;
-			double lowMid = (0.5 + 0.8) * 0.5;
-			return (pHigh * highMid + pMid * midMid + pLow * lowMid) / total;
 		}
 	}
 }

--- a/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineResourceSim.cs
+++ b/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PETTurbineResourceSim.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using UnityEngine;
+
+namespace KERBALISM
+{
+	/// <summary>
+	/// Shared EC rate logic for Planetside Exploration Technologies wind turbines.
+	/// Loaded vessels reuse PET's per-frame efficiency; unloaded vessels use expected wind.
+	/// </summary>
+	internal static class PETTurbineResourceSim
+	{
+		private const string ResourceEc = "ElectricCharge";
+
+		private static bool expectedWindCached;
+		private static double expectedWind = 0.8;
+		private static bool loadedRateDiagLogged;
+		private static bool loadedPositiveRateLogged;
+		private static float nextBackgroundTraceTime;
+
+		/// <summary>Broker id for ResourceUpdate / Background (must match ResourceBroker.WindTurbine.Id).</summary>
+		public static string BrokerId => ResourceBroker.WindTurbine.Id;
+
+		public static string BrokerTitle => Local.Brokers_WindTurbine;
+
+		public static double GetLoadedRate(PartModule turbine, Vessel vessel)
+		{
+			if (turbine == null || vessel == null)
+				return 0.0;
+
+			bool envOk = CanProduceEnvironment(vessel, turbine.part);
+			bool genOk = IsGeneratingState(turbine);
+			float chargeRate = PlanetsideExplorationTechnologies.Get(turbine, "chargeRate", 0f);
+			float efficiencyCurve = PlanetsideExplorationTechnologies.Get(turbine, "efficiencyCurve", 0f);
+			float trueEfficiencyAngle = GetAngleEfficiency(turbine);
+			object deployState = PlanetsideExplorationTechnologies.Get<object>(turbine, "deployState", null);
+			bool isActive = PlanetsideExplorationTechnologies.Get(turbine, "isActive", false);
+			double rate = (envOk && genOk) ? chargeRate * efficiencyCurve * trueEfficiencyAngle : 0.0;
+			if (rate < 0.0)
+				rate = 0.0;
+
+			// One-shot Release log so StockChinese KSP.log shows why Monitor gets (or misses) EC.
+			if (!loadedRateDiagLogged)
+			{
+				loadedRateDiagLogged = true;
+				Lib.Log(string.Format(
+					"PET turbine ResourceUpdate: vessel={0} landed={1} splashed={2} atm={3:F4} waterContact={4} deployState={5} isActive={6} envOk={7} genOk={8} chargeRate={9:F3} efficiencyCurve={10:F4} trueEfficiencyAngle={11:F4} rate={12:F3} EC/s",
+					vessel.vesselName,
+					vessel.Landed,
+					vessel.Splashed,
+					vessel.atmDensity,
+					turbine.part != null && turbine.part.WaterContact,
+					deployState != null ? deployState.ToString() : "null",
+					isActive,
+					envOk,
+					genOk,
+					chargeRate,
+					efficiencyCurve,
+					trueEfficiencyAngle,
+					rate));
+			}
+
+			if (rate > 0.0 && !loadedPositiveRateLogged)
+			{
+				loadedPositiveRateLogged = true;
+				Lib.Log(string.Format(
+					"PET turbine production active: vessel={0} rate={1:F3} EC/s broker={2}",
+					vessel.vesselName,
+					rate,
+					BrokerId));
+			}
+
+			return rate;
+		}
+
+		public static float GetAngleEfficiency(PartModule turbine)
+		{
+			// Newer PET source caches this factor, but the currently distributed DLL computes
+			// it directly into efficiencyAngle. Support both binary layouts.
+			float factor = PlanetsideExplorationTechnologies.Get(turbine, "trueEfficiencyAngle", float.NaN);
+			if (float.IsNaN(factor))
+				factor = PlanetsideExplorationTechnologies.Get(turbine, "efficiencyAngle", 0f);
+
+			return Mathf.Clamp01(factor);
+		}
+
+		public static double GetBackgroundRate(Vessel v, ProtoPartModuleSnapshot turbineProto, PartModule turbinePrefab)
+		{
+			if (v == null || turbineProto == null || turbinePrefab == null)
+				return 0.0;
+
+			bool envOk = CanProduceEnvironment(v, null);
+			bool genOk = IsGeneratingState(turbineProto);
+			float chargeRate = PlanetsideExplorationTechnologies.Get(turbinePrefab, "chargeRate", 0f);
+			float minWindSpeed = PlanetsideExplorationTechnologies.Get(turbinePrefab, "minWindSpeed", 0.25f);
+			FloatCurve atmCurve = PlanetsideExplorationTechnologies.Get<FloatCurve>(turbinePrefab, "atmEfficiencyCurve", null);
+			double alignment = GetAlignmentFactor(turbinePrefab);
+			double wind = GetExpectedWindMultiplier();
+			double atmDensity = GetAtmosphericDensity(v);
+			double localWindSpeed = atmDensity * wind * alignment;
+			double rate = 0.0;
+
+			if (envOk && genOk && localWindSpeed >= minWindSpeed && atmDensity > double.Epsilon)
+			{
+				double atmFactor = atmCurve != null ? atmCurve.Evaluate((float)atmDensity) : 1.0;
+				// Steady-state tracking approximation of PET's loaded formula
+				rate = chargeRate * wind * atmFactor * alignment;
+				if (rate < 0.0)
+					rate = 0.0;
+			}
+
+			if (Time.realtimeSinceStartup >= nextBackgroundTraceTime)
+			{
+				nextBackgroundTraceTime = Time.realtimeSinceStartup + 2.0f;
+				Lib.Log(string.Format(
+					"PET_TRACE BACKGROUND vessel={0} altitude={1:R} vesselAtmDensity={2:R} calculatedAtmDensity={3:R} deploy={4} active={5} envOk={6} genOk={7} expectedWind={8:R} alignment={9:R} localWind={10:R} minWind={11:R} rate={12:R}",
+					v.vesselName,
+					v.altitude,
+					v.atmDensity,
+					atmDensity,
+					GetDeployState(turbineProto),
+					Lib.Proto.GetBool(turbineProto, "isActive"),
+					envOk,
+					genOk,
+					wind,
+					alignment,
+					localWindSpeed,
+					minWindSpeed,
+					rate));
+			}
+
+			return rate;
+		}
+
+		public static void AddRate(List<KeyValuePair<string, double>> resourceChangeRequest, double rate)
+		{
+			if (resourceChangeRequest == null || rate <= 0.0)
+				return;
+
+			resourceChangeRequest.Add(new KeyValuePair<string, double>(ResourceEc, rate));
+		}
+
+		public static bool CanProduceEnvironment(Vessel v, Part part)
+		{
+			if (v == null)
+				return false;
+
+			// Match PET: only water contact / splash kills wind; do not require Landed
+			// (surface bases can report Landed=false while PET PAW still shows output).
+			if (v.loaded)
+			{
+				if (v.Splashed)
+					return false;
+				if (part != null && part.WaterContact)
+					return false;
+			}
+			else
+			{
+				if (v.protoVessel == null || v.protoVessel.splashed)
+					return false;
+			}
+
+			return GetAtmosphericDensity(v) > 1e-6;
+		}
+
+		private static double GetAtmosphericDensity(Vessel v)
+		{
+			if (v == null)
+				return 0.0;
+
+			if (v.loaded)
+				return Math.Max(0.0, v.atmDensity);
+
+			CelestialBody body = v.mainBody;
+			double altitude = Math.Max(0.0, v.altitude);
+			if (body == null || !body.atmosphere || altitude >= body.atmosphereDepth)
+				return 0.0;
+
+			double pressure = body.GetPressure(altitude);
+			double temperature = body.GetTemperature(altitude);
+			return Math.Max(0.0, body.GetDensity(pressure, temperature));
+		}
+
+		public static bool IsGeneratingState(PartModule turbine)
+		{
+			if (turbine == null)
+				return false;
+
+			object deployState = PlanetsideExplorationTechnologies.Get<object>(turbine, "deployState", null);
+			if (deployState == null || !string.Equals(deployState.ToString(), "EXTENDED", StringComparison.Ordinal))
+				return false;
+
+			return PlanetsideExplorationTechnologies.Get(turbine, "isActive", false);
+		}
+
+		public static bool IsGeneratingState(ProtoPartModuleSnapshot turbineProto)
+		{
+			if (turbineProto == null)
+				return false;
+
+			string deployState = Lib.Proto.GetString(turbineProto, "deployState");
+			if (!string.Equals(deployState, "EXTENDED", StringComparison.Ordinal))
+				return false;
+
+			return Lib.Proto.GetBool(turbineProto, "isActive");
+		}
+
+		public static string GetDeployState(PartModule turbine)
+		{
+			object deployState = PlanetsideExplorationTechnologies.Get<object>(turbine, "deployState", null);
+			return deployState != null ? deployState.ToString() : "RETRACTED";
+		}
+
+		public static string GetDeployState(ProtoPartModuleSnapshot turbineProto)
+		{
+			return Lib.Proto.GetString(turbineProto, "deployState", "RETRACTED");
+		}
+
+		public static bool IsDeployable(PartModule turbine)
+		{
+			if (turbine == null)
+				return false;
+
+			string animationName = PlanetsideExplorationTechnologies.Get(turbine, "animationName", string.Empty);
+			return !string.IsNullOrEmpty(animationName);
+		}
+
+		public static bool IsBroken(PartModule turbine)
+		{
+			return string.Equals(GetDeployState(turbine), "BROKEN", StringComparison.Ordinal);
+		}
+
+		public static bool IsBroken(ProtoPartModuleSnapshot turbineProto)
+		{
+			return string.Equals(GetDeployState(turbineProto), "BROKEN", StringComparison.Ordinal);
+		}
+
+		public static void Extend(PartModule turbine)
+		{
+			if (turbine == null || IsBroken(turbine))
+				return;
+			PlanetsideExplorationTechnologies.Call(turbine, "Extend");
+		}
+
+		public static void Retract(PartModule turbine)
+		{
+			if (turbine == null || IsBroken(turbine))
+				return;
+			PlanetsideExplorationTechnologies.Call(turbine, "Retract");
+		}
+
+		public static void SetActive(PartModule turbine, bool value)
+		{
+			if (turbine == null || IsBroken(turbine))
+				return;
+			PlanetsideExplorationTechnologies.Set(turbine, "isActive", value);
+		}
+
+		public static void ProtoSetDeployed(ProtoPartModuleSnapshot turbineProto, bool deployed)
+		{
+			if (turbineProto == null || IsBroken(turbineProto))
+				return;
+
+			if (deployed)
+			{
+				Lib.Proto.Set(turbineProto, "deployState", "EXTENDED");
+				Lib.Proto.Set(turbineProto, "savedAnimationTime", 1f);
+				Lib.Proto.Set(turbineProto, "isActive", true);
+			}
+			else
+			{
+				Lib.Proto.Set(turbineProto, "deployState", "RETRACTED");
+				Lib.Proto.Set(turbineProto, "savedAnimationTime", 0f);
+				Lib.Proto.Set(turbineProto, "isActive", false);
+			}
+		}
+
+		public static void ProtoSetActive(ProtoPartModuleSnapshot turbineProto, bool value)
+		{
+			if (turbineProto == null || IsBroken(turbineProto))
+				return;
+			Lib.Proto.Set(turbineProto, "isActive", value);
+		}
+
+		public static ProtoPartModuleSnapshot FindTurbineProto(ProtoPartSnapshot partSnapshot)
+		{
+			return IntegrationUtils.TryFindPartModuleSnapshot(partSnapshot, PlanetsideExplorationTechnologies.TurbineModuleName);
+		}
+
+		public static PartModule FindTurbinePrefab(Part partPrefab)
+		{
+			return PlanetsideExplorationTechnologies.FindTurbineModule(partPrefab);
+		}
+
+		private static double GetAlignmentFactor(PartModule turbinePrefab)
+		{
+			string turbineType = PlanetsideExplorationTechnologies.Get(turbinePrefab, "turbineType", string.Empty);
+			string rotationPivotName = PlanetsideExplorationTechnologies.Get(turbinePrefab, "rotationPivotName", string.Empty);
+			bool tracking = string.Equals(turbineType, "Tracking", StringComparison.OrdinalIgnoreCase)
+				|| !string.IsNullOrEmpty(rotationPivotName);
+			return tracking ? 1.0 : 0.75;
+		}
+
+		private static double GetExpectedWindMultiplier()
+		{
+			if (expectedWindCached)
+				return expectedWind;
+
+			expectedWindCached = true;
+			expectedWind = ComputeExpectedWindFromDifficulty();
+			return expectedWind;
+		}
+
+		private static double ComputeExpectedWindFromDifficulty()
+		{
+			// Defaults match PET DifficultyWindProbability field initializers
+			double pHigh = 0.10;
+			double pMid = 0.55;
+			double pLow = 0.25;
+			double pNone = 0.15;
+
+			try
+			{
+				if (HighLogic.CurrentGame != null)
+				{
+					Type difficultyType = AccessTools.TypeByName("PlanetsideExplorationTechnologies.DifficultySettings.DifficultyWindProbability");
+					if (difficultyType != null)
+					{
+						// GameParameters.CustomParams<T>() — invoke via MakeGenericMethod
+						MethodInfo generic = typeof(GameParameters).GetMethod("CustomParams", Type.EmptyTypes);
+						if (generic != null && generic.IsGenericMethodDefinition)
+						{
+							object node = generic.MakeGenericMethod(difficultyType).Invoke(HighLogic.CurrentGame.Parameters, null);
+							if (node != null)
+							{
+								pHigh = IntegrationReflection.GetFloat(node, "probabilityHighWinds", (float)pHigh);
+								pMid = IntegrationReflection.GetFloat(node, "probabilityMidWinds", (float)pMid);
+								pLow = IntegrationReflection.GetFloat(node, "probabilityLowWinds", (float)pLow);
+								pNone = IntegrationReflection.GetFloat(node, "probabilityNoWinds", (float)pNone);
+							}
+						}
+					}
+				}
+			}
+			catch (Exception e)
+			{
+				Lib.LogDebug("PET wind difficulty read failed: " + e.Message);
+			}
+
+			double total = pHigh + pMid + pLow + pNone;
+			if (total <= double.Epsilon)
+				return 0.8;
+
+			// Midpoints of PET GenerateWindSpeed ranges
+			double highMid = (1.1 + 1.8) * 0.5;
+			double midMid = (0.9 + 1.05) * 0.5;
+			double lowMid = (0.5 + 0.8) * 0.5;
+			return (pHigh * highMid + pMid * midMid + pLow * lowMid) / total;
+		}
+	}
+}

--- a/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PlanetsideExplorationTechnologiesIntegration.cs
+++ b/src/Kerbalism/Integrations/PlanetsideExplorationTechnologies/PlanetsideExplorationTechnologiesIntegration.cs
@@ -1,0 +1,12 @@
+using HarmonyLib;
+
+namespace KERBALISM
+{
+	internal static class PlanetsideExplorationTechnologiesIntegration
+	{
+		public static void ApplyHarmonyPatches(Harmony harmony)
+		{
+			PETTurbineHarmony.Apply(harmony);
+		}
+	}
+}

--- a/src/Kerbalism/LocalizationCache.cs
+++ b/src/Kerbalism/LocalizationCache.cs
@@ -336,6 +336,7 @@ namespace KERBALISM
 		////////////////////////////////////////////////////////////////////
 		public static string Brokers_Others = GetLoc("Brokers_Others"); // "others"
 		public static string Brokers_SolarPanel = GetLoc("Brokers_SolarPanel"); // "solar panel"
+		public static string Brokers_WindTurbine = GetLoc("Brokers_WindTurbine"); // "wind turbine"
 		public static string Brokers_KSPIEGenerator = GetLoc("Brokers_KSPIEGenerator"); // "KSPIE generator"
 		public static string Brokers_FissionReactor = GetLoc("Brokers_FissionReactor"); // "fission generator"
 		public static string Brokers_RTG = GetLoc("Brokers_RTG"); // "radioisotope generator"

--- a/src/Kerbalism/Resource.cs
+++ b/src/Kerbalism/Resource.cs
@@ -27,6 +27,7 @@ namespace KERBALISM
 
 		public static ResourceBroker Generic = GetOrCreate("Others", BrokerCategory.Unknown, Local.Brokers_Others);
 		public static ResourceBroker SolarPanel = GetOrCreate("SolarPanel", BrokerCategory.SolarPanel, Local.Brokers_SolarPanel);
+		public static ResourceBroker WindTurbine = GetOrCreate("WindTurbine", BrokerCategory.Generator, Local.Brokers_WindTurbine);
 		public static ResourceBroker KSPIEGenerator = GetOrCreate("KSPIEGenerator", BrokerCategory.Generator, Local.Brokers_KSPIEGenerator);
 		public static ResourceBroker FissionReactor = GetOrCreate("FissionReactor", BrokerCategory.Converter, Local.Brokers_FissionReactor);
 		public static ResourceBroker RTG = GetOrCreate("RTG", BrokerCategory.RTG, Local.Brokers_RTG);
@@ -864,6 +865,10 @@ namespace KERBALISM
 
 			// remember vessel-wide amount currently known, to calculate rate and detect non-Kerbalism brokers
 			double oldAmount = Amount;
+			double windTurbineQuantity = 0.0;
+			bool traceWindTurbine = ResourceName == "ElectricCharge"
+				&& brokersResourceAmounts.TryGetValue(ResourceBroker.WindTurbine, out windTurbineQuantity);
+			double deferredBeforeClamp = Deferred;
 
 			// remember vessel-wide capacity currently known, to detect flow state changes
 			double oldCapacity = Capacity;
@@ -873,6 +878,7 @@ namespace KERBALISM
 			//   that by-pass the resource cache, and flow state changes in general
 			Amount = pts.amount;
 			Capacity = pts.maxAmount;
+			double physicalAmountBefore = Amount;
 
 			// As we haven't yet synchronized anything, changes to amount can only come from non-Kerbalism producers or consumers
 			double unsupportedBrokersRate = Amount - oldAmount;
@@ -888,6 +894,7 @@ namespace KERBALISM
 			// - if deferred is negative, then amount is guaranteed to be greater than zero
 			// - if deferred is positive, then capacity - amount is guaranteed to be greater than zero
 			Deferred = Lib.Clamp(Deferred, -Amount, Capacity - Amount);
+			double deferredAfterClamp = Deferred;
 
 			// apply deferred consumption/production to all parts
 			// If the resource has a flowmode that respects priority, we'll be doing this in
@@ -898,6 +905,20 @@ namespace KERBALISM
 
 			// update amount, to get correct rate and levels at all times
 			Amount = pts.amount;
+
+			if (traceWindTurbine)
+			{
+				PETTurbineHarmony.TraceResourceSync(
+					v,
+					windTurbineQuantity,
+					deferredBeforeClamp,
+					deferredAfterClamp,
+					oldAmount,
+					physicalAmountBefore,
+					Amount,
+					Capacity,
+					elapsed_s);
+			}
 
 			// reset deferred production/consumption
 			Deferred = 0.0;

--- a/src/Kerbalism/Resource.cs
+++ b/src/Kerbalism/Resource.cs
@@ -865,10 +865,6 @@ namespace KERBALISM
 
 			// remember vessel-wide amount currently known, to calculate rate and detect non-Kerbalism brokers
 			double oldAmount = Amount;
-			double windTurbineQuantity = 0.0;
-			bool traceWindTurbine = ResourceName == "ElectricCharge"
-				&& brokersResourceAmounts.TryGetValue(ResourceBroker.WindTurbine, out windTurbineQuantity);
-			double deferredBeforeClamp = Deferred;
 
 			// remember vessel-wide capacity currently known, to detect flow state changes
 			double oldCapacity = Capacity;
@@ -878,7 +874,6 @@ namespace KERBALISM
 			//   that by-pass the resource cache, and flow state changes in general
 			Amount = pts.amount;
 			Capacity = pts.maxAmount;
-			double physicalAmountBefore = Amount;
 
 			// As we haven't yet synchronized anything, changes to amount can only come from non-Kerbalism producers or consumers
 			double unsupportedBrokersRate = Amount - oldAmount;
@@ -894,7 +889,6 @@ namespace KERBALISM
 			// - if deferred is negative, then amount is guaranteed to be greater than zero
 			// - if deferred is positive, then capacity - amount is guaranteed to be greater than zero
 			Deferred = Lib.Clamp(Deferred, -Amount, Capacity - Amount);
-			double deferredAfterClamp = Deferred;
 
 			// apply deferred consumption/production to all parts
 			// If the resource has a flowmode that respects priority, we'll be doing this in
@@ -905,20 +899,6 @@ namespace KERBALISM
 
 			// update amount, to get correct rate and levels at all times
 			Amount = pts.amount;
-
-			if (traceWindTurbine)
-			{
-				PETTurbineHarmony.TraceResourceSync(
-					v,
-					windTurbineQuantity,
-					deferredBeforeClamp,
-					deferredAfterClamp,
-					oldAmount,
-					physicalAmountBefore,
-					Amount,
-					Capacity,
-					elapsed_s);
-			}
 
 			// reset deferred production/consumption
 			Deferred = 0.0;

--- a/src/Kerbalism/UI/Planner/ResourceSimulator.cs
+++ b/src/Kerbalism/UI/Planner/ResourceSimulator.cs
@@ -331,7 +331,8 @@ namespace KERBALISM.Planner
 			// prepare recipe
 			if (r.output.Length == 0)
 			{
-				Resource(r.input).Consume(rate * k, r.name);
+				// Use localized title, not internal rule name
+				Resource(r.input).Consume(rate * k, r.title);
 			}
 			else if (rate > double.Epsilon)
 			{


### PR DESCRIPTION
1. Add targeted Kerbalism support for Planetside Exploration Technologies (Benjee10_MMSEV): habitat volumes, comfort bonuses, greenhouse, logistics supply containers, expandable HDU attic Habitat, and PT-3B Sickbay RDU.
2. Integrate PET wind turbines into Kerbalism EC/telemetry/automation via `PETTurbineFixer` + Harmony, with unloaded background rates using PET wind-band probabilities (including fixed-rotor `a²` expectation and per-band min-wind cutoffs).
3. Localize science `PARTUPGRADE` title/description strings that previously showed hardcoded English in part tooltips.
