### PR TITLE
Add inv: profile modifier for resource amount inverse (#863)

### DIFF
--- a/src/Kerbalism/Profile/Modifiers.cs
+++ b/src/Kerbalism/Profile/Modifiers.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
 using KERBALISM.Planner;
 
 
@@ -10,6 +9,9 @@ namespace KERBALISM
 
 	public static class Modifiers
 	{
+		/// <summary>Prefix for multiplicative inverse of a resource amount: inv:Water → 1/Water.Amount</summary>
+		public const string InversePrefix = "inv:";
+
 		///<summary> Modifiers Evaluate method used for the Monitors background and current vessel simulation </summary>
 		public static double Evaluate(Vessel v, VesselData vd, VesselResources resources, List<string> modifiers)
 		{
@@ -75,7 +77,7 @@ namespace KERBALISM
 						break;
 
 					default:
-						k *= resources.GetResource(v, mod).Amount;
+						k *= ResourceAmountFactor(mod, res => resources.GetResource(v, res).Amount);
 						break;
 				}
 			}
@@ -148,11 +150,30 @@ namespace KERBALISM
 						break;
 
 					default:
-						k *= sim.Resource(mod).amount;
+						k *= ResourceAmountFactor(mod, res => sim.Resource(res).amount);
 						break;
 				}
 			}
 			return k;
+		}
+
+		/// <summary>
+		/// Resource amount, or 1/amount when prefixed with <see cref="InversePrefix"/>.
+		/// Zero (or near-zero) amount yields 0 for the inverse, so rates stay finite.
+		/// </summary>
+		static double ResourceAmountFactor(string mod, Func<string, double> amountOf)
+		{
+			if (mod.StartsWith(InversePrefix, StringComparison.Ordinal))
+			{
+				string resource = mod.Substring(InversePrefix.Length);
+				if (string.IsNullOrEmpty(resource))
+					return 0.0;
+
+				double amount = amountOf(resource);
+				return amount > double.Epsilon ? 1.0 / amount : 0.0;
+			}
+
+			return amountOf(mod);
 		}
 	}
 


### PR DESCRIPTION
## Usage
```cfg
modifier = Food,inv:Water
```
This scales the process/rule by `Food.Amount / Water.Amount`.
If the named resource amount is zero (or near zero), the inverse contributes `0` so rates stay finite.
Works in both flight simulation and the VAB/SPH planner.