### PR TITLE
Fix space weather notification preset not applying to new vessels (#812)

### DIFF
--- a/src/Kerbalism/Database/VesselData.cs
+++ b/src/Kerbalism/Database/VesselData.cs
@@ -830,7 +830,7 @@ namespace KERBALISM
 			cfg_supply = PreferencesMessages.Instance.supply;
 			cfg_signal = PreferencesMessages.Instance.signal;
 			cfg_malfunction = PreferencesMessages.Instance.malfunction;
-			cfg_storm = Features.SpaceWeather && PreferencesMessages.Instance.storm && Lib.CrewCount(pv) > 0;
+			cfg_storm = Features.SpaceWeather && PreferencesMessages.Instance.storm;
 			cfg_script = PreferencesMessages.Instance.script;
 			cfg_highlights = PreferencesReliability.Instance.highlights;
 			cfg_showlink = true;
@@ -866,7 +866,7 @@ namespace KERBALISM
 			cfg_supply = Lib.ConfigValue(node, "cfg_supply", PreferencesMessages.Instance.supply);
 			cfg_signal = Lib.ConfigValue(node, "cfg_signal", PreferencesMessages.Instance.signal);
 			cfg_malfunction = Lib.ConfigValue(node, "cfg_malfunction", PreferencesMessages.Instance.malfunction);
-			cfg_storm = Lib.ConfigValue(node, "cfg_storm", PreferencesMessages.Instance.storm);
+			cfg_storm = Lib.ConfigValue(node, "cfg_storm", Features.SpaceWeather && PreferencesMessages.Instance.storm);
 			cfg_script = Lib.ConfigValue(node, "cfg_script", PreferencesMessages.Instance.script);
 			cfg_highlights = Lib.ConfigValue(node, "cfg_highlights", PreferencesReliability.Instance.highlights);
 			cfg_showlink = Lib.ConfigValue(node, "cfg_showlink", true);


### PR DESCRIPTION
Fixes #812: enabling the Space Weather notification preset in difficulty settings did not correctly initialize per-vessel `cfg_storm`.

## Why
`cfg_storm` was initialized as:

```csharp
Features.SpaceWeather && PreferencesMessages.Instance.storm && Lib.CrewCount(pv) > 0
```

As noted in the [issue discussion](https://github.com/Kerbalism/Kerbalism/issues/812#issuecomment-1188848282) (gotmachine), `Lib.CrewCount` can still be `0` when `VesselData` is created at launch, because stock crew data may not be populated yet. That made the difficulty preset ineffective for new vessels.

Gating the preset on “has crew right now” is also a poor fit for a notification default: it depends on init order, and it decides for the player based on crewing instead of their settings.

## Change
Drop the crew check. New vessels (and missing save defaults) now use:

```csharp
cfg_storm = Features.SpaceWeather && PreferencesMessages.Instance.storm;
```

- If the Space Weather feature is off → default off
- If the feature is on → follow the difficulty notification preset
- Players can still enable/disable the notification per vessel afterward