### PR TITLE
Fix unpowered unloaded vessels remaining as CommNet relays (#684)

### DIFF
--- a/src/Kerbalism/Comms/CommHandlerCommNetBase.cs
+++ b/src/Kerbalism/Comms/CommHandlerCommNetBase.cs
@@ -2,12 +2,15 @@
 using KSP.Localization;
 using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using HarmonyLib;
 
 namespace KERBALISM
 {
 	public class CommHandlerCommNetBase : CommHandler
 	{
+		private static readonly ConditionalWeakTable<CommNetVessel, object> powerDisabledVessels = new ConditionalWeakTable<CommNetVessel, object>();
+
 		/// <summary> base data rate set in derived classes from UpdateTransmitters()</summary>
 		protected double baseRate = 0.0;
 
@@ -100,6 +103,8 @@ namespace KERBALISM
 			return node?.transform?.gameObject.GetComponent<Vessel>();
 		}
 
+		private static bool UseStockCommNet => API.Comm.handlers.Count == 0 && !RemoteTech.Installed;
+
 		public static void ApplyHarmonyPatches()
 		{
 			MethodInfo CommNetVessel_OnNetworkPreUpdate_Info = AccessTools.Method(typeof(CommNetVessel), nameof(CommNetVessel.OnNetworkPreUpdate));
@@ -124,23 +129,53 @@ namespace KERBALISM
 		// ensure unloadedDoOnce is true for unloaded vessels
 		private static void CommNetVessel_OnNetworkPreUpdate_Prefix(CommNetVessel __instance, ref bool ___unloadedDoOnce)
 		{
-			if (!__instance.Vessel.loaded && __instance.CanComm)
+			if (!UseStockCommNet || __instance.Vessel.loaded)
+				return;
+
+			// Stock doesn't update unloaded vessels after canComm becomes false. Force an update
+			// only when a vessel disabled by Kerbalism has power again, so it can rejoin CommNet.
+			if (__instance.CanComm
+				|| (powerDisabledVessels.TryGetValue(__instance, out _)
+					&& __instance.Vessel.TryGetVesselData(out VesselData vd)
+					&& vd.IsSimulated
+					&& Lib.IsPowered(__instance.Vessel)))
+			{
 				___unloadedDoOnce = true;
+			}
 		}
 
 
 		// ensure unloadedDoOnce is true for unloaded vessels
 		private static void CommNetVessel_OnNetworkPostUpdate_Prefix(CommNetVessel __instance, ref bool ___unloadedDoOnce)
 		{
-			if (!__instance.Vessel.loaded && __instance.CanComm)
+			if (UseStockCommNet && !__instance.Vessel.loaded && __instance.CanComm)
 				___unloadedDoOnce = true;
 		}
 
 
-		// apply storm radiation factor to the comm strength multiplier used by stock for plasma blackout
-		private static void CommNetVessel_OnNetworkPreUpdate_Postfix(CommNetVessel __instance, ref bool ___inPlasma, ref double ___plasmaMult)
+		// prevent unpowered vessels from remaining in CommNet, and apply storm radiation
+		// factor to the comm strength multiplier used by stock for plasma blackout
+		private static void CommNetVessel_OnNetworkPreUpdate_Postfix(CommNetVessel __instance, ref bool ___canComm, ref bool ___inPlasma, ref double ___plasmaMult)
 		{
-			if (!__instance.CanComm || !__instance.Vessel.TryGetVesselData(out VesselData vd))
+			if (!UseStockCommNet)
+				return;
+
+			if (!__instance.Vessel.TryGetVesselData(out VesselData vd))
+				return;
+
+			// Stock doesn't consume resources for unloaded vessels, so it never notices when
+			// Kerbalism background simulation drains their EC. Keep the CommNet node in sync
+			// with Kerbalism's resource cache so an unpowered vessel can't act as a relay.
+			if (vd.IsSimulated && !Lib.IsPowered(__instance.Vessel))
+			{
+				___canComm = false;
+				powerDisabledVessels.GetOrCreateValue(__instance);
+				return;
+			}
+
+			powerDisabledVessels.Remove(__instance);
+
+			if (!___canComm)
 				return;
 
 			if (vd.EnvStormRadiation > 0.0)
@@ -154,6 +189,12 @@ namespace KERBALISM
 		// apply storm radiation factor to the comm strength multiplier used by stock for plasma blackout
 		private static bool CommNetVessel_GetSignalStrengthModifier_Prefix(CommNetVessel __instance, bool ___canComm, bool ___inPlasma, double ___plasmaMult, out double __result)
 		{
+			if (!UseStockCommNet)
+			{
+				__result = 0.0;
+				return true;
+			}
+
 			if (!___canComm)
 			{
 				__result = 0.0;


### PR DESCRIPTION
## Description

Fixes https://github.com/Kerbalism/Kerbalism/issues/684

Stock CommNet only notices a vessel is out of power when that vessel is loaded. Kerbalism also drains EC in the background, so an unloaded relay can hit 0 EC while CommNet still thinks it's fine and keeps using it.

That's why probes can stay linked through a dead relay until you switch vessels and stock refreshes the network. Kerbalism already knew the relay was dead; it just never told CommNet.

This PR syncs stock CommNet with Kerbalism's EC cache:
- no EC → force `canComm = false`, so the vessel drops out of CommNet
- if Kerbalism previously killed it for power and EC comes back → force an unloaded refresh so it can rejoin without loading the vessel
- RemoteTech / RealAntenna (and other Comm API handlers) are left alone