### PR TITLE
Fix pressurized tanks storing too much XenonGas (#688)

### DIFF
--- a/GameData/KerbalismConfig/Profiles/Default.cfg
+++ b/GameData/KerbalismConfig/Profiles/Default.cfg
@@ -1217,8 +1217,10 @@ PARTUPGRADE:NEEDS[ProfileDefault]
 
     SETUP
     {
-      name = Xenon Gas  // Stored at 85 bar (1250psi) when full
-						// see https://www.cobham.com/mission-systems/composite-pressure-solutions/space-systems/xenon-propellant-tank-datasheet/
+      // Stored at 85 bar (1250psi) when full; see Cobham xenon tank datasheet.
+      // Stock XenonGas is 0.1 kg/unit (~17 L STP), not 1 L/unit like CRP gases,
+      // so units-per-liter is ~85/17 ≈ 5 rather than the pressure itself.
+      name = Xenon Gas
       title = #KERBALISM_Setup_XenonGas_title
       desc = #KERBALISM_PressurizedTank_desc6//Store pressurized <b>Xenon</b> gas @ 85 bar.
       tech = ionPropulsion
@@ -1226,8 +1228,8 @@ PARTUPGRADE:NEEDS[ProfileDefault]
       RESOURCE
       {
         name = XenonGas
-        amount = 85
-        maxAmount = 85
+        amount = 5
+        maxAmount = 5
         @amount *= #$/ContainerVolume$
         @maxAmount *= #$/ContainerVolume$
       }

--- a/GameData/KerbalismConfig/Support/B9PartSwitch.cfg
+++ b/GameData/KerbalismConfig/Support/B9PartSwitch.cfg
@@ -180,8 +180,9 @@ B9_TANK_TYPE
 	RESOURCE
 	{
 		name = XenonGas
-		unitsPerVolume = 85
-		// see https://www.cobham.com/mission-systems/composite-pressure-solutions/space-systems/xenon-propellant-tank-datasheet/
+		// Stored at 85 bar; stock XenonGas is 0.1 kg/unit (~17 L STP),
+		// not 1 L/unit like CRP gases → unitsPerVolume ≈ 85/17 ≈ 5
+		unitsPerVolume = 5
 	}
 }
 

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -1878,7 +1878,9 @@ PARTUPGRADE:NEEDS[FeatureComfort,HabTech2]
 
 		SETUP
 		{
-			name = Xenon Gas	Stored at 85 bar (1250psi) when full
+			// Stored at 85 bar; stock XenonGas is 0.1 kg/unit (~17 L STP),
+			// not 1 L/unit like CRP gases → units-per-liter ≈ 85/17 ≈ 5
+			name = Xenon Gas
 			title = #KERBALISM_Setup_XenonGas_title
 			desc = #KERBALISM_PressurizedTank_desc6//Store pressurized <b>Xenon</b> gas @ 85 bar.
 			tech = ionPropulsion
@@ -1886,8 +1888,8 @@ PARTUPGRADE:NEEDS[FeatureComfort,HabTech2]
 			RESOURCE
 			{
 				name = XenonGas
-				amount = 85
-				maxAmount = 85
+				amount = 5
+				maxAmount = 5
 				@amount *= #$/ContainerVolume$
 				@maxAmount *= #$/ContainerVolume$
 			}


### PR DESCRIPTION
## Description
Fixes https://github.com/Kerbalism/Kerbalism/issues/688
Pressurized radial tanks size gas capacity as `pressure × ContainerVolume`. That works for CRP gases, where 1 unit is about 1 L at STP. Xenon used the same pattern with `85` (85 bar), but stock `XenonGas` is 0.1 kg/unit (~17 L STP), not 1 L/unit.
So xenon setups were roughly 17× too full, with wet/dry mass ratios around 28–133 instead of stock xenon tanks' ~4.
This PR keeps the 85 bar intent, but converts it to stock units (~85/17 ≈ 5) in:
- `Profiles/Default.cfg`
- `Support/B9PartSwitch.cfg`
- `Support/HabTech2.cfg` (also fixes a broken SETUP name where the comment was glued into `name`)
Oxygen/Nitrogen/Hydrogen/etc. are left alone; those CRP coefficients were already correct.
