### PR TITLE
Fix Configure dropdown clipping and scrollbar flicker

### DIFF
--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -602,7 +602,9 @@ namespace KERBALISM
 			// set metadata
 			p.Title(Lib.BuildString(Local.Module_Configure , " " , "<color=#cccccc>", Lib.Ellipsis(Localizer.Format(title), Styles.ScaleStringLength(40)), "</color>"));//Configure
 			p.Width(Styles.ScaleWidthFloat(300.0f));
-			p.UseCompactScrollbar();
+			// Show every configure option without a vertical scrollbar; the window grows
+			// to fit the full list (including "None").
+			p.ExpandWithoutScrollbar();
 		}
 
 		void Render_panel(Panel p, ConfigureSetup setup, int selected_i, int setup_i)
@@ -628,11 +630,14 @@ namespace KERBALISM
 			}
 
 			int capturedSlot = selected_i;
+			// Do not pin the expanded title: with ExpandWithoutScrollbar the list is not
+			// in a ScrollView, and a pinned title makes Height() disagree with layout
+			// (bottom-row flicker while dragging). Keep the same non-pinned flow as the
+			// collapsed details view.
 			p.AddSection(
 				titleText,
 				isExpanded ? string.Empty : setupDesc,
-				click: canReconfigure ? (Action)(() => Toggle_expansion(capturedSlot)) : null,
-				pin: isExpanded);
+				click: canReconfigure ? (Action)(() => Toggle_expansion(capturedSlot)) : null);
 
 			if (isExpanded)
 			{

--- a/src/Kerbalism/Modules/Configure.cs
+++ b/src/Kerbalism/Modules/Configure.cs
@@ -602,9 +602,9 @@ namespace KERBALISM
 			// set metadata
 			p.Title(Lib.BuildString(Local.Module_Configure , " " , "<color=#cccccc>", Lib.Ellipsis(Localizer.Format(title), Styles.ScaleStringLength(40)), "</color>"));//Configure
 			p.Width(Styles.ScaleWidthFloat(300.0f));
-			// Show every configure option without a vertical scrollbar; the window grows
-			// to fit the full list (including "None").
-			p.ExpandWithoutScrollbar();
+			// Grow to show every configure option (including "None") when possible;
+			// only use a vertical scrollbar if the full panel exceeds screen height.
+			p.ScrollOnlyOnOverflow();
 		}
 
 		void Render_panel(Panel p, ConfigureSetup setup, int selected_i, int setup_i)
@@ -630,10 +630,8 @@ namespace KERBALISM
 			}
 
 			int capturedSlot = selected_i;
-			// Do not pin the expanded title: with ExpandWithoutScrollbar the list is not
-			// in a ScrollView, and a pinned title makes Height() disagree with layout
-			// (bottom-row flicker while dragging). Keep the same non-pinned flow as the
-			// collapsed details view.
+			// Keep the same non-pinned flow as the collapsed details view so Height()
+			// agrees with layout (avoids bottom-row flicker while dragging).
 			p.AddSection(
 				titleText,
 				isExpanded ? string.Empty : setupDesc,

--- a/src/Kerbalism/UI/Panel.cs
+++ b/src/Kerbalism/UI/Panel.cs
@@ -26,7 +26,7 @@ namespace KERBALISM
 			callbacks = new List<Action>();
 			win_title = string.Empty;
 			min_width = Styles.ScaleWidthFloat(280.0f);
-			expand_without_scrollbar = false;
+			scroll_only_on_overflow = false;
 			paneltype = PanelType.unknown;
 		}
 
@@ -36,7 +36,7 @@ namespace KERBALISM
 			sections.Clear();
 			win_title = string.Empty;
 			min_width = Styles.ScaleWidthFloat(280.0f);
-			expand_without_scrollbar = false;
+			scroll_only_on_overflow = false;
 			paneltype = PanelType.unknown;
 		}
 
@@ -369,18 +369,18 @@ namespace KERBALISM
 		}
 
 		/// <summary>
-		/// Grow the window to fit all panel content instead of hosting it in a
-		/// vertical ScrollView. Used by Configure so every option is visible.
+		/// Grow the window to fit all panel content and only use a vertical
+		/// ScrollView when the content exceeds the screen-height limit.
 		/// </summary>
-		public void ExpandWithoutScrollbar()
+		public void ScrollOnlyOnOverflow()
 		{
-			expand_without_scrollbar = true;
+			scroll_only_on_overflow = true;
 		}
 
 		// get medata
 		public string Title() { return win_title; }
 		public float Width() { return min_width; }
-		public bool ExpandsWithoutScrollbar() { return expand_without_scrollbar; }
+		public bool UsesOverflowOnlyScrollbar() { return scroll_only_on_overflow; }
 
 		sealed class Header
 		{
@@ -428,7 +428,7 @@ namespace KERBALISM
 		List<Action> callbacks;  // functions to call on input events
 		string win_title;        // metadata stored in panel
 		float min_width;         // metadata stored in panel
-		bool expand_without_scrollbar; // opt-in: grow window, no vertical ScrollView
+		bool scroll_only_on_overflow; // opt-in: scroll only when screen height is exceeded
 		public PanelType paneltype;
 	}
 } // KERBALISM

--- a/src/Kerbalism/UI/Panel.cs
+++ b/src/Kerbalism/UI/Panel.cs
@@ -26,7 +26,7 @@ namespace KERBALISM
 			callbacks = new List<Action>();
 			win_title = string.Empty;
 			min_width = Styles.ScaleWidthFloat(280.0f);
-			compact_scrollbar = false;
+			expand_without_scrollbar = false;
 			paneltype = PanelType.unknown;
 		}
 
@@ -36,7 +36,7 @@ namespace KERBALISM
 			sections.Clear();
 			win_title = string.Empty;
 			min_width = Styles.ScaleWidthFloat(280.0f);
-			compact_scrollbar = false;
+			expand_without_scrollbar = false;
 			paneltype = PanelType.unknown;
 		}
 
@@ -203,10 +203,9 @@ namespace KERBALISM
 				}
 				foreach (Entry e in p.entries)
 				{
-					if (e.selectable)
-						GUILayout.BeginHorizontal(Styles.entry_container_wrap, GUILayout.MinHeight(Styles.entry_container.fixedHeight));
-					else
-						GUILayout.BeginHorizontal(Styles.entry_container);
+					// Selectable rows use the same fixed-height container as normal
+					// content so Height() matches layout (avoids bottom-row flicker).
+					GUILayout.BeginHorizontal(Styles.entry_container);
 					if (e.leftIcon != null)
 					{
 						GUILayout.Label(new GUIContent(e.leftIcon.texture, e.leftIcon.tooltip), Styles.left_icon);
@@ -214,12 +213,12 @@ namespace KERBALISM
 							callbacks.Add(e.leftIcon.click);
 					}
 					if (e.selectable)
-						GUILayout.Label(new GUIContent(e.label, e.tooltip), Styles.entry_label);
+						GUILayout.Label(new GUIContent(e.label, e.tooltip), Styles.entry_label_nowrap, GUILayout.Height(Styles.entry_label.fontSize));
 					else
 						GUILayout.Label(new GUIContent(e.label, e.tooltip), Styles.entry_label, GUILayout.Height(Styles.entry_label.fontSize));
 					if (e.hover != null && Lib.IsHover()) callbacks.Add(e.hover);
 					if (e.selectable)
-						GUILayout.Label(new GUIContent(e.value, e.tooltip), Styles.entry_value, GUILayout.Width(Styles.ScaleWidthFloat(20.0f)));
+						GUILayout.Label(new GUIContent(e.value, e.tooltip), Styles.entry_value, GUILayout.Width(Styles.ScaleWidthFloat(20.0f)), GUILayout.Height(Styles.entry_value.fontSize));
 					else
 						GUILayout.Label(new GUIContent(e.value, e.tooltip), Styles.entry_value, GUILayout.Height(Styles.entry_value.fontSize));
 					if (!e.selectable && e.click != null && Lib.IsClicked()) callbacks.Add(e.click);
@@ -249,6 +248,8 @@ namespace KERBALISM
 							GUI.DrawTexture(rowRect, Texture2D.whiteTexture);
 							GUI.color = previousColor;
 						}
+						// Slightly roomier gaps between configure dropdown options.
+						GUILayout.Space(Styles.ScaleFloat(4.0f));
 					}
 				}
 
@@ -299,17 +300,9 @@ namespace KERBALISM
 				h += Styles.ScaleFloat(34.0f);
 				foreach (Entry e in p.entries)
 				{
+					h += Styles.entry_container.fixedHeight;
 					if (e.selectable)
-					{
-						float labelWidth = Math.Max(Styles.ScaleWidthFloat(40.0f),
-							min_width - Styles.ScaleWidthFloat(50.0f));
-						h += Math.Max(Styles.entry_container.fixedHeight,
-							Styles.entry_label.CalcHeight(new GUIContent(e.label), labelWidth));
-					}
-					else
-					{
-						h += Styles.entry_container.fixedHeight;
-					}
+						h += Styles.ScaleFloat(4.0f);
 				}
 				if (p.desc.Length > 0)
 				{
@@ -375,15 +368,19 @@ namespace KERBALISM
 			min_width = Math.Max(w, min_width);
 		}
 
-		public void UseCompactScrollbar()
+		/// <summary>
+		/// Grow the window to fit all panel content instead of hosting it in a
+		/// vertical ScrollView. Used by Configure so every option is visible.
+		/// </summary>
+		public void ExpandWithoutScrollbar()
 		{
-			compact_scrollbar = true;
+			expand_without_scrollbar = true;
 		}
 
 		// get medata
 		public string Title() { return win_title; }
 		public float Width() { return min_width; }
-		public bool UsesCompactScrollbar() { return compact_scrollbar; }
+		public bool ExpandsWithoutScrollbar() { return expand_without_scrollbar; }
 
 		sealed class Header
 		{
@@ -431,7 +428,7 @@ namespace KERBALISM
 		List<Action> callbacks;  // functions to call on input events
 		string win_title;        // metadata stored in panel
 		float min_width;         // metadata stored in panel
-		bool compact_scrollbar;  // opt-in compact vertical scrollbar
+		bool expand_without_scrollbar; // opt-in: grow window, no vertical ScrollView
 		public PanelType paneltype;
 	}
 } // KERBALISM

--- a/src/Kerbalism/UI/Window.cs
+++ b/src/Kerbalism/UI/Window.cs
@@ -136,17 +136,21 @@ namespace KERBALISM
 			// Keep explicitly pinned section titles outside the scrolling viewport.
 			panel.RenderPinned();
 
-			// start scrolling view
-			GUIStyle verticalScrollbar = panel.UsesCompactScrollbar()
-				? Styles.vertical_scrollbar
-				: HighLogic.Skin.verticalScrollbar;
-			scroll_pos = GUILayout.BeginScrollView(scroll_pos, HighLogic.Skin.horizontalScrollbar, verticalScrollbar);
-
-			// render panel content
-			panel.Render();
-
-			// end scroll view
-			GUILayout.EndScrollView();
+			if (panel.ExpandsWithoutScrollbar())
+			{
+				// Configure lists show every option; grow the window instead of scrolling.
+				scroll_pos = Vector2.zero;
+				panel.Render();
+			}
+			else
+			{
+				scroll_pos = GUILayout.BeginScrollView(
+					scroll_pos,
+					HighLogic.Skin.horizontalScrollbar,
+					HighLogic.Skin.verticalScrollbar);
+				panel.Render();
+				GUILayout.EndScrollView();
+			}
 
 			// Capture after all controls have been rendered. Drawing happens outside the
 			// GUI.Window so the tooltip can use the full screen bounds.

--- a/src/Kerbalism/UI/Window.cs
+++ b/src/Kerbalism/UI/Window.cs
@@ -79,7 +79,10 @@ namespace KERBALISM
 			// adapt window size to panel
 			// - clamp to screen height
 			win_rect.width = Math.Min(panel.Width(), Screen.width * 0.8f);
-			win_rect.height = Math.Min(Styles.ScaleFloat(20.0f) + panel.Height(), Screen.height * 0.8f);
+			float desiredHeight = Styles.ScaleFloat(20.0f) + panel.Height();
+			float maxHeight = Screen.height * 0.8f;
+			content_overflows = panel.UsesOverflowOnlyScrollbar() && desiredHeight > maxHeight;
+			win_rect.height = Math.Min(desiredHeight, maxHeight);
 
 			// clamp the window to the screen, so it can't be dragged outside
 			float offset_x = Math.Max(0.0f, -win_rect.xMin) + Math.Min(0.0f, Screen.width - win_rect.xMax);
@@ -136,18 +139,21 @@ namespace KERBALISM
 			// Keep explicitly pinned section titles outside the scrolling viewport.
 			panel.RenderPinned();
 
-			if (panel.ExpandsWithoutScrollbar())
+			if (panel.UsesOverflowOnlyScrollbar() && !content_overflows)
 			{
-				// Configure lists show every option; grow the window instead of scrolling.
+				// Configure content fits: render directly so no scrollbar is created.
 				scroll_pos = Vector2.zero;
 				panel.Render();
 			}
 			else
 			{
+				GUIStyle verticalScrollbar = panel.UsesOverflowOnlyScrollbar()
+					? Styles.vertical_scrollbar
+					: HighLogic.Skin.verticalScrollbar;
 				scroll_pos = GUILayout.BeginScrollView(
 					scroll_pos,
 					HighLogic.Skin.horizontalScrollbar,
-					HighLogic.Skin.verticalScrollbar);
+					verticalScrollbar);
 				panel.Render();
 				GUILayout.EndScrollView();
 			}
@@ -214,6 +220,7 @@ namespace KERBALISM
 
 		// used by scroll window mechanics
 		private Vector2 scroll_pos;
+		private bool content_overflows;
 
 		// tooltip utility
 		private Tooltip tooltip;


### PR DESCRIPTION
## Description

1. Grow the Configure window to show the full option list (including "None") instead of clipping entries or showing a scrollbar for short lists.
2. Enable a compact vertical scrollbar only when the panel would exceed 80% of the screen height.
