### PR TITLE
Fix editor part list clutter by removing duplicate categories (#702)

### DIFF
--- a/GameData/KerbalismConfig/Support/CCK.cfg
+++ b/GameData/KerbalismConfig/Support/CCK.cfg
@@ -1,33 +1,10 @@
-@PART[kerbalism-container-*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalismDefault]
+// Life-support related Kerbalism parts → CCK Life Support only
+@PART[kerbalism-container-*|kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalismDefault]
 {
 	%tags = #$tags$ cck-lifesupport
 }
 
-// radial tanks also appear in containers
-@PART[kerbalism-container-radial*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalismDefault]
-{
-	%tags = #$tags$ cck-containers 
-}
-
-@PART[kerbalism-container-*]:NEEDS[CommunityCategoryKit,!FilterExtensions]:AFTER[zzzKerbalismDefault]
+@PART[kerbalism-container-*|kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit,!FilterExtensions]:AFTER[zzzKerbalismDefault]
 {
 	%category = none
-}
-
-@PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit]:AFTER[zzzKerbalismDefault]
-{
-	%tags = #$tags$ cck-lifesupport
-}
-
-@PART[kerbalism-greenhouse|kerbalism-lifesupport*]:NEEDS[CommunityCategoryKit,!FilterExtensions]:AFTER[zzzKerbalismDefault]
-{
-	%category = none
-}
-
-// ----------------------------------------------------------------------------
-// Remove all parts from the _kerbalism category, removes it from the editors
-// ----------------------------------------------------------------------------
-@PART[kerbalism-*]:NEEDS[CommunityCategoryKit,!FilterExtensions]:AFTER[zzzKerbalismDefault]
-{
-	@tags ^= :_kerbalism::
 }

--- a/GameData/KerbalismConfig/Support/HabTech2.cfg
+++ b/GameData/KerbalismConfig/Support/HabTech2.cfg
@@ -928,7 +928,7 @@ PARTUPGRADE:NEEDS[FeatureComfort,HabTech2]
 
 @PART[ht2_moduleJEMlogistics]:NEEDS[HabTech2,CommunityCategoryKit]:AFTER[zzzKerbalismDefault]
 {
-	%tags = #$tags$ cck-containers cck-lifesupport
+	%tags = #$tags$ cck-lifesupport
 }
 
 @PART[ht2_moduleJEMlogistics]:NEEDS[HabTech2,CommunityCategoryKit,!FilterExtensions]:AFTER[zzzKerbalismDefault]
@@ -1754,7 +1754,7 @@ PARTUPGRADE:NEEDS[FeatureComfort,HabTech2]
 
 @PART[ht2_MPLM]:NEEDS[HabTech2,CommunityCategoryKit]:AFTER[zzzKerbalismDefault]
 {
-	%tags = #$tags$ cck-containers cck-lifesupport
+	%tags = #$tags$ cck-lifesupport
 }
 
 @PART[ht2_MPLM]:NEEDS[HabTech2,CommunityCategoryKit,!FilterExtensions]:AFTER[zzzKerbalismDefault]
@@ -1983,7 +1983,7 @@ PARTUPGRADE:NEEDS[FeatureComfort,HabTech2]
 
 @PART[ht2_questPod]:NEEDS[HabTech2,CommunityCategoryKit]:AFTER[zzzKerbalismDefault]
 {
-	%tags = #$tags$ cck-containers cck-lifesupport
+	%tags = #$tags$ cck-lifesupport
 }
 
 @PART[ht2_questPod]:NEEDS[HabTech2,CommunityCategoryKit,!FilterExtensions]:AFTER[zzzKerbalismDefault]

--- a/src/Kerbalism/System/Callbacks.cs
+++ b/src/Kerbalism/System/Callbacks.cs
@@ -119,7 +119,6 @@ namespace KERBALISM
 			GameEvents.onVesselUnloaded.Add((v) => Cache.PurgeVesselCaches(v));
 
 			GameEvents.OnTechnologyResearched.Add(this.TechResearched);
-			GameEvents.onGUIEditorToolbarReady.Add(this.AddEditorCategory);
 
 			GameEvents.onGUIAdministrationFacilitySpawn.Add(() => visible = false);
 			GameEvents.onGUIAdministrationFacilityDespawn.Add(() => visible = true);
@@ -673,16 +672,6 @@ namespace KERBALISM
 			// delete data on unloaded vessels only (this is handled trough OnPartWillDie for loaded vessels)
 			if (!v.loaded)
 				Drive.DeleteDrivesData(v);
-		}
-
-		void AddEditorCategory()
-		{
-			if (PartLoader.LoadedPartsList.Find(k => k.tags.IndexOf("_kerbalism", StringComparison.Ordinal) >= 0) != null)
-			{
-				RUI.Icons.Selectable.Icon icon = new RUI.Icons.Selectable.Icon("Kerbalism", Textures.category_normal, Textures.category_selected);
-				PartCategorizer.Category category = PartCategorizer.Instance.filters.Find(k => string.Equals(k.button.categoryName, "filter by function", StringComparison.OrdinalIgnoreCase));
-				PartCategorizer.AddCustomSubcategoryFilter(category, "Kerbalism", "Kerbalism", icon, k => k.tags.IndexOf("_kerbalism", StringComparison.Ordinal) >= 0);
-			}
 		}
 
 		void TechResearched(GameEvents.HostTargetAction<RDTech, RDTech.OperationResult> data)

--- a/src/Kerbalism/UI/Textures.cs
+++ b/src/Kerbalism/UI/Textures.cs
@@ -35,9 +35,6 @@ namespace KERBALISM
 		internal static Texture2D file_scicolor;
 		internal static Texture2D sample_scicolor;
 
-		internal static Texture2D category_normal;
-		internal static Texture2D category_selected;
-
 		internal static Texture2D sun_black;
 		internal static Texture2D sun_white;
 		internal static Texture2D solar_panel;
@@ -178,9 +175,6 @@ namespace KERBALISM
 
 			file_scicolor = GetTexture("icons8-file-scicolor");
 			sample_scicolor = GetTexture("icons8-sample-scicolor");
-
-			category_normal = GetTexture("category-normal");
-			category_selected = GetTexture("category-selected");
 
 			sun_black = GetTexture("sun-black");
 			sun_white = GetTexture("sun-white");


### PR DESCRIPTION
## Description
- Remove the hardcoded Kerbalism editor category so parts only appear in their stock category without CCK.
- Stop tagging Kerbalism/HabTech2 parts with `cck-containers`; keep them in CCK Life Support only.
- Stop stripping `_kerbalism` under CCK (no longer needed for categorization; still used as an enabled-part marker).
