### PR TITLE
Remove HardDrive from KER EngineerChip (#854)

### DIFF
--- a/GameData/KerbalismConfig/Support/KerbalEngineer_Science.cfg
+++ b/GameData/KerbalismConfig/Support/KerbalEngineer_Science.cfg
@@ -17,19 +17,13 @@
 			UnlockTech = start
 			Cost = 1250
 		}
-		
-		Chip
-		{
-			data = 3.2
-			samples = 0
-			UnlockTech = electronics
-			Cost = 18500									// high cost due to drive size. incentive not to spam chips on vessels.
-		}
 	}
 }
 
 // ============================================================================
-// Add hard drive to KER parts
+// Add hard drive to KER tape only.
+// EngineerChip is intentionally not a HardDrive: its tiny size and free
+// placement made it an unbalanced data expander (see issue #854).
 // ============================================================================
 @PART[Engineer7500]:NEEDS[KerbalEngineer,FeatureScience]
 {
@@ -37,15 +31,6 @@
 	{
 		name = HardDrive
 		title = KER 7500 
-	}
-}
-
-@PART[EngineerChip]:NEEDS[KerbalEngineer,FeatureScience]
-{
-	MODULE
-	{
-		name = HardDrive
-		title = KER Chip   
 	}
 }
 
@@ -59,15 +44,6 @@
 	{
 		%dataCapacity = #$@KERBALISM_HDD_SIZES/KER/Tape/data$
 		%sampleCapacity = #$@KERBALISM_HDD_SIZES/KER/Tape/samples$
-	}
-}
-
-@PART[EngineerChip]:NEEDS[KerbalEngineer,FeatureScience]:FOR[KerbalismDefault]
-{
-	@MODULE[HardDrive]
-	{
-		%dataCapacity = #$@KERBALISM_HDD_SIZES/KER/Chip/data$
-		%sampleCapacity = #$@KERBALISM_HDD_SIZES/KER/Chip/samples$
 	}
 }
 
@@ -85,9 +61,3 @@
 		!UPGRADES	{}
 	}
 }
-@PART[EngineerChip]:NEEDS[KerbalEngineer,FeatureScience]:FOR[zzzKerbalismDefault]
-{
-	@TechRequired = #$@KERBALISM_HDD_SIZES/KER/Chip/UnlockTech$
-	@cost = #$@KERBALISM_HDD_SIZES/KER/Chip/Cost$
-}
-	


### PR DESCRIPTION
## Description
- Stop treating `EngineerChip` as a Kerbalism HardDrive; it was an unbalanced data expander because of its tiny size and free placement.
- Keep only the KER tape (`Engineer7500`) as a small capacity option.