### PR TITLE
Fix home-star AU reference, adaptive comms damping, and multi-star storms (#829, #1080)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  ### Changes since the last release
  * Fixed: Home-star / AU reference and adaptive comms damping calibration for large and multi-star packs (#829, #1080, @Aebestach)
+ * Fixed: Multi-star solar storm generation, per-star vessel CME tracking, and storm radiation summing (#1080, @Aebestach)
  * Added: KerbalismEngineFailures companion (CKAN recommended by KerbalismConfig; conflicts with TestFlight / TestLite / RO / RP-1) (#1087, @Aebestach)
  * Added: KerbalismEngineFailures propulsion-family auto-ratings with bounded ISP/thrust curves and safe fallbacks (#1087, @Aebestach)
  * Added: Greenhouse overhaul with continuous food production and balance tuning (#1096, @Aebestach)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
  * Fixed: Pressurized tanks storing too much XenonGas (#1129, @Aebestach)
  * Fixed: Seafloor vessels treated as splashed for science situations (#1086, @Aebestach)
  * Fixed: KsmGui showing in facilities; Body Info hotkey ignored while typing (#1107, @Aebestach)
+ * Fixed: Body Info `B` hotkey ignored over empty map space (KEYBOARDINPUT lock was too broad)
  * Changed: Engine ignition, burn-time and turn-on failures moved into optional companion mod KerbalismEngineFailures; core Reliability keeps MTBF/radiation only (#1087, @Aebestach)
  * Changed: Kerbalism MTBF Reliability is no longer stripped entirely when TestFlight is present (#1087, @Aebestach)
  * Changed: Critical Reliability and engine failures can be repaired with two EVA repair kits by crew one qualification tier above the normal repair requirement (#814, @Aebestach)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
  - 2026-07-28
 
  ### Changes since the last release
+ * Fixed: Home-star / AU reference and adaptive comms damping calibration for large and multi-star packs (#829, #1080, @Aebestach)
  * Added: KerbalismEngineFailures companion (CKAN recommended by KerbalismConfig; conflicts with TestFlight / TestLite / RO / RP-1) (#1087, @Aebestach)
  * Added: KerbalismEngineFailures propulsion-family auto-ratings with bounded ISP/thrust curves and safe fallbacks (#1087, @Aebestach)
  * Added: Greenhouse overhaul with continuous food production and balance tuning (#1096, @Aebestach)

--- a/GameData/KerbalismConfig/Settings.cfg
+++ b/GameData/KerbalismConfig/Settings.cfg
@@ -27,7 +27,7 @@ Kerbalism
   TransmitterActiveEcFactorRT = 1.0     // RemoteTech factor to the nominal ec consumption rate while antenna is active (transmitting), 1 is RemoteTech cfg settings energy consumption per packet
   TransmitterPassiveEcFactorRT = 1.0   // RemoteTech factor to the nominal ec consumption rate while antenna is inactive (idle/receiving), 1 is RemoteTech cfg idle consumption
   DataRateMinimumBitsPerSecond = 1.0  // as long as there is a control connection, the science data rate will never go below this.
-  // DampingExponentOverride = 14        // Kerbalism will calculate a damping exponent to achieve good data communication rates (see KSP.log, search for DataRateDampingExponent). If the calculated value is not good for you, you can set your own.
+  // DampingExponentOverride = 14        // Kerbalism auto-calibrates damping from home-star AU (see KSP.log: DataRateDampingExponent / Home system). Set your own if needed.
 
   // reliability settings
   QualityScale = 4.0                  // scale applied to MTBF for high-quality components

--- a/docs/tech-guide/settings.en.md
+++ b/docs/tech-guide/settings.en.md
@@ -34,7 +34,7 @@ Values below are the **shipped official config** defaults (3.40). Code fallbacks
 | TransmitterActiveEcFactorRT | Same for RemoteTech while transmitting | `1.0` |
 | TransmitterPassiveEcFactorRT | Same for RemoteTech while idle | `1.0` |
 | DataRateMinimumBitsPerSecond | Floor on science data rate when a control link exists | `1.0` |
-| DampingExponentOverride | Optional override for data-rate damping (see KSP.log) | commented out |
+| DampingExponentOverride | Optional override for data-rate damping; auto-calibrates from home-star AU when unset (see KSP.log for `DataRateDampingExponent` / `Home system`) | commented out |
 | UnlinkedControl | Control when unlinked: `none` / `limited` / `full` | `none` (code; often omitted from cfg) |
 
 ## Science and reliability

--- a/src/Kerbalism/Database/VesselData.cs
+++ b/src/Kerbalism/Database/VesselData.cs
@@ -84,7 +84,10 @@ namespace KERBALISM
 
 		public bool msg_signal;       // message flag: link status
 		public bool msg_belt;         // message flag: crossing radiation belt
+		/// <summary>Legacy primary storm slot (mirrored from stormDataByStar for save compat).</summary>
 		public StormData stormData;
+		/// <summary>Per-source-star CME state for vessels in a star SOI (multi-star packs).</summary>
+		public Dictionary<string, StormData> stormDataByStar;
 		private Dictionary<string, SupplyData> supplies; // supplies data
 		public List<uint> scansat_id; // used to remember scansat sensors that were disabled
 		public double scienceTransmitted;
@@ -812,7 +815,7 @@ namespace KERBALISM
 			}
 			else
 			{
-				Load(node);
+				Load(node, protoVessel);
 				Lib.LogDebug("VesselData ctor (loaded from database) : id '" + VesselId + "' (" + protoVessel.vesselName + "), part count : " + parts.Count);
 			}
 
@@ -840,6 +843,7 @@ namespace KERBALISM
 			// note : we check that at vessel creation and persist it, as the vesselType can be changed by the player
 			isSerenityGroundController = pv != null && pv.vesselType == VesselType.DeployedScienceController;
 
+			stormDataByStar = new Dictionary<string, StormData>();
 			stormData = new StormData(null);
 			habitatInfo = new VesselHabitatInfo(null);
 			computer = new Computer(null);
@@ -851,6 +855,26 @@ namespace KERBALISM
 
 		}
 
+		/// <summary>Get or create the CME slot for a source star (interplanetary multi-star storms).</summary>
+		public StormData GetStormDataForStar(CelestialBody star)
+		{
+			if (stormDataByStar == null)
+				stormDataByStar = new Dictionary<string, StormData>();
+
+			string key = star != null ? star.bodyName : "Sun";
+			if (!stormDataByStar.TryGetValue(key, out StormData bd))
+			{
+				bd = new StormData(null);
+				stormDataByStar[key] = bd;
+			}
+
+			// Keep legacy slot pointing at a useful primary entry
+			if (stormData == null || stormData.storm_state == 0)
+				stormData = bd;
+
+			return bd;
+		}
+
 		private void InitializeCommHandler()
 		{
 			connection = new ConnectionInfo();
@@ -858,7 +882,7 @@ namespace KERBALISM
 			CommHandler = CommHandler.GetHandler(this, isSerenityGroundController);
 		}
 
-		private void Load(ConfigNode node)
+		private void Load(ConfigNode node, ProtoVessel protoVessel)
 		{
 			msg_signal = Lib.ConfigValue(node, "msg_signal", false);
 			msg_belt = Lib.ConfigValue(node, "msg_belt", false);
@@ -887,7 +911,62 @@ namespace KERBALISM
 			vesselBodyCrossSectionOrbitAvg = Lib.ConfigValue(node, "vesselBodyCrossSectionOrbitAvg", -1.0);
 			vesselEmissivity = Lib.ConfigValue(node, "vesselEmissivity", 0.9);
 
-			stormData = new StormData(node.GetNode("StormData"));
+			stormDataByStar = new Dictionary<string, StormData>();
+			ConfigNode byStarNode = node.GetNode("StormDataByStar");
+			if (byStarNode != null)
+			{
+				foreach (ConfigNode starNode in byStarNode.nodes)
+					stormDataByStar[DB.From_safe_key(starNode.name)] = new StormData(starNode);
+			}
+
+			// Migrate legacy single StormData into the per-star map when needed
+			ConfigNode legacyStorm = node.GetNode("StormData");
+			if (legacyStorm != null)
+			{
+				stormData = new StormData(legacyStorm);
+				if (stormDataByStar.Count == 0)
+				{
+					string migrateKey = "Sun";
+					CelestialBody referenceBody = null;
+					if (Vessel != null)
+					{
+						referenceBody = Vessel.mainBody;
+					}
+					else if (protoVessel?.orbitSnapShot != null)
+					{
+						int bodyIndex = protoVessel.orbitSnapShot.ReferenceBodyIndex;
+						if (bodyIndex >= 0 && bodyIndex < FlightGlobals.Bodies.Count)
+							referenceBody = FlightGlobals.Bodies[bodyIndex];
+					}
+
+					CelestialBody sun = Lib.IsSun(referenceBody) ? referenceBody : Lib.GetParentSun(referenceBody);
+					if (sun != null)
+						migrateKey = sun.bodyName;
+					else if (Sim.suns.Count > 0 && Sim.suns[0].body != null)
+						migrateKey = Sim.suns[0].body.bodyName;
+
+					stormDataByStar[migrateKey] = stormData;
+				}
+				else
+				{
+					// The per-star data is authoritative; keep the legacy field as an alias, not a detached copy.
+					foreach (StormData bd in stormDataByStar.Values)
+					{
+						stormData = bd;
+						break;
+					}
+				}
+			}
+			else
+			{
+				stormData = new StormData(null);
+				foreach (StormData bd in stormDataByStar.Values)
+				{
+					stormData = bd;
+					break;
+				}
+			}
+
 			habitatInfo = new VesselHabitatInfo(node.GetNode("SunShielding"));
 			computer = new Computer(node.GetNode("computer"));
 
@@ -969,7 +1048,30 @@ namespace KERBALISM
 			node.AddValue("vesselBodyCrossSectionOrbitAvg", vesselBodyCrossSectionOrbitAvg);
 			node.AddValue("vesselEmissivity", vesselEmissivity);
 
+			// Legacy single node (primary / first star) for older readers
+			if (stormData == null)
+				stormData = new StormData(null);
+			if (Vessel != null
+				&& (Lib.IsSun(Vessel.mainBody) || Lib.IsBarycenter(Vessel.mainBody))
+				&& Storm.TryGetPrimaryStorm(Vessel, out StormData primaryStorm, out _))
+				stormData = primaryStorm;
+			else if (stormDataByStar != null)
+			{
+				foreach (StormData bd in stormDataByStar.Values)
+				{
+					stormData = bd;
+					break;
+				}
+			}
 			stormData.Save(node.AddNode("StormData"));
+
+			if (stormDataByStar != null && stormDataByStar.Count > 0)
+			{
+				ConfigNode byStarSave = node.AddNode("StormDataByStar");
+				foreach (KeyValuePair<string, StormData> kv in stormDataByStar)
+					kv.Value.Save(byStarSave.AddNode(DB.To_safe_key(kv.Key)));
+			}
+
 			computer.Save(node.AddNode("computer"));
 
 			var supplies_node = node.AddNode("supplies");
@@ -1250,15 +1352,7 @@ namespace KERBALISM
 			thermosphere = Sim.InsideThermosphere(Vessel);
 			exosphere = Sim.InsideExosphere(Vessel);
 			inStorm = Storm.InProgress(Vessel);
-
-			if(inStorm)
-			{
-				var sunActivity = Radiation.Info(mainSun.SunData.body).SolarActivity(false) / 2.0;
-				stormRadiation = PreferencesRadiation.Instance.StormRadiation * mainSun.SunlightFactor * (sunActivity + 0.5);
-			} else
-			{
-				stormRadiation = 0.0;
-			}
+			stormRadiation = inStorm ? Storm.RadiationStrength(Vessel, this) : 0.0;
 
 			vesselSituations.Update();
 

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -1485,12 +1485,17 @@ namespace KERBALISM
 			if (IsSun(body)) return body;
 
 			CelestialBody refBody = body.referenceBody;
-			do
+			while (refBody != null)
 			{
 				if (IsSun(refBody)) return refBody;
 				refBody = refBody.referenceBody;
 			}
-			while (refBody != null);
+
+			// No sun on the referenceBody chain (barycenters / PostSpawnOrbit). Prefer the brightest
+			// known star at this body over silently assuming the universe root (#829).
+			CelestialBody brightest = Sim.BrightestSunAt(body.position);
+			if (brightest != null)
+				return brightest;
 
 			return FlightGlobals.Bodies[0];
 		}

--- a/src/Kerbalism/Lib.cs
+++ b/src/Kerbalism/Lib.cs
@@ -1431,13 +1431,29 @@ namespace KERBALISM
 
 		#region BODY
 
-		/// <summary>For a given body, return the last parent body that is not a sun </summary>
+		/// <summary>
+		/// For a given body, return the planetary-system root. A sun or barycenter is treated
+		/// as a hierarchy boundary, so planets sharing a barycenter keep independent storm state.
+		/// </summary>
 		public static CelestialBody GetParentPlanet(CelestialBody body)
 		{
-			if (Lib.IsSun(body)) return body;
-			CelestialBody checkedBody = body;
-			while (!Lib.IsSun(checkedBody.referenceBody)) checkedBody = checkedBody.referenceBody;
-			return checkedBody;
+			if (body == null) return null;
+			if (IsSun(body)) return body;
+
+			CelestialBody current = body;
+			int remainingBodies = FlightGlobals.Bodies.Count + 1;
+			while (remainingBodies-- > 0)
+			{
+				CelestialBody parent = current.referenceBody;
+				if (parent == null || parent == current)
+					return current;
+				if (IsSun(parent) || IsBarycenter(parent))
+					return current;
+
+				current = parent;
+			}
+
+			return current;
 		}
 
 		/// <summary> optimized method for getting normalized direction and distance between the surface of two bodies</summary>
@@ -1471,6 +1487,7 @@ namespace KERBALISM
 		/// <summary> Is this body a sun ? </summary>
 		public static bool IsSun(CelestialBody body)
 		{
+			if (body == null) return false;
 			int idx = body.flightGlobalsIndex;
 			foreach (Sim.SunData s in Sim.suns)
 			{
@@ -1479,13 +1496,33 @@ namespace KERBALISM
 			return false;
 		}
 
+		/// <summary>
+		/// True for a non-luminous hierarchy root used as a multi-star barycenter.
+		/// Kopernicus barycenters either parent one or more stars or are self-referential roots.
+		/// </summary>
+		public static bool IsBarycenter(CelestialBody body)
+		{
+			if (body == null || IsSun(body)) return false;
+			if (body.referenceBody == body) return true;
+
+			foreach (Sim.SunData sun in Sim.suns)
+			{
+				if (sun.body != null && sun.body.referenceBody == body)
+					return true;
+			}
+
+			return false;
+		}
+
 		/// <summary> return the first found parent sun for a given body </summary>
 		public static CelestialBody GetParentSun(CelestialBody body)
 		{
+			if (body == null) return null;
 			if (IsSun(body)) return body;
 
 			CelestialBody refBody = body.referenceBody;
-			while (refBody != null)
+			int remainingBodies = FlightGlobals.Bodies.Count + 1;
+			while (refBody != null && remainingBodies-- > 0)
 			{
 				if (IsSun(refBody)) return refBody;
 				refBody = refBody.referenceBody;

--- a/src/Kerbalism/Radiation/Radiation.cs
+++ b/src/Kerbalism/Radiation/Radiation.cs
@@ -782,14 +782,12 @@ namespace KERBALISM
             if (Storm.InProgress(v))
             {
                 // inside a magnetopause (except heliosphere), blackout the signal
-                // outside, add storm radiations modulated by sun visibility
+                // outside, add storm radiations from every active CME (multi-star aware)
                 if (magnetosphere) blackout = true;
                 else
                 {
                     var vd = v.KerbalismData();
-
-                    var activity = Info(vd.EnvMainSun.SunData.body).SolarActivity(false) / 2.0;
-                    var strength = PreferencesRadiation.Instance.StormRadiation * sunlight * (activity + 0.5);
+                    var strength = Storm.RadiationStrength(v, vd);
 
                     radiation += strength;
                     shieldedRadiation += vd.EnvHabitatInfo.AverageHabitatRadiation(strength);

--- a/src/Kerbalism/Radiation/Storm.cs
+++ b/src/Kerbalism/Radiation/Storm.cs
@@ -6,254 +6,557 @@ using KSP.Localization;
 
 namespace KERBALISM
 {
-    public static class Storm
-    {
-        // TODO multi sun support?
-        public static float sun_observation_quality = 1.0f;
+	public static class Storm
+	{
+		/// <summary>Global observatory quality [0..1]. Affects CME warning chance and displayed duration error.</summary>
+		public static float sun_observation_quality = 1.0f;
 
-        internal static void CreateStorm(StormData bd, CelestialBody body, double distanceToSun)
-        {
-            // do nothing if storms are disabled
-            if (!Features.SpaceWeather) return;
+		/// <summary>
+		/// Companion stars whose flux at the target is at least this fraction of the primary are also
+		/// allowed to generate CMEs (binary / multi-star packs).
+		/// </summary>
+		const double MinCompanionFluxFraction = 0.05;
 
-            var now = Planetarium.GetUniversalTime();
-
-            if (bd.storm_generation < now)
-            {
-                var sun = Lib.GetParentSun(body);
-                var avgDuration = PreferencesRadiation.Instance.AvgStormDuration;
-
-                // retry after 5 * average storm duration + jitter (to avoid recalc spikes)
-                bd.storm_generation = now + avgDuration * 5 + avgDuration * Lib.RandomDouble();
-
-                var rb = Radiation.Info(sun);
-                var activity = rb.solar_cycle > 0 ? rb.SolarActivity() : 1.0;
-
-                if (Lib.RandomDouble() < activity * PreferencesRadiation.Instance.stormFrequency)
-                {
-                    // storm duration depends on current solar activity
-                    bd.storm_duration = avgDuration / 2.0 + avgDuration * activity * 2;
-
-                    // if further out, the storm lasts longer (but is weaker)
-                    bd.storm_duration /= Storm_frequency(distanceToSun);
-
-                    // set a start time to give enough time for warning
-                    bd.storm_time = now + Time_to_impact(distanceToSun);
-
-                    // delay next storm generation by duration of this one
-                    bd.storm_generation += bd.storm_duration;
-
-                    // add a random error to the estimated storm duration if we don't observe the sun too well
-                    var error = bd.storm_duration * 3 * Lib.RandomDouble() * (1 - sun_observation_quality);
-                    bd.displayed_duration = bd.storm_duration + error;
-
-                    // show warning message only if you're lucky...
-                    bd.display_warning = Lib.RandomFloat() < sun_observation_quality;
-
-
-#if DEBUG_RADIATION
-					Lib.Log("Storm on " + body + " will start in " + Lib.HumanReadableDuration(bd.storm_time - now) + " and last for " + Lib.HumanReadableDuration(bd.storm_duration));
-				}
-				else
-				{
-					Lib.Log("No storm on " + body + ", will retry in " + Lib.HumanReadableDuration(bd.storm_generation - now));
-#endif
-                }
-            }
-
-            if (bd.storm_time + bd.storm_duration < now)
-            {
-                // storm is over
-                bd.Reset();
-            }
-            else if (bd.storm_time < now && bd.storm_time + bd.storm_duration > now)
-            {
-                // storm in progress
-                bd.storm_state = 2;
-            }
-            else if (bd.storm_time > now)
-            {
-                // storm incoming
-                bd.storm_state = 1;
-            }
-        }
-
-        public static void Update(CelestialBody body, double elapsed_s)
-        {
+		/// <summary>
+		/// Generate / advance a storm delivered from <paramref name="sourceStar"/> over <paramref name="distanceToSun"/>.
+		/// </summary>
+		internal static void CreateStorm(StormData bd, CelestialBody sourceStar, double distanceToSun)
+		{
 			// do nothing if storms are disabled
 			if (!Features.SpaceWeather) return;
 
-            StormData bd = DB.Storm(body.name);
-            CreateStorm(bd, body, body.orbit.semiMajorAxis);
+			var now = Planetarium.GetUniversalTime();
 
-            // send messages
+			if (bd.storm_generation < now)
+			{
+				var avgDuration = PreferencesRadiation.Instance.AvgStormDuration;
 
-            if (Body_is_relevant(body))
-            {
-                switch (bd.storm_state)
-                {
-                    case 2:
-                        if (bd.msg_storm < 2)
-                        {
-							Message.Post(Severity.danger, Local.Storm_msg1.Format("<b>" + body.name + "</b>"),//"The coronal mass ejection hit <<1>> system  //Lib.BuildString( )
-								Lib.BuildString(Local.Storm_msg1text, " ", Lib.HumanReadableDuration(bd.displayed_duration)));//"Storm duration:"
-                        }
-                        break;
+				// retry after 5 * average storm duration + jitter (to avoid recalc spikes)
+				bd.storm_generation = now + avgDuration * 5 + avgDuration * Lib.RandomDouble();
 
-                    case 1:
-                        if (bd.msg_storm < 1 && bd.display_warning)
-                        {
-                            var tti = bd.storm_time - Planetarium.GetUniversalTime();
-							Message.Post(Severity.warning, Local.Storm_msg2.Format("<b>" + body.name + "</b>"),//Lib.BuildString("Our observatories report a coronal mass ejection directed toward <<1>> system")
-								Lib.BuildString(Local.Storm_msg2text," ", Lib.HumanReadableDuration(tti)));//"Time to impact:"
-                        }
-                        break;
+				var rb = Radiation.Info(sourceStar);
+				var activity = rb.solar_cycle > 0 ? rb.SolarActivity() : 1.0;
 
-                    case 0:
-                        if (bd.msg_storm == 2)
-                        {
-                            Message.Post(Severity.relax, Local.Storm_msg3.Format("<b>" + body.name + "</b>"));//Lib.BuildString("The solar storm at <<1>> system is over")
-                        }
-                        break;
-                }
-            }
+				if (Lib.RandomDouble() < activity * PreferencesRadiation.Instance.stormFrequency)
+				{
+					// storm duration depends on current solar activity
+					bd.storm_duration = avgDuration / 2.0 + avgDuration * activity * 2;
 
-            bd.msg_storm = bd.storm_state;
-        }
+					// if further out, the storm lasts longer (but is weaker)
+					bd.storm_duration /= Storm_frequency(distanceToSun);
 
-        public static void Update(Vessel v, VesselData vd, double elapsed_s)
-        {
+					// set a start time to give enough time for warning
+					bd.storm_time = now + Time_to_impact(distanceToSun);
+
+					// delay next storm generation by duration of this one
+					bd.storm_generation += bd.storm_duration;
+
+					// add a random error to the estimated storm duration if we don't observe the sun too well
+					var error = bd.storm_duration * 3 * Lib.RandomDouble() * (1 - sun_observation_quality);
+					bd.displayed_duration = bd.storm_duration + error;
+
+					// show warning message only if you're lucky...
+					bd.display_warning = Lib.RandomFloat() < sun_observation_quality;
+
+
+#if DEBUG_RADIATION
+					Lib.Log("Storm from " + sourceStar + " will start in " + Lib.HumanReadableDuration(bd.storm_time - now) + " and last for " + Lib.HumanReadableDuration(bd.storm_duration));
+				}
+				else
+				{
+					Lib.Log("No storm from " + sourceStar + ", will retry in " + Lib.HumanReadableDuration(bd.storm_generation - now));
+#endif
+				}
+			}
+
+			AdvanceStormState(bd, now);
+		}
+
+		static void AdvanceStormState(StormData bd, double now)
+		{
+			if (bd.storm_time + bd.storm_duration < now)
+			{
+				// storm is over
+				bd.Reset();
+			}
+			else if (bd.storm_time < now && bd.storm_time + bd.storm_duration > now)
+			{
+				// storm in progress
+				bd.storm_state = 2;
+			}
+			else if (bd.storm_time > now)
+			{
+				// storm incoming
+				bd.storm_state = 1;
+			}
+		}
+
+		public static void Update(CelestialBody body, double elapsed_s)
+		{
+			// do nothing if storms are disabled
+			if (!Features.SpaceWeather) return;
+
+			foreach (CelestialBody star in RelevantStarsAt(body.position, Lib.GetParentSun(body)))
+			{
+				double dist = Vector3d.Distance(body.position, star.position);
+				StormData bd = DB.Storm(StormKey(body, star));
+				CreateStorm(bd, star, dist);
+
+				// send messages
+				if (Body_is_relevant(body))
+					PostBodyMessages(body, bd, star);
+
+				bd.msg_storm = bd.storm_state;
+			}
+		}
+
+		public static void Update(Vessel v, VesselData vd, double elapsed_s)
+		{
 			try
 			{
 				// do nothing if storms are disabled
 				if (!Features.SpaceWeather) return;
 
-				// only consider vessels in interplanetary space
-				if (!Lib.IsSun(v.mainBody)) return;
+				// only consider vessels in interplanetary space (star or multi-star barycenter SOI)
+				if (!IsInterplanetaryBody(v.mainBody)) return;
 
 				// disregard EVAs
 				if (v.isEVA) return;
 
-				var bd = vd.stormData;
-				CreateStorm(bd, v.mainBody, vd.EnvMainSun.Distance);
-
-				if (vd.cfg_storm)
+				if (vd.EnvSunsInfo == null || vd.EnvSunsInfo.Count == 0)
 				{
-					switch (bd.storm_state)
+					// Suns not evaluated yet this tick — fall back to the SOI star or brightest local star
+					CelestialBody star = Lib.IsSun(v.mainBody) ? v.mainBody : Sim.BrightestSunAt(Lib.VesselPosition(v));
+					if (star == null) return;
+					StormData bd = vd.GetStormDataForStar(star);
+					double dist = vd.EnvMainSun != null && vd.EnvMainSun.SunData.body == star
+						? vd.EnvMainSun.Distance
+						: Sim.SunDistance(Lib.VesselPosition(v), star);
+					CreateStorm(bd, star, dist);
+					if (vd.cfg_storm)
+						PostVesselMessages(v, bd, star);
+					bd.msg_storm = bd.storm_state;
+					return;
+				}
+
+				var relevantKeys = new HashSet<string>();
+				foreach (VesselData.SunInfo sunInfo in vd.EnvSunsInfo)
+				{
+					if (!IsVesselStormSun(v, vd, sunInfo))
+						continue;
+
+					CelestialBody star = sunInfo.SunData.body;
+					relevantKeys.Add(star.bodyName);
+					StormData bd = vd.GetStormDataForStar(star);
+					CreateStorm(bd, star, sunInfo.Distance);
+
+					if (vd.cfg_storm)
+						PostVesselMessages(v, bd, star);
+
+					bd.msg_storm = bd.storm_state;
+				}
+
+				// Historical slots must still expire, but must not affect the vessel or generate new CMEs
+				// while their source star is no longer locally relevant.
+				if (vd.stormDataByStar != null)
+				{
+					double now = Planetarium.GetUniversalTime();
+					foreach (KeyValuePair<string, StormData> kv in vd.stormDataByStar)
 					{
-						case 0: // no storm
-							if (bd.msg_storm == 2)
-							{
-								// send message
-								Message.Post(Severity.relax, Local.Storm_msg4.Format("<b>" + v.vesselName + "</b>"));//Lib.BuildString("The solar storm around <<1>> is over")
-								vd.msg_signal = false; // used to avoid sending 'signal is back' messages en-masse after the storm is over
-							}
-							break;
-
-						case 2: // storm in progress
-							if (bd.msg_storm < 2)
-							{
-								Message.Post(Severity.danger, Local.Storm_msg5.Format("<b>" + v.vesselName + "</b>"),//Lib.BuildString("The coronal mass ejection hit <<1>>)
-								  Lib.BuildString(Local.Storm_msg1text, " ", Lib.HumanReadableDuration(bd.displayed_duration)));//"Storm duration:"
-							}
-							break;
-
-						case 1: // storm incoming
-							if (bd.msg_storm < 1 && bd.display_warning)
-							{
-								var tti = bd.storm_time - Planetarium.GetUniversalTime();
-								Message.Post(Severity.warning, Local.Storm_msg6.Format("<b>" + v.vesselName + "</b>"),//Lib.BuildString("Our observatories report a coronal mass ejection directed toward <<1>>)
-									Lib.BuildString(Local.Storm_msg2text, " ", Lib.HumanReadableDuration(tti)));//"Time to impact:
-							}
-							break;
+						if (relevantKeys.Contains(kv.Key))
+							continue;
+						AdvanceStormState(kv.Value, now);
 					}
 				}
-				bd.msg_storm = bd.storm_state;
 			}
 			catch
 			{
 				vd.IsSimulated = vd.CheckIfSimulated();
 				return;
 			}
-        }
+		}
+
+		static void PostBodyMessages(CelestialBody body, StormData bd, CelestialBody star)
+		{
+			string systemLabel = StormTargetLabel(body.name, star);
+
+			switch (bd.storm_state)
+			{
+				case 2:
+					if (bd.msg_storm < 2)
+					{
+						Message.Post(Severity.danger, Local.Storm_msg1.Format("<b>" + systemLabel + "</b>"),
+							Lib.BuildString(Local.Storm_msg1text, " ", Lib.HumanReadableDuration(bd.displayed_duration)));
+					}
+					break;
+
+				case 1:
+					if (bd.msg_storm < 1 && bd.display_warning)
+					{
+						var tti = bd.storm_time - Planetarium.GetUniversalTime();
+						Message.Post(Severity.warning, Local.Storm_msg2.Format("<b>" + systemLabel + "</b>"),
+							Lib.BuildString(Local.Storm_msg2text, " ", Lib.HumanReadableDuration(tti)));
+					}
+					break;
+
+				case 0:
+					if (bd.msg_storm == 2)
+					{
+						Message.Post(Severity.relax, Local.Storm_msg3.Format("<b>" + systemLabel + "</b>"));
+					}
+					break;
+			}
+		}
+
+		static void PostVesselMessages(Vessel v, StormData bd, CelestialBody star)
+		{
+			string vesselLabel = StormTargetLabel(v.vesselName, star);
+
+			switch (bd.storm_state)
+			{
+				case 0: // no storm
+					if (bd.msg_storm == 2)
+					{
+						Message.Post(Severity.relax, Local.Storm_msg4.Format("<b>" + vesselLabel + "</b>"));
+						v.KerbalismData().msg_signal = false; // avoid mass 'signal is back' messages after the storm
+					}
+					break;
+
+				case 2: // storm in progress
+					if (bd.msg_storm < 2)
+					{
+						Message.Post(Severity.danger, Local.Storm_msg5.Format("<b>" + vesselLabel + "</b>"),
+							Lib.BuildString(Local.Storm_msg1text, " ", Lib.HumanReadableDuration(bd.displayed_duration)));
+					}
+					break;
+
+				case 1: // storm incoming
+					if (bd.msg_storm < 1 && bd.display_warning)
+					{
+						var tti = bd.storm_time - Planetarium.GetUniversalTime();
+						Message.Post(Severity.warning, Local.Storm_msg6.Format("<b>" + vesselLabel + "</b>"),
+							Lib.BuildString(Local.Storm_msg2text, " ", Lib.HumanReadableDuration(tti)));
+					}
+					break;
+			}
+		}
+
+		static string StormTargetLabel(string name, CelestialBody star)
+		{
+			if (Sim.suns.Count <= 1 || star == null)
+				return name;
+			return name + " / " + star.bodyName;
+		}
+
+		/// <summary>DB key for a planetary-system storm from a given source star (save-compatible for the parent sun).</summary>
+		public static string StormKey(CelestialBody planet, CelestialBody star)
+		{
+			CelestialBody parent = Lib.GetParentSun(planet);
+			if (parent == null || star == null || parent == star)
+				return planet.name;
+			return planet.name + "@" + star.bodyName;
+		}
+
+		/// <summary>Stars that can deliver a CME to a world position (primary + bright companions).</summary>
+		public static List<CelestialBody> RelevantStarsAt(Vector3d worldPos, CelestialBody preferredPrimary = null)
+		{
+			var result = new List<CelestialBody>();
+			if (Sim.suns.Count == 0)
+				return result;
+
+			CelestialBody primary = preferredPrimary;
+			if (primary == null || !Lib.IsSun(primary))
+				primary = Sim.BrightestSunAt(worldPos);
+			if (primary == null)
+				primary = Sim.suns[0].body;
+
+			result.Add(primary);
+			if (Sim.suns.Count == 1)
+				return result;
+
+			Sim.SunData primaryData = null;
+			foreach (Sim.SunData sd in Sim.suns)
+			{
+				if (sd.body == primary)
+				{
+					primaryData = sd;
+					break;
+				}
+			}
+
+			double primaryDist = Vector3d.Distance(worldPos, primary.position);
+			double primaryFlux = primaryData != null ? primaryData.FluxProxyAtDistance(primaryDist) : 0.0;
+
+			foreach (Sim.SunData sd in Sim.suns)
+			{
+				if (sd.body == primary)
+					continue;
+				double flux = sd.FluxProxyAtDistance(Vector3d.Distance(worldPos, sd.body.position));
+				if (primaryFlux <= double.Epsilon || flux / primaryFlux >= MinCompanionFluxFraction)
+					result.Add(sd.body);
+			}
+
+			return result;
+		}
+
+		static bool IsInterplanetaryBody(CelestialBody body)
+		{
+			return Lib.IsSun(body) || Lib.IsBarycenter(body);
+		}
+
+		static bool IsVesselStormSun(Vessel v, VesselData vd, VesselData.SunInfo sunInfo)
+		{
+			if (sunInfo == null || sunInfo.SunData == null)
+				return false;
+			if (Sim.suns.Count <= 1)
+				return true;
+			// Always track the local brightest / SOI star and any companion contributing meaningful flux
+			return sunInfo == vd.EnvMainSun
+				|| sunInfo.SunData.body == v.mainBody
+				|| sunInfo.FluxProportion >= MinCompanionFluxFraction;
+		}
+
+		/// <summary>Enumerate storm slots that can affect this vessel.</summary>
+		public static IEnumerable<KeyValuePair<CelestialBody, StormData>> GetAffectingStorms(Vessel v)
+		{
+			if (v == null)
+				yield break;
+
+			if (IsInterplanetaryBody(v.mainBody))
+			{
+				VesselData vd = v.KerbalismData();
+				if (vd?.stormDataByStar == null)
+					yield break;
+
+				if (vd.EnvSunsInfo != null && vd.EnvSunsInfo.Count > 0)
+				{
+					foreach (VesselData.SunInfo sunInfo in vd.EnvSunsInfo)
+					{
+						if (!IsVesselStormSun(v, vd, sunInfo))
+							continue;
+						CelestialBody star = sunInfo.SunData.body;
+						if (vd.stormDataByStar.TryGetValue(star.bodyName, out StormData data))
+							yield return new KeyValuePair<CelestialBody, StormData>(star, data);
+					}
+				}
+				else
+				{
+					CelestialBody star = Lib.IsSun(v.mainBody) ? v.mainBody : Sim.BrightestSunAt(Lib.VesselPosition(v));
+					if (star != null && vd.stormDataByStar.TryGetValue(star.bodyName, out StormData data))
+						yield return new KeyValuePair<CelestialBody, StormData>(star, data);
+				}
+				yield break;
+			}
+
+			CelestialBody planet = Lib.GetParentPlanet(v.mainBody);
+			if (planet == null)
+				yield break;
+
+			foreach (CelestialBody star in RelevantStarsAt(planet.position, Lib.GetParentSun(planet)))
+			{
+				yield return new KeyValuePair<CelestialBody, StormData>(star, DB.Storm(StormKey(planet, star)));
+			}
+		}
+
+		/// <summary>
+		/// Best storm for UI. When <paramref name="requiredState"/> is 0: prefer in-progress, else soonest warned inbound.
+		/// Pass 1 or 2 to restrict to incoming / in-progress only.
+		/// </summary>
+		public static bool TryGetPrimaryStorm(Vessel v, out StormData bd, out CelestialBody star, uint requiredState = 0)
+		{
+			bd = null;
+			star = null;
+			if (v == null)
+				return false;
+
+			StormData bestInProgress = null;
+			StormData bestIncoming = null;
+			CelestialBody bestInProgressStar = null;
+			CelestialBody bestIncomingStar = null;
+			double bestRemaining = double.MaxValue;
+			double bestTTI = double.MaxValue;
+			double now = Planetarium.GetUniversalTime();
+
+			foreach (KeyValuePair<CelestialBody, StormData> kv in GetAffectingStorms(v))
+			{
+				StormData data = kv.Value;
+				if (data == null)
+					continue;
+
+				if (data.storm_state == 2 && (requiredState == 0 || requiredState == 2))
+				{
+					double remaining = data.storm_time + data.displayed_duration - now;
+					if (remaining < bestRemaining)
+					{
+						bestRemaining = remaining;
+						bestInProgress = data;
+						bestInProgressStar = kv.Key;
+					}
+				}
+				else if (data.storm_state == 1 && data.display_warning && (requiredState == 0 || requiredState == 1))
+				{
+					double tti = data.storm_time - now;
+					if (tti < bestTTI)
+					{
+						bestTTI = tti;
+						bestIncoming = data;
+						bestIncomingStar = kv.Key;
+					}
+				}
+			}
+
+			if (requiredState == 1)
+			{
+				bd = bestIncoming;
+				star = bestIncomingStar;
+				return bd != null;
+			}
+
+			if (requiredState == 2)
+			{
+				bd = bestInProgress;
+				star = bestInProgressStar;
+				return bd != null;
+			}
+
+			if (bestInProgress != null)
+			{
+				bd = bestInProgress;
+				star = bestInProgressStar;
+				return true;
+			}
+
+			if (bestIncoming != null)
+			{
+				bd = bestIncoming;
+				star = bestIncomingStar;
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>Extra storm radiation rate (rad/s) from all active CMEs affecting the vessel.</summary>
+		public static double RadiationStrength(Vessel v, VesselData vd)
+		{
+			if (v == null || vd == null || !Features.SpaceWeather)
+				return 0.0;
+
+			double total = 0.0;
+			foreach (KeyValuePair<CelestialBody, StormData> kv in GetAffectingStorms(v))
+			{
+				if (kv.Value == null || kv.Value.storm_state != 2)
+					continue;
+
+				CelestialBody star = kv.Key;
+				double sunlight = 1.0;
+				double fluxWeight = 1.0;
+				if (vd.EnvSunsInfo != null)
+				{
+					fluxWeight = 0.0;
+					foreach (VesselData.SunInfo sunInfo in vd.EnvSunsInfo)
+					{
+						if (sunInfo.SunData.body == star)
+						{
+							sunlight = sunInfo.SunlightFactor;
+							fluxWeight = sunInfo.FluxProportion;
+							break;
+						}
+					}
+				}
+				else if (vd.EnvMainSun != null && vd.EnvMainSun.SunData.body == star)
+				{
+					sunlight = vd.EnvMainSun.SunlightFactor;
+				}
+
+				double activity = Radiation.Info(star).SolarActivity(false) / 2.0;
+				total += PreferencesRadiation.Instance.StormRadiation * sunlight * fluxWeight * (activity + 0.5);
+			}
+
+			return total;
+		}
+
+		// return storm frequency factor by distance from sun
+		static double Storm_frequency(double dist)
+		{
+			if (dist <= 0.0)
+				return 1.0;
+			return Sim.AU / dist;
+		}
 
 
-        // return storm frequency factor by distance from sun
-        static double Storm_frequency(double dist)
-        {
-            return Sim.AU / dist;
-        }
+		// return time to impact from CME event, in seconds
+		static double Time_to_impact(double dist)
+		{
+			return dist / PreferencesRadiation.Instance.StormEjectionSpeed;
+		}
 
 
-        // return time to impact from CME event, in seconds
-        static double Time_to_impact(double dist)
-        {
-            return dist / PreferencesRadiation.Instance.StormEjectionSpeed;
-        }
+		// return true if body is relevant to the player
+		// - body: reference body of the planetary system
+		static bool Body_is_relevant(CelestialBody body)
+		{
+			// for each vessel
+			foreach (Vessel v in FlightGlobals.Vessels)
+			{
+				// if inside the system
+				if (Lib.GetParentPlanet(v.mainBody) == body)
+				{
+					// get info from the cache
+					VesselData vd = v.KerbalismData();
+
+					// skip invalid vessels
+					if (!vd.IsSimulated) continue;
+
+					// obey message config
+					if (!v.KerbalismData().cfg_storm) continue;
+
+					// body is relevant
+					return true;
+				}
+			}
+			return false;
+		}
 
 
-        // return true if body is relevant to the player
-        // - body: reference body of the planetary system
-        static bool Body_is_relevant(CelestialBody body)
-        {
-            // [disabled]
-            // special case: home system is always relevant
-            // note: we deal with the case of a planet mod setting homebody as a moon
-            //if (body == Lib.PlanetarySystem(FlightGlobals.GetHomeBody())) return true;
+		// used by the engine to update one body per-step
+		public static bool Skip_body(CelestialBody body)
+		{
+			// skip all bodies if storms are disabled
+			if (!Features.SpaceWeather) return true;
 
-            // for each vessel
-            foreach (Vessel v in FlightGlobals.Vessels)
-            {
-                // if inside the system
-                if (Lib.GetParentPlanet(v.mainBody) == body)
-                {
-                    // get info from the cache
-                    VesselData vd = v.KerbalismData();
+			if (body == null)
+				return true;
 
-                    // skip invalid vessels
-                    if (!vd.IsSimulated) continue;
+			// skip the suns themselves
+			if (Lib.IsSun(body)) return true;
+			if (Lib.IsBarycenter(body)) return true;
 
-                    // obey message config
-                    if (!v.KerbalismData().cfg_storm) continue;
+			// only planetary-system roots (not moons); works with barycenter hierarchies
+			return body != Lib.GetParentPlanet(body);
+		}
 
-                    // body is relevant
-                    return true;
-                }
-            }
-            return false;
-        }
+		/// <summary>return true if a storm is incoming</summary>
+		public static bool Incoming(Vessel v)
+		{
+			foreach (KeyValuePair<CelestialBody, StormData> kv in GetAffectingStorms(v))
+			{
+				if (kv.Value != null && kv.Value.storm_state == 1 && kv.Value.display_warning)
+					return true;
+			}
+			return false;
+		}
 
-
-        // used by the engine to update one body per-step
-        public static bool Skip_body(CelestialBody body)
-        {
-            // skip all bodies if storms are disabled
-            if (!Features.SpaceWeather) return true;
-
-            // skip the sun
-            if (Lib.IsSun(body)) return true;
-
-            // skip moons
-            // note: referenceBody is never null here
-            if (!Lib.IsSun(body.referenceBody)) return true;
-
-            // do not skip the body
-            return false;
-        }
-
-        /// <summary>return true if a storm is incoming</summary>
-        public static bool Incoming(Vessel v)
-        {
-            var bd = Lib.IsSun(v.mainBody) ? v.KerbalismData().stormData : DB.Storm(Lib.GetParentPlanet(v.mainBody).name);
-            return bd.storm_state == 1 && bd.display_warning;
-        }
-
-        /// <summary>return true if a storm is in progress</summary>
-        public static bool InProgress(Vessel v)
-        {
-            var bd = Lib.IsSun(v.mainBody) ? v.KerbalismData().stormData : DB.Storm(Lib.GetParentPlanet(v.mainBody).name);
-            return bd.storm_state == 2;
-        }
-    }
+		/// <summary>return true if a storm is in progress</summary>
+		public static bool InProgress(Vessel v)
+		{
+			foreach (KeyValuePair<CelestialBody, StormData> kv in GetAffectingStorms(v))
+			{
+				if (kv.Value != null && kv.Value.storm_state == 2)
+					return true;
+			}
+			return false;
+		}
+	}
 
 } // KERBALISM

--- a/src/Kerbalism/Radiation/Storm.cs
+++ b/src/Kerbalism/Radiation/Storm.cs
@@ -310,10 +310,14 @@ namespace KERBALISM
 				return false;
 			if (Sim.suns.Count <= 1)
 				return true;
+
+			double primaryFluxProportion = vd.EnvMainSun?.FluxProportion ?? 0.0;
 			// Always track the local brightest / SOI star and any companion contributing meaningful flux
 			return sunInfo == vd.EnvMainSun
 				|| sunInfo.SunData.body == v.mainBody
-				|| sunInfo.FluxProportion >= MinCompanionFluxFraction;
+				// Both proportions have the same total-flux denominator, so this compares
+				// companion flux against primary flux rather than against total system flux.
+				|| sunInfo.FluxProportion >= primaryFluxProportion * MinCompanionFluxFraction;
 		}
 
 		/// <summary>Enumerate storm slots that can affect this vessel.</summary>

--- a/src/Kerbalism/Science/ExperimentRequirements.cs
+++ b/src/Kerbalism/Science/ExperimentRequirements.cs
@@ -475,17 +475,16 @@ namespace KERBALISM
 		}
 
 		/// <summary>
-		/// Heliocentric distance / home-body SMA. Requires sun SOI. Returns NaN when unavailable.
-		/// Uses FlightGlobals.GetHomeBody() so RSS/Kopernicus follow the configured home world.
-		/// EnvMainSun.Distance is surface distance; home SMA is center-to-center, so Radius is added.
+		/// Heliocentric distance / Sim.AU (home-star orbital scale). Requires sun SOI. Returns NaN when unavailable.
+		/// Uses the shared home-system AU so RSS/Kopernicus match solar-flux and comms calibration (#829 / #1080).
+		/// EnvMainSun.Distance is surface distance; AU is center-to-center, so Radius is added.
 		/// </summary>
 		private static double TestHomeStarDistanceAU(Vessel vessel, VesselData vd)
 		{
 			if (vessel == null || !Lib.IsSun(vessel.mainBody))
 				return double.NaN;
 
-			CelestialBody home = FlightGlobals.GetHomeBody();
-			if (home == null || home.orbit == null || home.orbit.semiMajorAxis <= 0.0)
+			if (Sim.AU <= 0.0)
 				return double.NaN;
 
 			double heliocentric;
@@ -494,7 +493,7 @@ namespace KERBALISM
 			else
 				heliocentric = Vector3d.Distance(Lib.VesselPosition(vessel), vessel.mainBody.position);
 
-			return heliocentric / home.orbit.semiMajorAxis;
+			return heliocentric / Sim.AU;
 		}
 
 		/// <summary>

--- a/src/Kerbalism/Sim.cs
+++ b/src/Kerbalism/Sim.cs
@@ -29,8 +29,7 @@ namespace KERBALISM
 					if (c.GetType().ToString().Contains("LightShifter"))
 					{
 						double starFluxAtHome = Lib.ReflectionValue<double>(c, "solarLuminosity");
-						double packSunAU = ReadLightShifterSunAU(c);
-						suns.Add(new SunData(body.flightGlobalsIndex, starFluxAtHome, packSunAU));
+						suns.Add(new SunData(body.flightGlobalsIndex, starFluxAtHome));
 					}
 				}
 			}
@@ -38,7 +37,7 @@ namespace KERBALISM
 			// if nothing was found, assume the sun is the stock default
 			if (suns.Count == 0)
 			{
-				suns.Add(new SunData(0, PhysicsGlobals.SolarLuminosityAtHome, 0.0));
+				suns.Add(new SunData(0, PhysicsGlobals.SolarLuminosityAtHome));
 			}
 
 			// Resolve home star / AU before converting pack "flux at 1 AU" into total luminosity (#829 / #1080)
@@ -595,17 +594,14 @@ namespace KERBALISM
 		{
 			public CelestialBody body;
 			public int bodyIndex;
-			/// <summary>Kopernicus Light.sunAU when present (pack author AU scale); 0 if unknown.</summary>
-			public readonly double packSunAU;
 			private double solarFluxAtAU;
 			private double solarFluxTotal;
 
-			public SunData(int bodyIndex, double solarFluxAtAU, double packSunAU = 0.0)
+			public SunData(int bodyIndex, double solarFluxAtAU)
 			{
 				body = FlightGlobals.Bodies[bodyIndex];
 				this.bodyIndex = bodyIndex;
 				this.solarFluxAtAU = solarFluxAtAU;
-				this.packSunAU = packSunAU;
 			}
 
 			// This must be called after home-system AU is resolved (#829 / #1080)
@@ -877,7 +873,8 @@ namespace KERBALISM
 			if (Lib.IsSun(refBody))
 				return refBody;
 			refBody = home.referenceBody;
-			while (refBody != null)
+			int remainingBodies = FlightGlobals.Bodies.Count + 1;
+			while (refBody != null && remainingBodies-- > 0)
 			{
 				if (Lib.IsSun(refBody))
 					return refBody;
@@ -905,22 +902,15 @@ namespace KERBALISM
 				return homeBodySma;
 			}
 
-			// 2) Pack-authored Light.sunAU on the home star
-			SunData homeStarData = suns.Find(s => s.body == star);
-			if (homeStarData != null && homeStarData.packSunAU > 0.0)
-			{
-				source = "LightShifter.sunAU";
-				return homeStarData.packSunAU;
-			}
-
-			// 3) SMA of the body in the home hierarchy that directly orbits the home star
+			// 2) SMA of the body in the home hierarchy that directly orbits the home star.
+			// Kopernicus Light.sunAU is intentionally not used here: it only scales brightnessCurve visuals.
 			if (TryGetDirectOrbitSMAAroundStar(home, star, out double sma) && sma > 0.0)
 			{
 				source = "orbit.semiMajorAxis";
 				return sma;
 			}
 
-			// 4) Last resort: instantaneous world distance (eccentricity / timing sensitive)
+			// 3) Last resort: instantaneous world distance (eccentricity / timing sensitive)
 			double instantaneous = (home.position - star.position).magnitude;
 			if (instantaneous > 0.0)
 			{
@@ -940,7 +930,8 @@ namespace KERBALISM
 				return false;
 
 			CelestialBody body = home;
-			while (body != null && body != star)
+			int remainingBodies = FlightGlobals.Bodies.Count + 1;
+			while (body != null && body != star && remainingBodies-- > 0)
 			{
 				if (body.referenceBody == star && body.orbit != null && body.orbit.semiMajorAxis > 0.0)
 				{
@@ -979,21 +970,6 @@ namespace KERBALISM
 				}
 			}
 			return best;
-		}
-
-		static double ReadLightShifterSunAU(object lightShifter)
-		{
-			try
-			{
-				FieldInfo fi = lightShifter.GetType().GetField("sunAU", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-				if (fi == null)
-					return 0.0;
-				return Convert.ToDouble(fi.GetValue(lightShifter));
-			}
-			catch
-			{
-				return 0.0;
-			}
 		}
 
 		static bool TryGetKopernicusLocalStar(CelestialBody body, out CelestialBody star)

--- a/src/Kerbalism/Sim.cs
+++ b/src/Kerbalism/Sim.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using UnityEngine;
 using System.Collections.Generic;
 
@@ -10,6 +11,12 @@ namespace KERBALISM
 		public static void Init()
 		{
 			Sim.SolarFluxAtHome = 0.0;
+			suns.Clear();
+			homeBody = null;
+			homeStar = null;
+			au = 0.0;
+			auSource = "unset";
+
 			// Search for "LightShifter" components, added by Kopernicus to bodies that are stars
 			foreach (CelestialBody body in FlightGlobals.Bodies)
 			{
@@ -22,8 +29,8 @@ namespace KERBALISM
 					if (c.GetType().ToString().Contains("LightShifter"))
 					{
 						double starFluxAtHome = Lib.ReflectionValue<double>(c, "solarLuminosity");
-						suns.Add(new SunData(body.flightGlobalsIndex, starFluxAtHome));
-						
+						double packSunAU = ReadLightShifterSunAU(c);
+						suns.Add(new SunData(body.flightGlobalsIndex, starFluxAtHome, packSunAU));
 					}
 				}
 			}
@@ -31,11 +38,13 @@ namespace KERBALISM
 			// if nothing was found, assume the sun is the stock default
 			if (suns.Count == 0)
 			{
-				suns.Add(new SunData(0, PhysicsGlobals.SolarLuminosityAtHome));
+				suns.Add(new SunData(0, PhysicsGlobals.SolarLuminosityAtHome, 0.0));
 			}
 
-			// calculate each sun total flux (must be done after the "suns" list is populated
-			CelestialBody home = FlightGlobals.GetHomeBody();
+			// Resolve home star / AU before converting pack "flux at 1 AU" into total luminosity (#829 / #1080)
+			ResolveHomeSystem();
+
+			// calculate each sun total flux (must be done after the "suns" list is populated and AU is known)
 			foreach (SunData sd in suns)
 			{
 				sd.InitSolarFluxTotal();
@@ -44,7 +53,7 @@ namespace KERBALISM
 				// that is higher than what is defined in PhysicsGlobals.SolarLuminosityAtHome.
 				// Can't remember what case exactly, if that code is causing issues,
 				// remove it and just always use PhysicsGlobals.SolarLuminosityAtHome
-				double distance = (home.position - sd.body.position).magnitude;
+				double distance = (HomeBody.position - sd.body.position).magnitude;
 				double sunSolarFluxAtHome = sd.SolarFlux(distance, false);
 				if (sunSolarFluxAtHome > 0.1)
 				{
@@ -586,20 +595,36 @@ namespace KERBALISM
 		{
 			public CelestialBody body;
 			public int bodyIndex;
+			/// <summary>Kopernicus Light.sunAU when present (pack author AU scale); 0 if unknown.</summary>
+			public readonly double packSunAU;
 			private double solarFluxAtAU;
 			private double solarFluxTotal;
 
-			public SunData(int bodyIndex, double solarFluxAtAU)
+			public SunData(int bodyIndex, double solarFluxAtAU, double packSunAU = 0.0)
 			{
 				body = FlightGlobals.Bodies[bodyIndex];
 				this.bodyIndex = bodyIndex;
 				this.solarFluxAtAU = solarFluxAtAU;
+				this.packSunAU = packSunAU;
 			}
 
-			// This must be called after "suns" SunData list is populated (because it use AU > Lib.IsSun)
+			// This must be called after home-system AU is resolved (#829 / #1080)
 			public void InitSolarFluxTotal()
 			{
 				this.solarFluxTotal = solarFluxAtAU * AU * AU * Math.PI * 4.0;
+			}
+
+			/// <summary>
+			/// Relative flux ranking proxy that does not require solarFluxTotal.
+			/// Safe to use while resolving HomeStar before InitSolarFluxTotal().
+			/// </summary>
+			public double FluxProxyAtDistance(double distanceFromCenter)
+			{
+				if (distanceFromCenter < 1.0)
+					distanceFromCenter = 1.0;
+				if (solarFluxTotal > 0.0)
+					return SolarFlux(distanceFromCenter, false);
+				return solarFluxAtAU / (distanceFromCenter * distanceFromCenter);
 			}
 
 			/// <summary>Luminosity in W/m² at the given distance from this sun/star</summary>
@@ -761,18 +786,266 @@ namespace KERBALISM
 		static readonly BodyCache bodyCache = new BodyCache();
 
 		static double au = 0.0;
-		/// <summary> Distance between the home body and its main sun</summary>
+		static string auSource = "unset";
+		static CelestialBody homeBody;
+		static CelestialBody homeStar;
+
+		/// <summary>Configured home world (FlightGlobals.GetHomeBody).</summary>
+		public static CelestialBody HomeBody
+		{
+			get
+			{
+				EnsureHomeSystem();
+				return homeBody;
+			}
+		}
+
+		/// <summary>Lighting home star used as the 1 AU reference (#829 / #1080).</summary>
+		public static CelestialBody HomeStar
+		{
+			get
+			{
+				EnsureHomeSystem();
+				return homeStar;
+			}
+		}
+
+		/// <summary>
+		/// Orbital scale distance between the home world and its lighting home star (1 AU).
+		/// Prefer SMA / Kopernicus pack values over instantaneous world positions.
+		/// </summary>
 		public static double AU
 		{
 			get
 			{
-				if (au == 0.0)
-				{
-					CelestialBody home = FlightGlobals.GetHomeBody();
-					au = (home.position - Lib.GetParentSun(home).position).magnitude;
-				}
+				EnsureHomeSystem();
 				return au;
 			}
+		}
+
+		/// <summary>How AU was resolved (for logs / diagnostics).</summary>
+		public static string AUSource
+		{
+			get
+			{
+				EnsureHomeSystem();
+				return auSource;
+			}
+		}
+
+		static void EnsureHomeSystem()
+		{
+			if (au > 0.0 && homeBody != null && homeStar != null)
+				return;
+			if (suns.Count == 0)
+			{
+				// Very early access before Init: stock-safe defaults
+				homeBody = FlightGlobals.GetHomeBody();
+				homeStar = FlightGlobals.Bodies[0];
+				au = homeBody != null && homeBody.orbit != null && homeBody.orbit.semiMajorAxis > 0.0
+					? homeBody.orbit.semiMajorAxis
+					: 13599840256.0;
+				auSource = "pre-init-fallback";
+				return;
+			}
+			ResolveHomeSystem();
+		}
+
+		/// <summary>
+		/// Resolve HomeBody / HomeStar / AU once suns are known.
+		/// AU is the scale Kopernicus luminosity is defined against (flux at 1 AU).
+		/// </summary>
+		static void ResolveHomeSystem()
+		{
+			homeBody = FlightGlobals.GetHomeBody();
+			homeStar = ResolveHomeStar(homeBody);
+			au = ResolveAU(homeBody, homeStar, out auSource);
+			Lib.Log($"Home system: body={homeBody.bodyName}, star={homeStar.bodyName}, AU={au.ToString("F0")} m (source={auSource})");
+		}
+
+		static CelestialBody ResolveHomeStar(CelestialBody home)
+		{
+			if (home == null)
+				return suns.Count > 0 ? suns[0].body : FlightGlobals.Bodies[0];
+
+			// 1) Kopernicus lighting local star (handles multi-star / PostSpawnOrbit hierarchies)
+			if (TryGetKopernicusLocalStar(home, out CelestialBody kopStar) && Lib.IsSun(kopStar))
+				return kopStar;
+
+			// 2) Climb referenceBody until a known LightShifter / stock sun
+			CelestialBody refBody = home;
+			if (Lib.IsSun(refBody))
+				return refBody;
+			refBody = home.referenceBody;
+			while (refBody != null)
+			{
+				if (Lib.IsSun(refBody))
+					return refBody;
+				refBody = refBody.referenceBody;
+			}
+
+			// 3) Brightest known star at the home world (never silently assume Bodies[0])
+			CelestialBody brightest = BrightestSunAt(home.position);
+			if (brightest != null)
+			{
+				Lib.Log($"HomeStar: referenceBody climb found no sun; using brightest star at home ({brightest.bodyName})", Lib.LogLevel.Warning);
+				return brightest;
+			}
+
+			Lib.Log("HomeStar: falling back to Bodies[0]", Lib.LogLevel.Warning);
+			return FlightGlobals.Bodies[0];
+		}
+
+		static double ResolveAU(CelestialBody home, CelestialBody star, out string source)
+		{
+			// 1) Kopernicus HomeBodySMA — same quantity Kopernicus uses for SolarLuminosityAtHome
+			if (TryGetKopernicusHomeBodySMA(out double homeBodySma) && homeBodySma > 0.0)
+			{
+				source = "Kopernicus.HomeBodySMA";
+				return homeBodySma;
+			}
+
+			// 2) Pack-authored Light.sunAU on the home star
+			SunData homeStarData = suns.Find(s => s.body == star);
+			if (homeStarData != null && homeStarData.packSunAU > 0.0)
+			{
+				source = "LightShifter.sunAU";
+				return homeStarData.packSunAU;
+			}
+
+			// 3) SMA of the body in the home hierarchy that directly orbits the home star
+			if (TryGetDirectOrbitSMAAroundStar(home, star, out double sma) && sma > 0.0)
+			{
+				source = "orbit.semiMajorAxis";
+				return sma;
+			}
+
+			// 4) Last resort: instantaneous world distance (eccentricity / timing sensitive)
+			double instantaneous = (home.position - star.position).magnitude;
+			if (instantaneous > 0.0)
+			{
+				source = "instantaneous-position";
+				Lib.Log($"AU: using instantaneous home-star distance {instantaneous.ToString("F0")} m", Lib.LogLevel.Warning);
+				return instantaneous;
+			}
+
+			source = "stock-default";
+			return 13599840256.0;
+		}
+
+		static bool TryGetDirectOrbitSMAAroundStar(CelestialBody home, CelestialBody star, out double sma)
+		{
+			sma = 0.0;
+			if (home == null || star == null)
+				return false;
+
+			CelestialBody body = home;
+			while (body != null && body != star)
+			{
+				if (body.referenceBody == star && body.orbit != null && body.orbit.semiMajorAxis > 0.0)
+				{
+					sma = body.orbit.semiMajorAxis;
+					return true;
+				}
+				body = body.referenceBody;
+			}
+
+			// Home itself may orbit the star
+			if (home.orbit != null && home.orbit.referenceBody == star && home.orbit.semiMajorAxis > 0.0)
+			{
+				sma = home.orbit.semiMajorAxis;
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>Star with the highest flux proxy at a world position.</summary>
+		public static CelestialBody BrightestSunAt(Vector3d worldPos)
+		{
+			if (suns.Count == 0)
+				return null;
+
+			CelestialBody best = null;
+			double bestFlux = double.NegativeInfinity;
+			foreach (SunData sd in suns)
+			{
+				double dist = Vector3d.Distance(worldPos, sd.body.position);
+				double flux = sd.FluxProxyAtDistance(dist);
+				if (flux > bestFlux)
+				{
+					bestFlux = flux;
+					best = sd.body;
+				}
+			}
+			return best;
+		}
+
+		static double ReadLightShifterSunAU(object lightShifter)
+		{
+			try
+			{
+				FieldInfo fi = lightShifter.GetType().GetField("sunAU", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+				if (fi == null)
+					return 0.0;
+				return Convert.ToDouble(fi.GetValue(lightShifter));
+			}
+			catch
+			{
+				return 0.0;
+			}
+		}
+
+		static bool TryGetKopernicusLocalStar(CelestialBody body, out CelestialBody star)
+		{
+			star = null;
+			try
+			{
+				foreach (var a in AssemblyLoader.loadedAssemblies)
+				{
+					if (!string.Equals(a.name, "Kopernicus", StringComparison.OrdinalIgnoreCase))
+						continue;
+					Type t = a.assembly.GetType("Kopernicus.Components.KopernicusStar");
+					if (t == null)
+						continue;
+					MethodInfo mi = t.GetMethod("GetLocalStar", BindingFlags.Public | BindingFlags.Static, null, new Type[] { typeof(CelestialBody) }, null);
+					if (mi == null)
+						continue;
+					star = mi.Invoke(null, new object[] { body }) as CelestialBody;
+					return star != null;
+				}
+			}
+			catch (Exception e)
+			{
+				Lib.Log("Kopernicus GetLocalStar reflection failed: " + e.Message, Lib.LogLevel.Warning);
+			}
+			return false;
+		}
+
+		static bool TryGetKopernicusHomeBodySMA(out double sma)
+		{
+			sma = 0.0;
+			try
+			{
+				foreach (var a in AssemblyLoader.loadedAssemblies)
+				{
+					if (!string.Equals(a.name, "Kopernicus", StringComparison.OrdinalIgnoreCase))
+						continue;
+					Type t = a.assembly.GetType("Kopernicus.Components.KopernicusStar");
+					if (t == null)
+						continue;
+					FieldInfo fi = t.GetField("HomeBodySMA", BindingFlags.Public | BindingFlags.Static);
+					if (fi == null)
+						continue;
+					sma = Convert.ToDouble(fi.GetValue(null));
+					return sma > 0.0;
+				}
+			}
+			catch (Exception e)
+			{
+				Lib.Log("Kopernicus HomeBodySMA reflection failed: " + e.Message, Lib.LogLevel.Warning);
+			}
+			return false;
 		}
 
 		// get distance from the sun
@@ -1504,24 +1777,29 @@ namespace KERBALISM
 		public static double Graviolis(Vessel v)
 		{
 			double dist = Vector3d.Distance(v.GetWorldPos3D(), Lib.GetParentSun(v.mainBody).position);
-			double au = dist / FlightGlobals.GetHomeBody().orbit.semiMajorAxis;
-			return 1.0 - Math.Min(AU, 1.0); // 0 at 1AU -> 1 at sun position
+			double distanceAU = dist / AU;
+			return 1.0 - Math.Min(distanceAU, 1.0); // 0 at 1AU -> 1 at sun position
 		}
 		#endregion
 
 		#region SIGNAL
-		// Fallback used when auto-calc fails (DSN cannot reach 2 AU, etc). Matches pre-comms-refactor stock ~6.
+		// Fallback used when auto-calc fails (DSN cannot reach a usable calibration point, etc). Matches pre-comms-refactor stock ~6.
 		private const double DefaultDataRateDampingExponent = 6.0;
 		private const double DefaultDataRateDampingExponentRT = 2.4;
+		// Strength must be comfortably inside (0,1) so Math.Log is well-conditioned (#1031 / #721).
+		private const double MinCalibrationStrength = 1e-3;
+		private const double MaxCalibrationStrength = 0.999;
 
-		private static double dampingExponent = 0;
+		private static double dampingExponentCommNet = 0;
+		private static double dampingExponentRT = 0;
+
 		public static double DataRateDampingExponent
 		{
 			get
 			{
 				// NaN != 0 is true, so explicitly reject a cached failed calculation
-				if (dampingExponent != 0 && !double.IsNaN(dampingExponent) && !double.IsInfinity(dampingExponent))
-					return dampingExponent;
+				if (dampingExponentCommNet != 0 && !double.IsNaN(dampingExponentCommNet) && !double.IsInfinity(dampingExponentCommNet))
+					return dampingExponentCommNet;
 
 				if (Settings.DampingExponentOverride != 0)
 					return Settings.DampingExponentOverride;
@@ -1551,40 +1829,35 @@ namespace KERBALISM
 				// The problem is, we don't know which solar system we'll be in, and how big it will be.
 				// Popular systems like JNSQ are 2.7 times bigger than stock, RSS is 10 times bigger.
 				// So we try to find a damping exponent that gives good results for the solar system we're in,
-				// based on the distance of the home planet to the sun (1 AU).
+				// based on the distance of the home planet to the sun (1 AU). When 2 AU is beyond DSN
+				// range we walk the calibration point inward instead of immediately falling back (#1080).
 
-				// range of DSN at max. level
-				var maxDsnRange = GameVariables.Instance.GetDSNRange(1f);
-
-				// signal strength at ~ average earth - mars distance
-				var strengthAt2AU = SignalStrength(maxDsnRange, 2 * AU);
-
-				// For our estimation, we assume a base rate similar to the stock communotron 88-88
-				var baseRate = 0.48;
-
-				// At 2 AU, this is the rate we want to get out of it
+				double maxDsnRange = GameVariables.Instance.GetDSNRange(1f);
+				const double preferredAuMultiple = 2.0;
+				const double baseRate = 0.48;
 				// Value selected so we match pre-comms refactor damping exponent of ~6 in stock
-				var desiredRateAt2AU = 0.3925;
+				const double desiredRateAtPreferred = 0.3925;
 
-				// Math.Log(x, base) requires base in (0, 1) U (1, +inf). strengthAt2AU is in [0, 1];
-				// when DSN cannot reach 2 AU, strength is 0 and Log -> NaN (see #1031, also #721).
-				bool canCalculateExponent = strengthAt2AU > 0.0 && strengthAt2AU < 1.0;
-				if (canCalculateExponent)
-					dampingExponent = Math.Log(desiredRateAt2AU / baseRate, strengthAt2AU);
-				else
-					dampingExponent = DefaultDataRateDampingExponent;
-
-				if (!canCalculateExponent || double.IsNaN(dampingExponent) || double.IsInfinity(dampingExponent) || dampingExponent <= 0.0)
+				if (!TryCalibrateDampingExponent(
+					maxDsnRange,
+					preferredAuMultiple,
+					baseRate,
+					desiredRateAtPreferred,
+					DefaultDataRateDampingExponent,
+					out dampingExponentCommNet,
+					out double calDistance,
+					out double strength,
+					out string calSource))
 				{
-					Lib.Log($"DataRateDampingExponent calc failed (max. DSN range: {maxDsnRange.ToString("F0")}, strength at 2 AU: {strengthAt2AU.ToString("F3")}), using fallback {DefaultDataRateDampingExponent}");
-					dampingExponent = DefaultDataRateDampingExponent;
+					Lib.Log($"DataRateDampingExponent calc failed (max. DSN range: {maxDsnRange.ToString("F0")}, AU: {AU.ToString("F0")}, homeStar: {HomeStar.bodyName}, source: {calSource}), using fallback {DefaultDataRateDampingExponent}");
+					dampingExponentCommNet = DefaultDataRateDampingExponent;
 				}
 				else
 				{
-					Lib.Log($"Calculated DataRateDampingExponent: {dampingExponent.ToString("F4")} (max. DSN range: {maxDsnRange.ToString("F0")}, strength at 2 AU: {strengthAt2AU.ToString("F3")})");
+					Lib.Log($"Calculated DataRateDampingExponent: {dampingExponentCommNet.ToString("F4")} (max. DSN range: {maxDsnRange.ToString("F0")}, cal: {(calDistance / AU).ToString("F2")} AU / {calDistance.ToString("F0")} m, strength: {strength.ToString("F4")}, AU: {AU.ToString("F0")} via {AUSource}, homeStar: {HomeStar.bodyName}, {calSource})");
 				}
 
-				return dampingExponent;
+				return dampingExponentCommNet;
 			}
 		}
 
@@ -1592,8 +1865,8 @@ namespace KERBALISM
 		{
 			get
 			{
-				if (dampingExponent != 0 && !double.IsNaN(dampingExponent) && !double.IsInfinity(dampingExponent))
-					return dampingExponent;
+				if (dampingExponentRT != 0 && !double.IsNaN(dampingExponentRT) && !double.IsInfinity(dampingExponentRT))
+					return dampingExponentRT;
 
 				if (Settings.DampingExponentOverride != 0)
 					return Settings.DampingExponentOverride;
@@ -1622,35 +1895,99 @@ namespace KERBALISM
 
 				// For our estimation, we assume a base reach similar to the Reflectron KR-14 that has
 				// similar specs to Mars Reconnaissance Orbiter
-				double testRange = 60000000000.0; // 60Gm
+				const double testRange = 60000000000.0; // 60Gm
+				// signal strength at ~ farthest earth - mars distance, Duna is at 2.53 au with stock ksp solar system
+				const double preferredAuMultiple = 2.53;
+				const double baseRate = 0.4815;
+				const double desiredRateAtPreferred = 0.05;
 
-				// signal strength at ~ farthest earth - mars distance, Duna is at 2.53 au with stock ksp solar sytem
-				double strengthAt2AU = SignalStrength(testRange, 2.53 * AU);	// 34.4 Gm w stock solar system
-
-				// For our estimation, we assume a base rate similar to the Reflectron KR-14
-				double baseRate = 0.4815;
-
-				// At 2 AU, this is the rate we want to get out of it
-				double desiredRateAt2AU = 0.05;
-
-				// dataRate = baseRate * (strengthAt2AU ^ exponent)
-				// so...
-				// exponent = log_strengthAt2AU(dataRate / baseRate)
-				bool canCalculateExponent = strengthAt2AU > 0.0 && strengthAt2AU < 1.0;
-				if (canCalculateExponent)
-					dampingExponent = Math.Log(desiredRateAt2AU / baseRate, strengthAt2AU);
-				else
-					dampingExponent = DefaultDataRateDampingExponentRT;
-
-				// 2.4 seems good for RemoteTech (#914); same failure mode as CommNet (#1031)
-				if (!canCalculateExponent || double.IsNaN(dampingExponent) || double.IsInfinity(dampingExponent) || dampingExponent <= 0.0)
+				if (!TryCalibrateDampingExponent(
+					testRange,
+					preferredAuMultiple,
+					baseRate,
+					desiredRateAtPreferred,
+					DefaultDataRateDampingExponentRT,
+					out dampingExponentRT,
+					out double calDistance,
+					out double strength,
+					out string calSource))
 				{
-					Lib.Log($"DataRateDampingExponentRT calc failed (strength at 2.53 AU: {strengthAt2AU.ToString("F3")}), using fallback {DefaultDataRateDampingExponentRT}");
-					dampingExponent = DefaultDataRateDampingExponentRT;
+					// 2.4 seems good for RemoteTech (#914); same failure mode as CommNet (#1031)
+					Lib.Log($"DataRateDampingExponentRT calc failed (AU: {AU.ToString("F0")}, homeStar: {HomeStar.bodyName}, source: {calSource}), using fallback {DefaultDataRateDampingExponentRT}");
+					dampingExponentRT = DefaultDataRateDampingExponentRT;
+				}
+				else
+				{
+					Lib.Log($"Calculated DataRateDampingExponentRT: {dampingExponentRT.ToString("F4")} (cal: {(calDistance / AU).ToString("F2")} AU, strength: {strength.ToString("F4")}, AU: {AU.ToString("F0")} via {AUSource}, {calSource})");
 				}
 
-				return dampingExponent;
+				return dampingExponentRT;
 			}
+		}
+
+		/// <summary>
+		/// Invert rate = baseRate * strength(distance)^k at an adaptive calibration distance (#1080).
+		/// Prefers preferredAuMultiple * AU; if strength is unusable there, walks inward and scales the
+		/// target attenuation so closer calibration points do not collapse k toward zero.
+		/// </summary>
+		static bool TryCalibrateDampingExponent(
+			double maxRange,
+			double preferredAuMultiple,
+			double baseRate,
+			double desiredRateAtPreferred,
+			double fallback,
+			out double exponent,
+			out double calDistance,
+			out double strength,
+			out string source)
+		{
+			exponent = fallback;
+			calDistance = preferredAuMultiple * AU;
+			strength = 0.0;
+			source = "none";
+
+			if (AU <= 0.0 || maxRange <= 0.0 || baseRate <= 0.0 || desiredRateAtPreferred <= 0.0)
+			{
+				source = "invalid-inputs";
+				return false;
+			}
+
+			double desiredRatioAtPreferred = desiredRateAtPreferred / baseRate;
+			if (desiredRatioAtPreferred <= 0.0 || desiredRatioAtPreferred >= 1.0)
+			{
+				source = "invalid-desired-ratio";
+				return false;
+			}
+
+			// Preferred point first (stock / JNSQ path), then progressively closer AU multiples.
+			double[] auMultiples = { preferredAuMultiple, 1.5, 1.0, 0.75, 0.5, 0.25 };
+			foreach (double multiple in auMultiples)
+			{
+				if (multiple > preferredAuMultiple)
+					continue;
+
+				calDistance = multiple * AU;
+				if (calDistance <= 0.0 || calDistance >= maxRange)
+					continue;
+
+				strength = SignalStrength(maxRange, calDistance);
+				if (strength < MinCalibrationStrength || strength > MaxCalibrationStrength)
+					continue;
+
+				// At the preferred multiple keep the historical target rate. Closer points use a milder
+				// target attenuation (ratio -> 1 as multiple -> 0) so k stays meaningful.
+				double t = multiple / preferredAuMultiple;
+				double desiredRatio = Math.Pow(desiredRatioAtPreferred, t);
+				exponent = Math.Log(desiredRatio, strength);
+				if (double.IsNaN(exponent) || double.IsInfinity(exponent) || exponent <= 0.0)
+					continue;
+
+				source = multiple == preferredAuMultiple ? "preferred-AU" : $"adaptive-{multiple.ToString("F2")}xAU";
+				return true;
+			}
+
+			source = "no-usable-strength";
+			return false;
 		}
 
 		public static double SignalStrength(double maxRange, double distance)

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -164,7 +164,9 @@ namespace KERBALISM
 					Cache.Init();
 					ResourceCache.Init();
 
-					// prepare storm data
+					// prepare storm data (rebuild each save-game init; static list must not accumulate)
+					storm_bodies.Clear();
+					storm_index = 0;
 					foreach (CelestialBody body in FlightGlobals.Bodies)
 					{
 						if (Storm.Skip_body(body))

--- a/src/Kerbalism/System/Kerbalism.cs
+++ b/src/Kerbalism/System/Kerbalism.cs
@@ -915,12 +915,18 @@ namespace KERBALISM
 		}
 
 		/// <summary>true when an IMGUI or uGUI text field has keyboard focus</summary>
+		/// <remarks>
+		/// Do not use InputLockManager.KEYBOARDINPUT here: map view and several UI/mod
+		/// locks set that bit without a text field focused, which blocked Body Info (B)
+		/// over empty map space while still allowing it over toolbars/windows.
+		/// </remarks>
 		private static bool IsTextInputFocused()
 		{
-			if (global::InputLockManager.IsLocked(ControlTypes.KEYBOARDINPUT))
+			// Named IMGUI text fields (when a control called GUI.SetNextControlName is focused)
+			if (!string.IsNullOrEmpty(GUI.GetNameOfFocusedControl()))
 				return true;
 
-			// uGUI / TMP input fields used by some mods
+			// uGUI / TMP input fields used by stock rename dialogs and some mods
 			UnityEngine.EventSystems.EventSystem es = UnityEngine.EventSystems.EventSystem.current;
 			if (es == null || es.currentSelectedGameObject == null)
 				return false;

--- a/src/Kerbalism/UI/Monitor.cs
+++ b/src/Kerbalism/UI/Monitor.cs
@@ -497,21 +497,25 @@ namespace KERBALISM
 
 		void Problem_storm(Vessel v, ref List<Texture2D> icons, ref List<string> tooltips)
 		{
-			if (Storm.Incoming(v))
+			if (Storm.TryGetPrimaryStorm(v, out StormData inbound, out CelestialBody inboundStar, 1))
 			{
 				icons.Add(Textures.storm_yellow);
 
-				var bd = Lib.IsSun(v.mainBody) ? v.KerbalismData().stormData : DB.Storm(Lib.GetParentPlanet(v.mainBody).name);
-				var tti = bd.storm_time - Planetarium.GetUniversalTime();
-				tooltips.Add(Lib.BuildString(Lib.Color(Local.Monitor_ejectionincoming, Lib.Kolor.Orange), "\n<i>", Local.Monitor_TimetoimpactCoronalmass, Lib.HumanReadableDuration(tti), "</i>"));//"Coronal mass ejection incoming"Time to impact:
+				var tti = inbound.storm_time - Planetarium.GetUniversalTime();
+				string tip = Lib.BuildString(Lib.Color(Local.Monitor_ejectionincoming, Lib.Kolor.Orange), "\n<i>", Local.Monitor_TimetoimpactCoronalmass, Lib.HumanReadableDuration(tti), "</i>");
+				if (Sim.suns.Count > 1 && inboundStar != null)
+					tip = Lib.BuildString(tip, "\n<i>", inboundStar.bodyName, "</i>");
+				tooltips.Add(tip);//"Coronal mass ejection incoming"Time to impact:
 			}
-			if (Storm.InProgress(v))
+			if (Storm.TryGetPrimaryStorm(v, out StormData active, out CelestialBody activeStar, 2))
 			{
 				icons.Add(Textures.storm_red);
 
-				var bd = Lib.IsSun(v.mainBody) ? v.KerbalismData().stormData : DB.Storm(Lib.GetParentPlanet(v.mainBody).name);
-				var remainingDuration = bd.storm_time + bd.displayed_duration - Planetarium.GetUniversalTime();
-				tooltips.Add(Lib.BuildString(Lib.Color(Local.Monitor_Solarstorminprogress, Lib.Kolor.Red), "\n<i>", Local.Monitor_SolarstormRemaining, Lib.HumanReadableDuration(remainingDuration), "</i>"));//"Solar storm in progress"Remaining duration:
+				var remainingDuration = active.storm_time + active.displayed_duration - Planetarium.GetUniversalTime();
+				string tip = Lib.BuildString(Lib.Color(Local.Monitor_Solarstorminprogress, Lib.Kolor.Red), "\n<i>", Local.Monitor_SolarstormRemaining, Lib.HumanReadableDuration(remainingDuration), "</i>");
+				if (Sim.suns.Count > 1 && activeStar != null)
+					tip = Lib.BuildString(tip, "\n<i>", activeStar.bodyName, "</i>");
+				tooltips.Add(tip);//"Solar storm in progress"Remaining duration:
 			}
 		}
 


### PR DESCRIPTION
## Description
- Resolve the lighting home star and 1 AU from orbital hierarchy / SMA instead of fragile instantaneous distance, so solar flux and experiment home-star distances stay correct on non-central / multi-star packs (#829).
- Calibrate CommNet / RemoteTech data-rate damping at a reachable AU multiple (instead of a fixed ~2 AU point that often yields strength 0), with `DampingExponentOverride` still available (#1080).
- Add multi-star solar storm support: CME generation per source star, per-star vessel tracking (save-compatible), barycenter SOI handling, and storm radiation summed by per-star flux × activity.
- Fix companion CME eligibility to compare against primary-star flux share, and fix Body Info `B` being blocked over empty map space by overly broad `KEYBOARDINPUT` locks.
