### PR TITLE
Add support for biome values to science situation

### DIFF
--- a/src/Kerbalism/Science/ScienceSituation.cs
+++ b/src/Kerbalism/Science/ScienceSituation.cs
@@ -113,7 +113,7 @@ namespace KERBALISM
 			return true;
 		}
 
-		public static float BodyMultiplier(this ScienceSituation situation, CelestialBody body)
+		public static float BodyMultiplier(this ScienceSituation situation, CelestialBody body, CBAttributeMapSO.MapAttribute biome = null)
 		{
 			float result = 0f;
 			switch (situation)
@@ -141,6 +141,14 @@ namespace KERBALISM
 			{
 				Lib.Log("Science: invalid/unknown situation " + situation.ToString(), Lib.LogLevel.Error);
 				return 1f; // returning 0 will result in NaN values
+			}
+
+			if (biome != null)
+			{
+				if (biome.value > 0f)
+				{
+					result *= biome.value;
+				}
 			}
 			return result;
 		}

--- a/src/Kerbalism/Science/Situation.cs
+++ b/src/Kerbalism/Science/Situation.cs
@@ -132,7 +132,7 @@ namespace KERBALISM
 			return Lib.BuildString(BodyName, ScienceSituationName, BiomeName);
 		}
 
-		public virtual double SituationMultiplier => Body != null ? ScienceSituation.BodyMultiplier(Body) : 1.0;
+		public virtual double SituationMultiplier => Body != null ? ScienceSituation.BodyMultiplier(Body, Biome) : 1.0;
 
 		public virtual string GetTitleForExperiment(ExperimentInfo expInfo)
 		{


### PR DESCRIPTION
Add support for per-biome science multipliers allowed by Kopernicus. Many planet packs modify the biome science multiplier.

Testing:
Gave Oceans a multiplier of 0.5, Hot Deserts 0.25.
<img width="698" height="325" alt="Kerbalism" src="https://github.com/user-attachments/assets/5c8c5661-8ebf-45cb-9ea5-9e772c51143d" />
