### PR TITLE
 Fix KPBS greenhouse crew capacity, IVA deploy, and Pod ECLSS

### DIFF
--- a/GameData/KerbalismConfig/Support/PlanetaryBaseInc.cfg
+++ b/GameData/KerbalismConfig/Support/PlanetaryBaseInc.cfg
@@ -27,3 +27,55 @@
 
 	@tags ^= :$: comfort:
 }
+
+// ============================================================================
+// Greenhouse crew / IVA / ECLSS
+//
+// KPBS ProfileDefault zeroes CrewCapacity and deletes PlanetaryModule before Kerbalism,
+// then wires Greenhouse_Deploy to Greenhouse.shutters. That skips the generic Pod ECLSS
+// (CrewCapacity was 0 at FOR[KerbalismDefault]), leaves seats without capacity, and only
+// plays the exterior anim — IVA stays packed and FreeIva requireDeploy cannot see
+// PlanetaryModule.
+//
+// Restore capacity early so Habitat + Pod life support apply, then after KPBS's own
+// FOR[PlanetarySurfaceStructures] pass: restore PlanetaryModule, stop Greenhouse from
+// owning the deploy anim, and drop the undersized / duplicate habitat + pressure control
+// KPBS re-adds.
+// ============================================================================
+
+@PART[KKAOSS_Greenhouse_g]:NEEDS[PlanetaryBaseInc,ProfileDefault]:BEFORE[KerbalismDefault]
+{
+	@CrewCapacity = 2
+}
+
+@PART[KKAOSS_Greenhouse_g]:NEEDS[PlanetaryBaseInc,ProfileDefault]:AFTER[PlanetarySurfaceStructures]
+{
+	@CrewCapacity = 2
+
+	@MODULE[Greenhouse]
+	{
+		@shutters =
+	}
+
+	// KPBS adds a second Habitat and a 0.2143-capacity pressure controller on top of Pod ECLSS
+	!MODULE[Habitat],* {}
+	!MODULE[ProcessController]:HAS[#resource[_PressureControl],#capacity[0.2143]] {}
+	!MODULE[PlanetaryModule],* {}
+
+	MODULE
+	{
+		name = Habitat
+		toggle = false
+	}
+
+	MODULE
+	{
+		name = PlanetaryModule
+		animationName = Greenhouse_Deploy
+		startEventGUIName = #LOC_KPBS.planetarymodule.deploy
+		endEventGUIName = #LOC_KPBS.planetarymodule.retract
+		additionalInternalName = Greenhouse_g_internal_jsiatp
+		crewCapacityDeployed = 2
+		crewCapcityRetracted = 0
+	}
+}


### PR DESCRIPTION
## Description
- Restore KPBS greenhouse crew capacity and PlanetaryModule so IVA deploys with the exterior
- Let generic Pod ECLSS apply; remove the undersized/duplicate habitat and pressure control KPBS re-adds
