### PR TITLE
Gate PCSH fission UI on meltdown config; add Emitter emitterId for Configure

### DIFF
--- a/docs/tech-guide/part-modules/configure.en.md
+++ b/docs/tech-guide/part-modules/configure.en.md
@@ -27,7 +27,7 @@ A **MODULE** sub-node, inside a *SETUP* node, associates a specific module (that
 | PROPERTY | DESCRIPTION |
 | --- | --- |
 | type | module name |
-| id_field/id_value | the name of a field in the module definition and its value respectively, used to identify a module in particular if multiple ones of the same type exist in the part |
-| id_index | the zero-based index, selecting a specific module of *type* among all the ones present in the part |
+| id_field/id_value | the name of a field in the module definition and its value respectively, used to identify a module in particular if multiple ones of the same type exist in the part (for Emitter use `id_field = emitterId`) |
+| id_index | the zero-based index, selecting a specific module of *type* among all the ones present in the part (order-dependent; prefer a stable `id_field` when other mods may also patch the part) |
 
 A **RESOURCE** sub-node, inside a *SETUP* node, adds a specific resource amount and/or capacity to the setup. The resource definition is the same as the stock one you are familiar with. The resource doesn't need to be defined in the part directly but only in the setup. When the setup is selected, the resource will be added to the part. If the part already contain the same resource, the amount and/or capacity will simply increase when the setup is selected.

--- a/docs/tech-guide/part-modules/emitter.en.md
+++ b/docs/tech-guide/part-modules/emitter.en.md
@@ -7,3 +7,17 @@ The part emits radiation. Use a negative radiation value for absorption.
 | ec_rate | EC consumption rate per-second (optional) |  |
 | toggle | true if the effect can be toggled on/off | false |
 | active | name of animation to play when enabling/disabling |  |
+| emitterId | stable MM-safe id (no `#`); use with Configure `id_field = emitterId` when a part has multiple Emitters |  |
+
+When several Emitters share a part (for example one per Configure setup / reactor recipe), give each a unique `emitterId` and reference it from the setup:
+
+```
+MODULE
+{
+	type = Emitter
+	id_field = emitterId
+	id_value = my-reactor-uranium
+}
+```
+
+Prefer `emitterId` over `id_index`: module order is fragile when other mods also patch the part.

--- a/src/Kerbalism/Automation/Computer.cs
+++ b/src/Kerbalism/Automation/Computer.cs
@@ -252,7 +252,7 @@ namespace KERBALISM
 							ProcessControllerSystemHeat heatProcess = m as ProcessControllerSystemHeat;
 							if (heatProcess == null || !m.isEnabled)
 								continue;
-							if (heatProcess.resource == "_Nukereactor" && heatProcess.toggle)
+							if (heatProcess.IsFissionReactor() && heatProcess.toggle)
 								device = new FissionReactorProcessDevice(heatProcess);
 							else if (heatProcess.toggle)
 								device = new SystemHeatProcessDevice(heatProcess);
@@ -337,7 +337,7 @@ namespace KERBALISM
 								ProcessControllerSystemHeat heatProcess = module_prefab as ProcessControllerSystemHeat;
 								if (heatProcess == null || !heatProcess.toggle)
 									continue;
-								if (heatProcess.resource == "_Nukereactor")
+								if (heatProcess.IsFissionReactor())
 									device = new ProtoFissionReactorProcessDevice(heatProcess, p, m);
 								else
 									device = new ProtoSystemHeatProcessDevice(heatProcess, p, m);

--- a/src/Kerbalism/Integrations/SystemHeat/Process/ProcessControllerSystemHeat.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/Process/ProcessControllerSystemHeat.cs
@@ -50,7 +50,15 @@ namespace KERBALISM
 
 		private double ReactorPowerScale => IsRunning() ? Mathf.Clamp(CurrentPowerPercent, 0f, 100f) / 100.0 : 0.0;
 
-		private bool IsFissionReactor() => resource == "_Nukereactor";
+		/// <summary>
+		/// True when core-damage thresholds are configured on this module.
+		/// Gate is independent of the process pseudo-resource name so multi-recipe
+		/// reactors can keep distinct modifiers and still get fission UI / damage.
+		/// </summary>
+		internal static bool HasCoreDamageConfig(float meltdownTemperature, float maximumTemperature)
+			=> meltdownTemperature > 0f && maximumTemperature > meltdownTemperature;
+
+		internal bool IsFissionReactor() => HasCoreDamageConfig(meltdownTemperature, MaximumTemperature);
 
 		private float EffectiveShutdownTemperature() => IsFissionReactor() ? CurrentSafetyOverride : shutdownTemperature;
 
@@ -742,7 +750,7 @@ namespace KERBALISM
 
 		private void ApplyCoreDamage(float loopTemperature, float elapsedSeconds)
 		{
-			if (!IsFissionReactor() || meltdownTemperature <= 0f || elapsedSeconds <= 0f)
+			if (!IsFissionReactor() || elapsedSeconds <= 0f)
 				return;
 
 			CoreDamage = SystemHeatEditorSimulation.AccumulateCoreDamage(
@@ -810,7 +818,8 @@ namespace KERBALISM
 			List<KeyValuePair<string, double>> resourceChangeRequest,
 			double elapsed_s)
 		{
-			if (Lib.Proto.GetString(moduleSnapshot, "resource") == "_Nukereactor")
+			ProcessControllerSystemHeat heatPrefab = protoPartModule as ProcessControllerSystemHeat;
+			if (heatPrefab != null && heatPrefab.IsFissionReactor())
 				SystemHeatBackgroundThermal.SyncFrozenProcessReactor(v, partSnapshot, moduleSnapshot, protoPartModule, protoPart, elapsed_s);
 			else
 				SystemHeatBackgroundThermal.TryRun(v, elapsed_s);

--- a/src/Kerbalism/Integrations/SystemHeat/Process/SystemHeatProcessHarmony.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/Process/SystemHeatProcessHarmony.cs
@@ -78,7 +78,7 @@ namespace KERBALISM
 				{
 					foreach (PartModule module in part.Modules)
 					{
-						if (module is ProcessControllerSystemHeat heat && heat.resource == "_Nukereactor")
+						if (module is ProcessControllerSystemHeat heat && heat.IsFissionReactor())
 							heat.SyncPlannerPseudoResource();
 					}
 				}

--- a/src/Kerbalism/Integrations/SystemHeat/SystemHeatBackgroundThermal.cs
+++ b/src/Kerbalism/Integrations/SystemHeat/SystemHeatBackgroundThermal.cs
@@ -70,7 +70,7 @@ namespace KERBALISM
 		{
 			foreach (ProcessControllerSystemHeat process in part.FindModulesImplementing<ProcessControllerSystemHeat>())
 			{
-				if (process == null || process.resource != "_Nukereactor")
+				if (process == null || !process.IsFissionReactor())
 					continue;
 
 				ProtoPartModuleSnapshot protoModule = FindMatchingProcessModuleSnapshot(part.protoPartSnapshot, process.resource);
@@ -82,7 +82,7 @@ namespace KERBALISM
 				Lib.Proto.Set(protoModule, nameof(ProcessControllerSystemHeat.CurrentPowerPercent), process.CurrentPowerPercent);
 				Lib.Proto.Set(protoModule, nameof(ProcessControllerSystemHeat.CoreDamage), process.CoreDamage);
 
-				if (!part.Resources.Contains(process.resource))
+				if (string.IsNullOrEmpty(process.resource) || !part.Resources.Contains(process.resource))
 					continue;
 
 				PartResource pseudo = part.Resources[process.resource];
@@ -128,14 +128,17 @@ namespace KERBALISM
 
 				foreach (ProtoPartModuleSnapshot module in part.modules)
 				{
-					if (module.moduleName != "ProcessControllerSystemHeat"
-						|| Lib.Proto.GetString(module, "resource") != "_Nukereactor")
-						continue;
-
-					if (part.resources.Find(k => k.resourceName == "_Nukereactor") == null)
+					if (module.moduleName != "ProcessControllerSystemHeat")
 						continue;
 
 					PartModule processPrefab = FindMatchingPrefabModule(prefab, module, "ProcessControllerSystemHeat");
+					if (!IsFissionProcessController(prefab, module, processPrefab))
+						continue;
+
+					string resource = Lib.Proto.GetString(module, "resource");
+					if (string.IsNullOrEmpty(resource) || part.resources.Find(k => k.resourceName == resource) == null)
+						continue;
+
 					SyncFrozenProcessReactor(v, part, module, processPrefab, prefab, elapsed_s);
 				}
 			}
@@ -236,10 +239,14 @@ namespace KERBALISM
 			if (v == null || part == null || module == null || partPrefab == null || v.loaded)
 				return;
 
-			if (Lib.Proto.GetString(module, "resource") != "_Nukereactor")
+			if (!IsFissionProcessController(partPrefab, module, processPrefab))
 				return;
 
-			ProtoPartResourceSnapshot pseudoResource = part.resources.Find(k => k.resourceName == "_Nukereactor");
+			string resource = Lib.Proto.GetString(module, "resource");
+			if (string.IsNullOrEmpty(resource))
+				return;
+
+			ProtoPartResourceSnapshot pseudoResource = part.resources.Find(k => k.resourceName == resource);
 			if (pseudoResource == null)
 				return;
 
@@ -386,10 +393,10 @@ namespace KERBALISM
 						if (loopId < 0)
 							continue;
 
-						bool isFissionProcess = Lib.Proto.GetString(module, "resource") == "_Nukereactor";
 						float meltdown = GetProcessField(prefab, module, "meltdownTemperature", 0f);
 						float maximum = GetProcessField(prefab, module, "MaximumTemperature", 0f);
-						if (meltdown > 0f && maximum > meltdown)
+						bool isFissionProcess = ProcessControllerSystemHeat.HasCoreDamageConfig(meltdown, maximum);
+						if (isFissionProcess)
 							riskLoopIds.Add(loopId);
 
 						float shutdown = isFissionProcess
@@ -741,10 +748,13 @@ namespace KERBALISM
 			if (processPrefab != null && !IntegrationReflection.GetBool(processPrefab, "AutoShutdown", true))
 				return;
 
-			if (Lib.Proto.GetString(producer.module, "resource") == "_Nukereactor")
+			if (IsFissionProcessController(prefab, producer.module, processPrefab))
 			{
 				SetProtoFissionRunning(v, producer.part, producer.module, false);
-				ProtoPartResourceSnapshot pseudo = producer.part.resources.Find(k => k.resourceName == "_Nukereactor");
+				string resource = Lib.Proto.GetString(producer.module, "resource");
+				ProtoPartResourceSnapshot pseudo = !string.IsNullOrEmpty(resource)
+					? producer.part.resources.Find(k => k.resourceName == resource)
+					: null;
 				if (pseudo != null)
 					ClearFrozenFissionPseudoResource(pseudo);
 				return;
@@ -1012,6 +1022,16 @@ namespace KERBALISM
 		{
 			float percent = Lib.Proto.GetFloat(module, "CurrentPowerPercent", 100f);
 			return Mathf.Clamp(percent, 0f, 100f) / 100f;
+		}
+
+		private static bool IsFissionProcessController(Part prefab, ProtoPartModuleSnapshot module, PartModule processPrefab)
+		{
+			if (processPrefab is ProcessControllerSystemHeat heatPrefab)
+				return heatPrefab.IsFissionReactor();
+
+			float meltdown = GetProcessField(prefab, module, "meltdownTemperature", 0f);
+			float maximum = GetProcessField(prefab, module, "MaximumTemperature", 0f);
+			return ProcessControllerSystemHeat.HasCoreDamageConfig(meltdown, maximum);
 		}
 
 		private static ProtoPartModuleSnapshot FindMatchingProcessModuleSnapshot(ProtoPartSnapshot part, string resource)

--- a/src/Kerbalism/Modules/Emitter.cs
+++ b/src/Kerbalism/Modules/Emitter.cs
@@ -9,6 +9,8 @@ namespace KERBALISM
 	{
 		// config
 		[KSPField] public string active;                          // name of animation to play when enabling/disabling
+		// Stable MM-safe id for Configure MODULE matching (id_field = emitterId). Prefer this over id_index when a part has multiple Emitters.
+		[KSPField] public string emitterId = string.Empty;
 
 		[KSPField(isPersistant = true)] public string title = string.Empty;     // GUI name of the status action in the PAW
 		[KSPField(isPersistant = true)] public bool toggle;						// true if the effect can be toggled on/off


### PR DESCRIPTION
## Description
- Gate `ProcessControllerSystemHeat` fission PAW/core-damage behavior on meltdown configuration instead of requiring `_Nukereactor`, so non-`_Nukereactor` fission setups can still get the fission UI when meltdown is configured.
- Add `Emitter.emitterId` so Configure can target a specific Emitter via `id_field = emitterId` when a part has multiple Emitters (e.g. one per reactor recipe), without relying on fragile `id_index` ordering.
