### PR TITLE
Revert "Declare KerbalismBridge30Radiation correctly to prevent an MM error when DynamicRadiation.cfg is not present"

### DIFF
--- a/Extras/KerbalismSystemHeatCompat/DynamicRadiation.cfg
+++ b/Extras/KerbalismSystemHeatCompat/DynamicRadiation.cfg
@@ -2,7 +2,7 @@
 // Dynamic radiation for SystemHeat fission reactors
 // ============================================================================
 // Dynamic radiation for fission reactors
-@PART[*]:HAS[@MODULE[SystemHeatFissionReactorKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation,KerbalismBridge30Radiation]:LAST[KerbalismBridge30Radiation]
+@PART[*]:HAS[@MODULE[SystemHeatFissionReactorKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:LAST[KerbalismBridge30Radiation]
 {
 	MODULE
 	{
@@ -19,7 +19,7 @@
 // Dynamic radiation for SystemHeat fission engines
 // ============================================================================
 // Dynamic radiation for EC fission engines
-@PART[*]:HAS[@MODULE[SystemHeatFissionEngineKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation,KerbalismBridge30Radiation]:LAST[KerbalismBridge30Radiation]
+@PART[*]:HAS[@MODULE[SystemHeatFissionEngineKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:LAST[KerbalismBridge30Radiation]
 {
 	MODULE
 	{

--- a/GameData/KerbalismConfig/Support/DynamicRadiation.cfg
+++ b/GameData/KerbalismConfig/Support/DynamicRadiation.cfg
@@ -18,8 +18,6 @@ KERBALISM_DYNAMIC_RADIATION_SETTINGS
 	Engine_EmissionDecayRate = 360
 }
 
-// Establish the KerbalismBridge30Radiation mod id
-@KERBALISM_DYNAMIC_RADIATION_SETTINGS:FOR[KerbalismBridge30Radiation] {}
 
 // ============================================================================
 // ProcessController fission reactors (USI / Buffalo / FTT without SH; NFE uses ProcessControllerSystemHeat below)


### PR DESCRIPTION
Reverts Kerbalism/Kerbalism#1160