### PR TITLE
Declare KerbalismBridge30Radiation correctly to prevent an MM error when DynamicRadiation.cfg is not present

### DIFF
--- a/Extras/KerbalismSystemHeatCompat/DynamicRadiation.cfg
+++ b/Extras/KerbalismSystemHeatCompat/DynamicRadiation.cfg
@@ -2,7 +2,7 @@
 // Dynamic radiation for SystemHeat fission reactors
 // ============================================================================
 // Dynamic radiation for fission reactors
-@PART[*]:HAS[@MODULE[SystemHeatFissionReactorKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:AFTER[KerbalismBridge30Radiation]
+@PART[*]:HAS[@MODULE[SystemHeatFissionReactorKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation,KerbalismBridge30Radiation]:LAST[KerbalismBridge30Radiation]
 {
 	MODULE
 	{
@@ -19,7 +19,7 @@
 // Dynamic radiation for SystemHeat fission engines
 // ============================================================================
 // Dynamic radiation for EC fission engines
-@PART[*]:HAS[@MODULE[SystemHeatFissionEngineKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:AFTER[KerbalismBridge30Radiation]
+@PART[*]:HAS[@MODULE[SystemHeatFissionEngineKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation,KerbalismBridge30Radiation]:LAST[KerbalismBridge30Radiation]
 {
 	MODULE
 	{

--- a/Extras/KerbalismSystemHeatCompat/DynamicRadiation.cfg
+++ b/Extras/KerbalismSystemHeatCompat/DynamicRadiation.cfg
@@ -2,7 +2,7 @@
 // Dynamic radiation for SystemHeat fission reactors
 // ============================================================================
 // Dynamic radiation for fission reactors
-@PART[*]:HAS[@MODULE[SystemHeatFissionReactorKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:LAST[KerbalismBridge30Radiation]
+@PART[*]:HAS[@MODULE[SystemHeatFissionReactorKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:AFTER[KerbalismBridge30Radiation]
 {
 	MODULE
 	{
@@ -19,7 +19,7 @@
 // Dynamic radiation for SystemHeat fission engines
 // ============================================================================
 // Dynamic radiation for EC fission engines
-@PART[*]:HAS[@MODULE[SystemHeatFissionEngineKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:LAST[KerbalismBridge30Radiation]
+@PART[*]:HAS[@MODULE[SystemHeatFissionEngineKerbalismUpdater]]:NEEDS[Kerbalism,FeatureRadiation]:AFTER[KerbalismBridge30Radiation]
 {
 	MODULE
 	{

--- a/GameData/KerbalismConfig/Support/DynamicRadiation.cfg
+++ b/GameData/KerbalismConfig/Support/DynamicRadiation.cfg
@@ -7,7 +7,7 @@
 // ============================================================================
 // KerbalismBridge integration: Settings.cfg
 // ============================================================================
-KERBALISM_DYNAMIC_RADIATION_SETTINGS
+KERBALISM_DYNAMIC_RADIATION_SETTINGS:FOR[KerbalismBridge30Radiation]
 {
 	// Minimum radiation while idle, as percent of peak (MM / Kerbalism Emitter config).
 	Reactor_MinEmissionPercent = 25

--- a/GameData/KerbalismConfig/Support/DynamicRadiation.cfg
+++ b/GameData/KerbalismConfig/Support/DynamicRadiation.cfg
@@ -7,7 +7,7 @@
 // ============================================================================
 // KerbalismBridge integration: Settings.cfg
 // ============================================================================
-KERBALISM_DYNAMIC_RADIATION_SETTINGS:FOR[KerbalismBridge30Radiation]
+KERBALISM_DYNAMIC_RADIATION_SETTINGS
 {
 	// Minimum radiation while idle, as percent of peak (MM / Kerbalism Emitter config).
 	Reactor_MinEmissionPercent = 25
@@ -18,6 +18,8 @@ KERBALISM_DYNAMIC_RADIATION_SETTINGS:FOR[KerbalismBridge30Radiation]
 	Engine_EmissionDecayRate = 360
 }
 
+// Establish the KerbalismBridge30Radiation mod id
+@KERBALISM_DYNAMIC_RADIATION_SETTINGS:FOR[KerbalismBridge30Radiation] {}
 
 // ============================================================================
 // ProcessController fission reactors (USI / Buffalo / FTT without SH; NFE uses ProcessControllerSystemHeat below)


### PR DESCRIPTION
DynamicRadiation.cfg is not present in RO configs, yet the new KerbalismSystemHeatCompat assumed it was present with a `LAST` pass. As LAST [does not check](https://github.com/sarbian/ModuleManager/issues/190) is a mod is actually present, this causes MM errors. The solution is to switch to an AFTER pass, which does actually check if a mod is present.

Fix https://github.com/Kerbalism/Kerbalism/issues/1159