### PR TITLE
Downgrade to NET 4.8

### DIFF
--- a/src/Kerbalism/Kerbalism.csproj
+++ b/src/Kerbalism/Kerbalism.csproj
@@ -4,7 +4,7 @@
     <FileVersion>$(Version)</FileVersion>
     <AssemblyName>Kerbalism</AssemblyName>
     <RootNamespace>KERBALISM</RootNamespace>
-    <TargetFramework>net481</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
 
     <Description>Hundreds of Kerbals were killed in the making of this mod.</Description>
     <Product>Kerbalism</Product>

--- a/src/KerbalismEngineFailures/KerbalismEngineFailures.csproj
+++ b/src/KerbalismEngineFailures/KerbalismEngineFailures.csproj
@@ -4,7 +4,7 @@
     <FileVersion>$(Version)</FileVersion>
     <AssemblyName>KerbalismEngineFailures</AssemblyName>
     <RootNamespace>KERBALISM.EngineFailures</RootNamespace>
-    <TargetFramework>net481</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
 
     <Description>Optional Kerbalism companion mod for engine ignition, burn time, and turn-on failures.</Description>
     <Product>KerbalismEngineFailures</Product>


### PR DESCRIPTION
As discussed [here](https://discord.com/channels/319857228905447436/620690446540341261/1536106675730124890) in the KSP-RO discord

<img width="1199" height="589" alt="image" src="https://github.com/user-attachments/assets/c45ffd8c-512d-4f76-9231-f1f4c83c9bf8" />


Using 4.8.1 makes it impossible for mods that use 4.8 to reference Kerbalism and thus fails the build.

Can confirm that net48 works fine:
```
Rebuild started at 2:02 AM...
1>------ Rebuild All started: Project: Kerbalism, Configuration: Release Any CPU ------
Restored C:\Users\Clayel\Visual Studio Builds\Kerbalism\src\KerbalismEngineFailures\KerbalismEngineFailures.csproj (in 17 ms).
Restored C:\Users\Clayel\Visual Studio Builds\Kerbalism\src\Kerbalism\Kerbalism.csproj (in 17 ms).
1>Kerbalism -> C:\Users\Clayel\Visual Studio Builds\Kerbalism\src\Kerbalism\bin\Release\net48\Kerbalism.dll
2>------ Rebuild All started: Project: KerbalismEngineFailures, Configuration: Release Any CPU ------
2>KerbalismEngineFailures -> C:\Users\Clayel\Visual Studio Builds\Kerbalism\src\KerbalismEngineFailures\bin\Release\net48\KerbalismEngineFailures.dll
========== Rebuild All: 2 succeeded, 0 failed, 0 skipped ==========
========== Rebuild completed at 2:02 AM and took 00.673 seconds ==========
```